### PR TITLE
Consume already-registered hook fields (#891)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ All notable changes to Remi are documented here.
   by accident; a future one starts from the encrypted handshake.
 
 ### Added
+- **Hook fields remi was already receiving and dropping are now consumed**
+  (#891). No new hook registrations — this is entirely fields the
+  already-registered `Stop`, `SubagentStop` and `PostToolUse` hooks carry.
+  `SubagentStop.agent_transcript_path` now replaces the SubagentStart-time
+  path *derivation* for the subagent-view switcher: Claude Code hands the
+  real path over directly once the file is guaranteed to exist, so it wins
+  over the guess (validated the same way `agentId` already was, so a
+  malformed value can't override a good derived one; falls back to the
+  derivation when absent). `Stop.last_assistant_message` and
+  `PostToolUse.duration_ms` (above a 5s threshold) are now logged instead of
+  silently discarded — neither reaches a client yet, since `Session` /
+  `SessionUpdateMessage` have no text field to carry them and adding one is a
+  protocol change, out of scope here.
+
 - **Local capability token** (#869, groundwork). The daemon now keeps a random
   secret in `~/.remi/capability.key` (mode 0600) and the CLI presents it on
   connect, so a local client can prove it is one without a trust-on-first-use

--- a/packages/daemon/src/api/subagent-view-registry.ts
+++ b/packages/daemon/src/api/subagent-view-registry.ts
@@ -9,6 +9,16 @@
  * per-session `subagents/` subdir. `agentId` is exactly the hook's `agent_id`.
  * So we derive the path from the SubagentStart hook (which carries the MAIN
  * `transcript_path` + the subagent's `agent_id`) with no scanning/correlation.
+ *
+ * `SubagentStop` later hands over the same path directly as
+ * `agent_transcript_path` (#891) — `recordStop` prefers that carried value
+ * over the START-time derivation (it's read after the file is guaranteed to
+ * exist), falling back to the derivation when the field is absent or
+ * malformed. Verified against 18 real `SubagentStop` captures
+ * (`~/.remi/hook-diag.jsonl`, 2026-07-29): the carried path matched the
+ * derived one in every single case, so the two sources have not been
+ * observed to disagree — the derivation stays as a fallback on principle,
+ * not because a divergence has ever been seen.
  */
 
 export interface SubagentView {
@@ -29,6 +39,22 @@ export interface SubagentView {
 export function deriveSubagentTranscriptPath(mainTranscriptPath: string, agentId: string): string {
   const base = mainTranscriptPath.replace(/\.jsonl$/, '');
   return `${base}/subagents/agent-${agentId}.jsonl`;
+}
+
+/**
+ * Shape guard for a carried `agent_transcript_path` (#891): must be an
+ * absolute path ending in `.jsonl` with no `..` traversal segment. This is a
+ * transcript-load key (`transcript-events.ts` reads whatever `resolvePath`
+ * returns off disk and sends it to the client), so a value straight off the
+ * wire is validated the same way `recordStart` already validates `agentId`
+ * before it becomes a path segment, rather than trusted outright.
+ */
+function isPlausibleTranscriptPath(p: string | undefined): p is string {
+  if (!p) return false;
+  if (!p.startsWith('/')) return false;
+  if (!p.endsWith('.jsonl')) return false;
+  if (p.split('/').includes('..')) return false;
+  return true;
 }
 
 export class SubagentViewRegistry {
@@ -63,11 +89,30 @@ export class SubagentViewRegistry {
     });
   }
 
-  /** Mark a subagent inactive (SubagentStop); keep it listed so its chat stays viewable. */
-  recordStop(agentId: string | undefined): void {
+  /**
+   * Mark a subagent inactive (SubagentStop); keep it listed so its chat stays
+   * viewable.
+   *
+   * `carriedTranscriptPath` is `SubagentStop.agent_transcript_path` (#891):
+   * Claude Code hands the real path over directly at stop time, rather than
+   * remi having to derive it from `SubagentStart.transcript_path` + `agentId`
+   * (the module-doc derivation above). Preferred over the START-time guess
+   * when present and well-formed — by STOP the file is guaranteed to exist,
+   * so this is the more authoritative of the two. Validated with the same
+   * shape checks `recordStart` applies to its own inputs (must end in
+   * `.jsonl`, absolute, no `..` traversal segment) so a malformed or hostile
+   * value can never override a good derived path; falls back to whatever
+   * path is already stored when absent or invalid (derivation, or start
+   * hasn't been recorded at all, in which case this is a no-op).
+   */
+  recordStop(agentId: string | undefined, carriedTranscriptPath?: string): void {
     if (!agentId) return;
     const v = this.views.get(agentId);
-    if (v) this.views.set(agentId, { ...v, active: false });
+    if (!v) return;
+    const transcriptPath = isPlausibleTranscriptPath(carriedTranscriptPath)
+      ? carriedTranscriptPath
+      : v.transcriptPath;
+    this.views.set(agentId, { ...v, transcriptPath, active: false });
   }
 
   /** The transcript path for a known subagent, or null. */

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -73,6 +73,30 @@ import type { TranscriptDiscovery } from '../../transcript/transcript-discovery.
 import { log, logError } from '../logger.ts';
 import type { StatusWriter } from '../status-writer.ts';
 
+/**
+ * Cap for the Stop-turn log line (#891). `last_assistant_message` can run
+ * several paragraphs (real captures in `~/.remi/hook-diag.jsonl` include
+ * multi-paragraph reviewer summaries); this is a LOG line, not a client
+ * surface, so it is bounded so one verbose turn cannot dominate the daemon
+ * log. Whitespace (including embedded newlines) is collapsed for the same
+ * reason `notification-dispatcher.ts` normalizes push text.
+ */
+const STOP_LOG_MESSAGE_MAX = 200;
+
+/** Truncate + collapse whitespace in a hook-carried message for a single log line. */
+function summarizeForLog(text: string, max: number): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length > max ? `${collapsed.slice(0, max)}…` : collapsed;
+}
+
+/**
+ * Threshold above which a PostToolUse `duration_ms` is logged (#891). Tool
+ * calls are frequent (1220 in one real `~/.remi/hook-diag.jsonl` capture, 100%
+ * carrying `duration_ms`) so logging every one would be pure noise; only a
+ * genuinely slow call is operationally interesting.
+ */
+const SLOW_TOOL_MS = 5_000;
+
 export interface HookBridgeDeps {
   sessionRegistry: SessionRegistry;
   bindingStore: SessionBindingStore;
@@ -660,6 +684,15 @@ export function setupHookBridge(
   hookServer.on('PostToolUse', (input) => {
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
+    // #891: PostToolUse now carries duration_ms. No dedicated tool-activity
+    // tracker/UI exists to put it in yet (the epic notes a live view needs
+    // Q6's bus) -- this only stops discarding the signal that is actually
+    // operationally interesting: a genuinely slow tool call, for BOTH main
+    // and subagent activity (logged before the subagent-branch early return
+    // below).
+    if (typeof input.duration_ms === 'number' && input.duration_ms >= SLOW_TOOL_MS) {
+      log(`[Hooks] Slow tool: ${input.tool_name} took ${input.duration_ms}ms (${sessionId})`);
+    }
     if (isSubagentEvent(input)) {
       // #710: the subagent-context tracker pop must see EVERY admitted
       // PostToolUse, even one Claude Code stamps with the SPAWNED agent's own
@@ -765,6 +798,18 @@ export function setupHookBridge(
     // nothing) and killed their in-flight evals. SessionEnd below is real
     // teardown and keeps the wholesale release/cancel.
     autoApproveGate.cancelStale('Stop', { mainOnly: true });
+    // #891: Stop now carries the turn's real content (last_assistant_message),
+    // previously dropped entirely. There is no client-facing surface to carry
+    // it to a phone/lock-screen yet -- `Session`/`SessionUpdateMessage` have no
+    // text field, and adding one is a protocol change out of scope here (see
+    // PR body). Until that lands, at least stop discarding it at the point it
+    // enters the daemon: log it (truncated) so the real turn-complete content
+    // is observable operationally instead of a bare "Status: idle".
+    if (!input.stop_hook_active && input.last_assistant_message) {
+      log(
+        `[Hooks] Turn complete (${sessionId}): ${summarizeForLog(input.last_assistant_message, STOP_LOG_MESSAGE_MAX)}`,
+      );
+    }
     handlers.onStop?.(input);
   });
   hookServer.on('SessionEnd', (input) => {
@@ -850,7 +895,10 @@ export function setupHookBridge(
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
     try {
-      subagentViews?.recordStop(input.agent_id);
+      // #891: SubagentStop now carries agent_transcript_path directly;
+      // recordStop prefers it over the SubagentStart-time derivation (see
+      // subagent-view-registry.ts for the fallback + validation rules).
+      subagentViews?.recordStop(input.agent_id, input.agent_transcript_path);
       pushSubagentViews();
       handlers.onSubagentStop?.(input);
     } catch (err) {

--- a/packages/daemon/tests/api/subagent-view-registry.test.ts
+++ b/packages/daemon/tests/api/subagent-view-registry.test.ts
@@ -39,6 +39,51 @@ describe('SubagentViewRegistry', () => {
     expect(reg.resolvePath('a1')).not.toBeNull();
   });
 
+  describe('recordStop carried transcript path (#891)', () => {
+    test('prefers the carried agent_transcript_path over the START-time derivation', () => {
+      const reg = new SubagentViewRegistry();
+      reg.recordStart('a1', 'Explore', MAIN);
+      const carried = '/Users/y/.claude/projects/-Users-y-proj/some-other-real-path.jsonl';
+      reg.recordStop('a1', carried);
+      expect(reg.resolvePath('a1')).toBe(carried);
+      expect(reg.list()[0]?.active).toBe(false);
+    });
+
+    test('falls back to the derived path when agent_transcript_path is absent', () => {
+      const reg = new SubagentViewRegistry();
+      reg.recordStart('a1', 'Explore', MAIN);
+      reg.recordStop('a1', undefined);
+      expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+    });
+
+    test('falls back to the derived path when the carried value is a relative path', () => {
+      const reg = new SubagentViewRegistry();
+      reg.recordStart('a1', 'Explore', MAIN);
+      reg.recordStop('a1', 'relative/path.jsonl');
+      expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+    });
+
+    test('falls back to the derived path when the carried value has no .jsonl suffix', () => {
+      const reg = new SubagentViewRegistry();
+      reg.recordStart('a1', 'Explore', MAIN);
+      reg.recordStop('a1', '/Users/y/.claude/projects/-Users-y-proj/not-a-transcript');
+      expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+    });
+
+    test('falls back to the derived path when the carried value contains a .. traversal segment', () => {
+      const reg = new SubagentViewRegistry();
+      reg.recordStart('a1', 'Explore', MAIN);
+      reg.recordStop('a1', '/Users/y/.claude/projects/../../etc/passwd.jsonl');
+      expect(reg.resolvePath('a1')).toBe(deriveSubagentTranscriptPath(MAIN, 'a1'));
+    });
+
+    test('recordStop for an unknown agentId is a no-op (no entry to update)', () => {
+      const reg = new SubagentViewRegistry();
+      expect(() => reg.recordStop('never-started', '/a/b.jsonl')).not.toThrow();
+      expect(reg.size).toBe(0);
+    });
+  });
+
   test('active subagents are listed before finished ones', () => {
     const reg = new SubagentViewRegistry();
     reg.recordStart('done', 'code-reviewer', MAIN);

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -6,6 +6,7 @@ import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
 import type { MessageAPI } from '../../../src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
+import { SubagentViewRegistry } from '../../../src/api/subagent-view-registry.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
 import type { HookBridgeHandle } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
 import { setupHookBridge } from '../../../src/cli/session-phases/hook-bridge-setup.ts';
@@ -225,6 +226,11 @@ describe('setupHookBridge', () => {
        *  Each entry is the (input, callerSessionId) the resolver forwarded.
        *  Defaults to undefined (dep not wired). */
       foreignEscalationLog?: Array<{ input: unknown; sessionId: UUID }>;
+      /** Real SubagentViewRegistry instance (#891 tests need to inspect
+       *  recordStart/recordStop's effect on the stored transcript path).
+       *  Defaults to undefined (dep not wired, matches production callers
+       *  that skip subagent-view tracking). */
+      subagentViews?: SubagentViewRegistry;
     } = {},
   ): { tracker: QuestionPresenceTracker } {
     const localMessageApi = fakeMessageAPI(
@@ -297,6 +303,7 @@ describe('setupHookBridge', () => {
         autoApproveService,
         currentPort: () => 8765,
         transcriptDiscovery: new TranscriptDiscovery(),
+        ...(opts.subagentViews ? { subagentViews: opts.subagentViews } : {}),
         ...(opts.broadcastResolvedLog
           ? {
               broadcastQuestionResolved: (
@@ -3081,6 +3088,190 @@ describe('setupHookBridge', () => {
       expect(decision).toBe('allow');
       // And the broadcast was at least attempted (proving the throw path ran).
       expect(throwingLog.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('#891: free-win hook field consumption', () => {
+    /** Fire a SessionStart so the bridge locks onto `id` (admit gate then passes). */
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('SubagentStop threads agent_transcript_path through to the SubagentViewRegistry', () => {
+      const subagentViews = new SubagentViewRegistry();
+      build({ subagentViews });
+      lock('claude-891-a');
+      const mainTranscriptPath = path.join(tmpDir, 'claude-891-a.jsonl');
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-891-a',
+        agent_id: 'sub-1',
+        agent_type: 'code-architect',
+        transcript_path: mainTranscriptPath,
+      });
+      // The derived path (from SubagentStart) is the pre-#891 baseline.
+      const derived = subagentViews.resolvePath('sub-1');
+      expect(derived).not.toBeNull();
+
+      // SubagentStop now hands over the real path directly; it wins over the
+      // START-time derivation even when the two differ (a real Claude Code
+      // session never disagrees -- see subagent-view-registry.ts's #891 doc
+      // comment for the verified-against-captures claim -- but the plumbing
+      // must prefer the carried value regardless).
+      const carried = path.join(tmpDir, 'claude-891-a', 'subagents', 'agent-sub-1-carried.jsonl');
+      hookServer.fire('SubagentStop', {
+        session_id: 'claude-891-a',
+        agent_id: 'sub-1',
+        agent_transcript_path: carried,
+      });
+      expect(subagentViews.resolvePath('sub-1')).toBe(carried);
+      expect(subagentViews.resolvePath('sub-1')).not.toBe(derived);
+      expect(subagentViews.list()[0]?.active).toBe(false);
+    });
+
+    test('SubagentStop with no agent_transcript_path keeps the derived path (fallback)', () => {
+      const subagentViews = new SubagentViewRegistry();
+      build({ subagentViews });
+      lock('claude-891-b');
+      const mainTranscriptPath = path.join(tmpDir, 'claude-891-b.jsonl');
+      hookServer.fire('SubagentStart', {
+        session_id: 'claude-891-b',
+        agent_id: 'sub-1',
+        agent_type: 'Explore',
+        transcript_path: mainTranscriptPath,
+      });
+      const derived = subagentViews.resolvePath('sub-1');
+      hookServer.fire('SubagentStop', {
+        session_id: 'claude-891-b',
+        agent_id: 'sub-1',
+        // No agent_transcript_path (older Claude Code, or the field genuinely absent).
+      });
+      expect(subagentViews.resolvePath('sub-1')).toBe(derived);
+    });
+
+    test('Stop logs the truncated last_assistant_message (turn genuinely complete)', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-stop');
+      const longMessage = `Line one.\n\nLine two with lots of detail. ${'x'.repeat(300)}`;
+      hookServer.fire('Stop', {
+        session_id: 'claude-891-stop',
+        hook_event_name: 'Stop',
+        stop_hook_active: false,
+        last_assistant_message: longMessage,
+      });
+      const turnCompleteLines = logs.filter((l) => l.includes('Turn complete'));
+      expect(turnCompleteLines.length).toBe(1);
+      // The log line is keyed by remi's daemon-side session id (SID), not the
+      // raw Claude session_id from the hook payload -- same convention every
+      // other [Hooks] log line in this file uses.
+      expect(turnCompleteLines[0]).toContain(SID);
+      // Truncated: the 300+ char filler must not appear in full, and whitespace
+      // (including the embedded newlines) is collapsed to single spaces.
+      expect(turnCompleteLines[0]?.includes('x'.repeat(300))).toBe(false);
+      expect(turnCompleteLines[0]).not.toContain('\n');
+      expect(turnCompleteLines[0]).toContain('Line one. Line two with lots of detail.');
+    });
+
+    test('Stop does NOT log when stop_hook_active is true (turn is not actually done)', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-stop-active');
+      hookServer.fire('Stop', {
+        session_id: 'claude-891-stop-active',
+        hook_event_name: 'Stop',
+        stop_hook_active: true,
+        last_assistant_message: 'should not be logged',
+      });
+      expect(logs.some((l) => l.includes('Turn complete'))).toBe(false);
+    });
+
+    test('Stop does NOT log when last_assistant_message is absent', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-stop-nomsg');
+      hookServer.fire('Stop', {
+        session_id: 'claude-891-stop-nomsg',
+        hook_event_name: 'Stop',
+        stop_hook_active: false,
+      });
+      expect(logs.some((l) => l.includes('Turn complete'))).toBe(false);
+    });
+
+    test('PostToolUse logs a slow tool call (duration_ms at/above threshold)', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-slow');
+      hookServer.fire('PostToolUse', {
+        session_id: 'claude-891-slow',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 10' },
+        tool_response: {},
+        duration_ms: 5_000,
+      });
+      const slowLines = logs.filter((l) => l.includes('Slow tool'));
+      expect(slowLines.length).toBe(1);
+      expect(slowLines[0]).toContain('Bash');
+      expect(slowLines[0]).toContain('5000ms');
+      expect(slowLines[0]).toContain(SID);
+    });
+
+    test('PostToolUse does NOT log a fast tool call (duration_ms below threshold)', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-fast');
+      hookServer.fire('PostToolUse', {
+        session_id: 'claude-891-fast',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/x' },
+        tool_response: {},
+        duration_ms: 42,
+      });
+      expect(logs.some((l) => l.includes('Slow tool'))).toBe(false);
+    });
+
+    test('PostToolUse does NOT log when duration_ms is absent', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-nodur');
+      hookServer.fire('PostToolUse', {
+        session_id: 'claude-891-nodur',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/x' },
+        tool_response: {},
+      });
+      expect(logs.some((l) => l.includes('Slow tool'))).toBe(false);
+    });
+
+    test('a subagent-tagged slow PostToolUse still logs (logged before the subagent early-return)', () => {
+      const logs: string[] = [];
+      configureLogger({ writeLog: (msg) => logs.push(msg) });
+      build();
+      lock('claude-891-slow-sub');
+      hookServer.fire('PostToolUse', {
+        session_id: 'claude-891-slow-sub',
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 10' },
+        tool_response: {},
+        duration_ms: 9_000,
+        agent_id: 'sub-1',
+      });
+      const slowLines = logs.filter((l) => l.includes('Slow tool'));
+      expect(slowLines.length).toBe(1);
+      expect(slowLines[0]).toContain('9000ms');
     });
   });
 });


### PR DESCRIPTION
## Summary

Part 1 (zero-registration half) of Q7 #891. Consumes fields that the
ALREADY-REGISTERED `Stop`, `SubagentStop` and `PostToolUse` hooks carry and
remi currently drops. **No new hook registrations** — `REMI_REGISTERED_HOOK_EVENTS`
is untouched (verified: `git diff origin/develop -- packages/daemon/src/hooks/hook-types.ts`
is empty for this PR).

Part 2 of #891 (registering `TaskCreated`/`TaskCompleted`/`TeammateIdle`) is explicitly
out of scope per the issue and not touched here.

## Fields consumed, with capture evidence

Verified against `~/.remi/hook-diag.jsonl` (2144 lines, this machine, 2026-07-29) —
counts are higher than the issue's own numbers because the capture file has grown
since it was written, but the shape holds:

| Field | Event | n captured | Presence when event fires |
|---|---|---|---|
| `last_assistant_message` | `Stop` | 24 | 100% |
| `agent_transcript_path` | `SubagentStop` | 18 | 100% |
| `duration_ms` | `PostToolUse` | 1220 | 100% |

1. **`SubagentViewRegistry.recordStop`** (`packages/daemon/src/api/subagent-view-registry.ts`)
   now accepts the carried `agent_transcript_path` and prefers it over the
   `SubagentStart`-time derivation, validated with the same shape checks
   `recordStart` already applies to `agentId` (absolute, ends in `.jsonl`, no
   `..` traversal segment — this value ends up read off disk and sent to a
   client via `transcript-events.ts`, so it is validated rather than trusted
   outright). Falls back to the derived path when absent or malformed.
   Call site: `hook-bridge-setup.ts`'s existing `SubagentStop` listener now
   passes `input.agent_transcript_path` through.

2. **`Stop.last_assistant_message`** and **`PostToolUse.duration_ms`** (slow
   calls only, >= 5s) are now logged from `hook-bridge-setup.ts`'s existing
   `Stop`/`PostToolUse` listeners instead of being silently discarded. See
   "Contradicts the issue text" below for why this stops short of a
   client-facing notification.

## Whether carried and derived subagent-transcript paths ever differed

**Never, in all 18 captured `SubagentStop` events.** Verified with a script
over the full capture file: computed `deriveSubagentTranscriptPath(transcript_path,
agent_id)` for every `SubagentStop` and diffed it against the carried
`agent_transcript_path`. 18/18 matches, 0 mismatches. The derivation stays as
a fallback on principle (Claude Code could change its on-disk layout without
notice), not because a divergence has ever been observed.

## No new hook events registered

`REMI_REGISTERED_HOOK_EVENTS` in `packages/daemon/src/hooks/hook-types.ts` is
unmodified by this PR — confirmed by diff. All three fields consumed here
belong to events already in that list (`Stop`, `SubagentStop`, `PostToolUse`).
No new synchronous HTTP roundtrip is added to Claude Code's hot path.

## Contradicts the issue text

**Issue #891 frames "the turn-complete notification can carry what Claude
actually said" as an existing thing to enrich.** It is not — I could not find
any Stop-driven client notification or push in this codebase to thread the
message into:

- `NotificationDispatcher` (`packages/daemon/src/notifications/notification-dispatcher.ts`)
  only handles `Question` pushes (permission prompts); it has no Stop/idle path.
- `createSessionUpdate` (`packages/shared/src/protocol.ts:1487`) takes a
  `_statusContext` parameter that is prefixed underscore-unused and thrown
  away; `Session`/`SessionUpdateMessage` have no text field to carry it.
- `packages/web/src/lib/notifications.ts`'s `notifySessionComplete()` (a
  generic "The agent has completed its work." local notification) has **zero
  callers anywhere in the tree** — dead code, not a wired path.
- The macOS menu-bar app's `NotificationManager.swift` only posts for pending
  questions ("Claude needs you").

Building a real one needs a new field on `Session`/`SessionUpdateMessage` (or
an entirely new push path), which the task scoped as out-of-scope protocol
work. So this PR does the honest, in-scope part: `last_assistant_message` is
now surfaced in the daemon's own operational log (truncated to 200 chars,
whitespace-collapsed) instead of being dropped at the point it enters the
daemon, and the gap to a client is called out explicitly here and in the code
comment for whoever picks up the protocol side.

Same story for `PostToolUse.duration_ms`: the epic (#885) itself says "a live
tool-activity view... is purely a client surface once Q6 gives it a bus" —
there is no daemon-side tool-activity tracker to put it in yet either. This
PR logs genuinely slow tool calls (>= 5s) rather than building one.

## Concurrency (Q2 / #887)

`hook-event-bridge.ts`, `question-parser.ts`, `auto-approve-gate.ts` and
`question-trace.ts` are untouched. My diff in `hook-bridge-setup.ts` is
confined to the existing `Stop`/`SubagentStop`/`PostToolUse` listener bodies
(module-level log helpers + inline field reads) — no question-id handling, no
refactor of surrounding logic. Rebased onto `origin/develop` tip
(`a7cf1e0`) before opening this PR.

## Break-it-then-fix-it

Stashed the two source-file changes (kept the new tests), ran the affected
suites, restored, re-ran:

- **Red:** `bun test packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
  packages/daemon/tests/api/subagent-view-registry.test.ts` → **93 pass, 5 fail**
  (exactly the 5 new positive-assertion tests; the negative/fallback tests
  correctly still passed, since they assert current behavior).
- **Green (after restoring source):** same command → **98 pass, 0 fail**.

## Test plan

- [x] `bun test packages/daemon/tests/api/subagent-view-registry.test.ts` — 15 pass (6 new)
- [x] `bun test packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` — 83 pass (9 new)
- [x] `bun test packages/daemon/tests/cli/handlers/transcript-events.test.ts` (consumes `subagentViews.resolvePath`) — 10 pass
- [x] Full daemon suite excluding `tests/auto-approve/` (per repo notes: LLM-judgment tests are slow/flaky and unrelated) — **2535 pass, 0 fail, 139 files**
- [x] `bun run typecheck` (root) — clean
- [x] `bun run typecheck:web` — clean
- [x] `bunx biome check .` — 48 pre-existing warnings, all in files this PR does not touch (confirmed via a scoped `biome check` on only the changed files: 0 warnings)
- [ ] `packages/daemon/tests/auto-approve/` — not run (repo convention: skip when not touching auto-approve; this PR does not touch it)