### PR TITLE
C6: unify daemon inbound routing

### DIFF
--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -66,6 +66,7 @@ import type {
   ConnectionAdapter,
 } from '../adapters/connection-adapter.ts';
 import type { Authenticator } from '../auth/authenticator.ts';
+import { type ClientMessageHandlers, routeClientMessage } from '../server/route-client-message.ts';
 import { SignalingClient } from './signaling-client.ts';
 
 /**
@@ -301,12 +302,7 @@ export class RelayAdapter implements ConnectionAdapter {
 
       // Handle auth_response during challenging state
       if (message.type === 'auth_response') {
-        this.handleAuthResponse(message as AuthResponseMessage).catch((err) => {
-          console.error('Relay auth error:', err instanceof Error ? err.message : err);
-          const failResult = createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR');
-          this.client?.sendRelay(JSON.stringify(failResult));
-          this.resetClient();
-        });
+        this.routeAuthResponse(message as AuthResponseMessage);
         return;
       }
 
@@ -316,11 +312,31 @@ export class RelayAdapter implements ConnectionAdapter {
         return;
       }
 
-      // Route incoming protocol messages from the remote client
-      this.routeMessage(message);
+      // Route incoming protocol messages from the remote client. `message`
+      // has only been checked for a string `type` field at this point (not
+      // the full envelope) -- deliberately unchanged from before #899, so a
+      // truly unregistered type still gets reported back by name (see
+      // routeMessage's default branch) instead of being silently dropped.
+      // #899 unifies WHICH handler fires for a known type, not this
+      // envelope-parsing step, which is relay-specific (sealed/self-
+      // authenticating answers above have no full envelope at all).
+      this.routeMessage(message as ProtocolMessage);
     } catch (e) {
       console.warn('Failed to parse relay payload:', e instanceof Error ? e.message : e);
     }
+  }
+
+  /** Shared by the pre-authenticated handshake branch above and the
+   *  post-authenticated handler map in `routeMessage` (see that map's
+   *  `auth_response` entry for why the latter is reachable only
+   *  defensively). Mirrors `connection.ts`'s `routeAuthResponse` (#899). */
+  private routeAuthResponse(message: AuthResponseMessage): void {
+    this.handleAuthResponse(message).catch((err) => {
+      console.error('Relay auth error:', err instanceof Error ? err.message : err);
+      const failResult = createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR');
+      this.client?.sendRelay(JSON.stringify(failResult));
+      this.resetClient();
+    });
   }
 
   /** Give the adapter the key that opens sealed answers (#875). */
@@ -515,160 +531,110 @@ export class RelayAdapter implements ConnectionAdapter {
     this.kexChallenge = null;
   }
 
-  private routeMessage(msg: Record<string, unknown>): void {
+  /**
+   * Route one client-to-daemon message (#899): a total map over every
+   * client-to-daemon type, mirroring `connection.ts`'s handler map so both
+   * transports do "which handler for which type" the same way. The ad-hoc
+   * per-field `typeof` checks this replaced are GONE, not relocated --
+   * `msg` is trusted the same way `connection.ts` trusts it post-
+   * `deserialize`: a malformed field (e.g. a non-string `sessionId`) now
+   * flows straight to the event handler instead of being dropped with a
+   * warning, matching the direct-WebSocket path's existing (equally
+   * unvalidated) behavior. See the PR description for the concrete list of
+   * payloads this stops rejecting.
+   */
+  private routeMessage(msg: ProtocolMessage): void {
     if (!this.clientConnectionId) return;
     const connectionId = this.clientConnectionId;
-    switch (msg['type']) {
-      case 'user_input': {
-        if (typeof msg['content'] !== 'string' || typeof msg['sessionId'] !== 'string') {
-          console.warn('Invalid user_input payload: missing content or sessionId');
-          return;
-        }
-        const claudeId =
-          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
-        const messageId = typeof msg['id'] === 'string' ? msg['id'] : undefined;
+    const handlers: ClientMessageHandlers = {
+      // Hello is handled at connection level (the relay's `peer-connected`
+      // event), not message level -- a client never needs to send one here.
+      hello: 'ignore',
+      user_input: (m) => {
         this.events.onUserInput?.(
           connectionId,
-          msg['sessionId'],
-          msg['content'],
-          msg['raw'] === true,
-          claudeId,
-          messageId,
+          m.sessionId,
+          m.content,
+          m.raw,
+          m.claudeSessionId,
+          m.id,
         );
-        break;
-      }
-      case 'answer': {
-        if (typeof msg['questionId'] !== 'string' || typeof msg['answer'] !== 'string') {
-          console.warn('Invalid answer payload: missing questionId or answer');
-          return;
-        }
-        const claudeId =
-          typeof msg['claudeSessionId'] === 'string' ? msg['claudeSessionId'] : undefined;
+      },
+      answer: (m) => {
+        // Forward structured AskUserQuestion selections/cancel (#627) same
+        // as connection.ts's handleAnswer -- previously dropped over relay
+        // (found while unifying this dispatch; see the PR description).
+        const extra =
+          m.selections !== undefined || m.cancel !== undefined
+            ? { selections: m.selections, cancel: m.cancel }
+            : undefined;
         this.events.onAnswer?.(
           connectionId,
-          typeof msg['sessionId'] === 'string' ? msg['sessionId'] : '',
-          msg['questionId'],
-          msg['answer'],
-          claudeId,
+          m.sessionId,
+          m.questionId,
+          m.answer,
+          m.claudeSessionId,
+          extra,
         );
-        break;
-      }
-      case 'session_list_request':
-        if (typeof msg['id'] !== 'string') {
-          console.warn('Invalid session_list_request payload: missing id');
-          return;
-        }
-        this.events.onSessionListRequest?.(
-          connectionId,
-          msg['id'],
-          (msg['includeExternal'] as boolean) ?? false,
-        );
-        break;
-      case 'transcript_load_request':
-        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
-          console.warn('Invalid transcript_load_request payload: missing sessionId or id');
-          return;
-        }
-        this.events.onTranscriptLoadRequest?.(connectionId, msg['sessionId'], msg['id']);
-        break;
-      case 'create_session_request':
-        if (typeof msg['id'] !== 'string') {
-          console.warn('Invalid create_session_request payload: missing id');
-          return;
-        }
-        this.events.onCreateSessionRequest?.(
-          connectionId,
-          msg['directory'] as string | undefined,
-          msg['id'],
-        );
-        break;
-      case 'resume_session_request':
-        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
-          console.warn('Invalid resume_session_request payload: missing sessionId or id');
-          return;
-        }
-        this.events.onResumeSessionRequest?.(connectionId, msg['sessionId'], msg['id']);
-        break;
-      case 'bullet_expand_request':
-        if (
-          typeof msg['sessionId'] !== 'string' ||
-          typeof msg['bulletId'] !== 'number' ||
-          typeof msg['id'] !== 'string'
-        ) {
-          console.warn('Invalid bullet_expand_request payload: missing required fields');
-          return;
-        }
-        this.events.onBulletExpandRequest?.(
-          connectionId,
-          msg['sessionId'],
-          msg['bulletId'],
-          msg['id'],
-        );
-        break;
-      case 'terminal_resize':
-        if (typeof msg['cols'] !== 'number' || typeof msg['rows'] !== 'number') {
-          console.warn('Invalid terminal_resize payload: cols and rows must be numbers');
-          return;
-        }
-        this.events.onTerminalResize?.(connectionId, msg['cols'], msg['rows']);
-        break;
-      case 'kill_session_request':
-        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
-          console.warn('Invalid kill_session_request payload: missing sessionId or id');
-          return;
-        }
-        this.events.onKillSessionRequest?.(connectionId, msg['sessionId'], msg['id']);
-        break;
-      case 'detach_session':
-        if (typeof msg['sessionId'] !== 'string' || typeof msg['id'] !== 'string') {
-          console.warn('Invalid detach_session payload: missing sessionId or id');
-          return;
-        }
-        this.events.onDetachSession?.(connectionId, msg['sessionId'], msg['id']);
-        break;
-      case 'session_history_request': {
-        if (typeof msg['id'] !== 'string') {
-          console.warn('Invalid session_history_request payload: missing id');
-          return;
-        }
-        const limit = typeof msg['limit'] === 'number' ? msg['limit'] : undefined;
-        this.events.onSessionHistoryRequest?.(connectionId, msg['id'], limit);
-        break;
-      }
-      case 'register_device_token':
-        if (typeof msg['token'] !== 'string') {
-          console.warn('Invalid register_device_token payload: missing token');
-          return;
-        }
-        if (msg['platform'] !== 'ios' && msg['platform'] !== 'android') {
-          console.warn('Invalid register_device_token payload: platform must be ios or android');
-          return;
-        }
-        this.events.onRegisterDeviceToken?.(connectionId, msg['token'], msg['platform']);
-        break;
-      case 'unregister_device_token':
-        if (typeof msg['token'] !== 'string') {
-          console.warn('Invalid unregister_device_token payload: missing token');
-          return;
-        }
-        this.events.onUnregisterDeviceToken?.(connectionId, msg['token']);
-        break;
-      case 'ping':
-        // Liveness ping needs no reply over relay.
-        break;
-      case 'hello':
-        // Hello is handled at connection level, not message level
-        break;
-      default:
-        console.warn(`Unknown relay message type: ${msg['type']}`);
-        this.client?.sendRelay(
-          JSON.stringify(
-            createError(
-              'UNSUPPORTED',
-              `Message type '${String(msg['type'])}' is not supported over relay`,
-            ),
-          ),
-        );
+      },
+      session_list_request: (m) => {
+        this.events.onSessionListRequest?.(connectionId, m.id, m.includeExternal ?? false);
+      },
+      transcript_load_request: (m) => {
+        this.events.onTranscriptLoadRequest?.(connectionId, m.sessionId, m.id);
+      },
+      create_session_request: (m) => {
+        this.events.onCreateSessionRequest?.(connectionId, m.directory, m.id);
+      },
+      resume_session_request: (m) => {
+        this.events.onResumeSessionRequest?.(connectionId, m.sessionId, m.id);
+      },
+      bullet_expand_request: (m) => {
+        this.events.onBulletExpandRequest?.(connectionId, m.sessionId, m.bulletId, m.id);
+      },
+      terminal_resize: (m) => {
+        this.events.onTerminalResize?.(connectionId, m.cols, m.rows);
+      },
+      kill_session_request: (m) => {
+        this.events.onKillSessionRequest?.(connectionId, m.sessionId, m.id);
+      },
+      detach_session: (m) => {
+        this.events.onDetachSession?.(connectionId, m.sessionId, m.id);
+      },
+      session_history_request: (m) => {
+        this.events.onSessionHistoryRequest?.(connectionId, m.id, m.limit);
+      },
+      register_device_token: (m) => {
+        this.events.onRegisterDeviceToken?.(connectionId, m.token, m.platform);
+      },
+      unregister_device_token: (m) => {
+        this.events.onUnregisterDeviceToken?.(connectionId, m.token);
+      },
+      // Liveness ping needs no reply over relay.
+      ping: 'ignore',
+      // No relay-side liveness tracking consumes this yet, but it is a real
+      // client-to-daemon type (#899's trap): treat it as the no-op
+      // connection.ts already does rather than rejecting it as UNSUPPORTED,
+      // which is what happened before this map existed (found while
+      // unifying this dispatch; see the PR description).
+      pong: 'ignore',
+      // Client acknowledging our message - just track (no-op), matching
+      // connection.ts. Same trap as `pong`: previously fell through to the
+      // UNSUPPORTED default because relay's switch had no case for it.
+      ack: 'ignore',
+      // Unreachable here in practice -- handleRelayMessage intercepts
+      // auth_response before routeMessage is ever called. Real handler for
+      // defense in depth + exhaustiveness (mirrors connection.ts).
+      auth_response: (m) => this.routeAuthResponse(m),
+    };
+    const routed = routeClientMessage(msg, handlers);
+    if (!routed) {
+      console.warn(`Unknown relay message type: ${msg.type}`);
+      this.client?.sendRelay(
+        JSON.stringify(
+          createError('UNSUPPORTED', `Message type '${msg.type}' is not supported over relay`),
+        ),
+      );
     }
   }
 

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -49,6 +49,7 @@ import type {
   UserInputMessage,
 } from '@remi/shared';
 import type { Authenticator } from '../auth/authenticator.ts';
+import { type ClientMessageHandlers, routeClientMessage } from './route-client-message.ts';
 
 /** Connection state */
 export type ConnectionState = 'connecting' | 'authenticating' | 'connected' | 'disconnected';
@@ -308,11 +309,7 @@ export class Connection {
     // In authenticating state, only accept auth_response
     if (this.state === 'authenticating') {
       if (message.type === 'auth_response') {
-        this.handleAuthResponse(message).catch((err) => {
-          this.send(createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR'));
-          this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
-          this.close('Authentication error');
-        });
+        this.routeAuthResponse(message);
       } else if (message.type === 'ping') {
         this.handlePing(message);
       } else {
@@ -321,65 +318,60 @@ export class Connection {
       return;
     }
 
-    // Route by message type
-    switch (message.type) {
-      case 'hello':
-        this.handleHello(message);
-        break;
-      case 'user_input':
-        this.handleUserInput(message);
-        break;
-      case 'answer':
-        this.handleAnswer(message);
-        break;
-      case 'bullet_expand_request':
-        this.handleBulletExpandRequest(message);
-        break;
-      case 'session_list_request':
-        this.handleSessionListRequest(message);
-        break;
-      case 'transcript_load_request':
-        this.handleTranscriptLoadRequest(message);
-        break;
-      case 'create_session_request':
-        this.handleCreateSessionRequest(message);
-        break;
-      case 'terminal_resize':
-        this.handleTerminalResize(message);
-        break;
-      case 'kill_session_request':
-        this.handleKillSessionRequest(message);
-        break;
-      case 'resume_session_request':
-        this.handleResumeSessionRequest(message);
-        break;
-      case 'session_history_request':
-        this.handleSessionHistoryRequest(message);
-        break;
-      case 'detach_session':
-        this.handleDetachSession(message);
-        break;
-      case 'ping':
-        this.handlePing(message);
-        break;
-      case 'register_device_token':
-        this.handleRegisterDeviceToken(message);
-        break;
-      case 'unregister_device_token':
-        this.handleUnregisterDeviceToken(message);
-        break;
-      case 'pong':
+    // Route by message type (#899): a total map over every client-to-daemon
+    // type, so a new registry key breaks this object's compile until it is
+    // decided, rather than silently falling through a switch's default.
+    const handlers: ClientMessageHandlers = {
+      hello: (m) => this.handleHello(m),
+      user_input: (m) => this.handleUserInput(m),
+      answer: (m) => this.handleAnswer(m),
+      bullet_expand_request: (m) => this.handleBulletExpandRequest(m),
+      session_list_request: (m) => this.handleSessionListRequest(m),
+      transcript_load_request: (m) => this.handleTranscriptLoadRequest(m),
+      create_session_request: (m) => this.handleCreateSessionRequest(m),
+      terminal_resize: (m) => this.handleTerminalResize(m),
+      kill_session_request: (m) => this.handleKillSessionRequest(m),
+      resume_session_request: (m) => this.handleResumeSessionRequest(m),
+      session_history_request: (m) => this.handleSessionHistoryRequest(m),
+      detach_session: (m) => this.handleDetachSession(m),
+      register_device_token: (m) => this.handleRegisterDeviceToken(m),
+      unregister_device_token: (m) => this.handleUnregisterDeviceToken(m),
+      ping: (m) => this.handlePing(m),
+      pong: () => {
         // Explicit protocol-level liveness reply. Redundant with the
         // any-message reset above (kept as documentation of intent and a
         // second line of defense if that reset is ever narrowed).
         this.missedPongs = 0;
-        break;
-      case 'ack':
-        // Client acknowledging our message - just track
-        break;
-      default:
-        this.sendError('UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
+      },
+      // Client acknowledging our message - just track (no-op). #899's trap:
+      // `ack` is tagged 'both' (not 'c2d') precisely because this case is
+      // real and accepting, not a forgotten one -- see MESSAGE_DIRECTION's
+      // comment on `ack` and ClientToDaemonType's doc comment.
+      ack: 'ignore',
+      // Reachable only if a client resends auth_response after already
+      // completing (or skipping) the handshake -- the authenticating-state
+      // branch above intercepts the normal case before this map is ever
+      // consulted. Kept as a real handler (not 'ignore') for defense in
+      // depth: `handleAuthResponse` itself guards on state and answers
+      // INVALID_STATE, a more specific reply than falling through to
+      // UNKNOWN_MESSAGE would have given.
+      auth_response: (m) => this.routeAuthResponse(m),
+    };
+    const routed = routeClientMessage(message, handlers);
+    if (!routed) {
+      this.sendError('UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
     }
+  }
+
+  /** Shared by the authenticating-state branch and the post-connect handler
+   *  map: both may see a real `auth_response` (see the map entry's comment
+   *  on why the latter is reachable only defensively). */
+  private routeAuthResponse(message: AuthResponseMessage): void {
+    this.handleAuthResponse(message).catch((err) => {
+      this.send(createAuthResult(false, undefined, 'INTERNAL_AUTH_ERROR'));
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
+      this.close('Authentication error');
+    });
   }
 
   /**

--- a/packages/daemon/src/server/route-client-message.ts
+++ b/packages/daemon/src/server/route-client-message.ts
@@ -1,0 +1,54 @@
+/**
+ * Unified inbound (client-to-daemon) dispatch (#899, C6 of epic #883).
+ *
+ * Before this, `connection.ts` (direct WebSocket) and `relay-adapter.ts`
+ * (signaling relay) each hand-rolled their own switch over `message.type`,
+ * with different validation styles: `connection.ts` trusted the type system
+ * after `deserialize`/`isValidMessage` (envelope-only checks — type, id,
+ * timestamp); `relay-adapter.ts` reimplemented routing over
+ * `Record<string, unknown>` with ad-hoc `typeof` checks per field. Both
+ * switches did the same job. This module is the single place that does it,
+ * built on the `MessageHandlers`/`dispatchMessage` mechanism from #895/#896.
+ *
+ * `ClientMessageHandlers` is total over {@link ClientToDaemonType} — omitting
+ * a key is a compile error, not a silent drop. Both call sites build their
+ * own handler map (closures over their own event bag), because
+ * `ConnectionEvents` (no `connectionId` — one `Connection` instance per
+ * peer) and `AdapterEvents` (`connectionId` as the first arg — one
+ * `RelayAdapter` instance can in principle serve several) are genuinely
+ * different shapes. Collapsing THAT is C7 (#900), deliberately out of scope
+ * here — this module only kills the duplicate routing/validation, not the
+ * event-interface duplication.
+ */
+import {
+  type ClientToDaemonType,
+  type MessageHandlers,
+  type ProtocolMessage,
+  dispatchMessage,
+} from '@remi/shared';
+
+/** Total handler map over every client-to-daemon message type (#899). */
+export type ClientMessageHandlers = MessageHandlers<ClientToDaemonType, void>;
+
+/**
+ * Routes `msg` to the handler registered for its type in `handlers`.
+ *
+ * Returns `false` when `msg.type` is not a key of `handlers` at all — either
+ * a `d2c`-only type arriving inbound (a confused/malicious client) or a type
+ * this build's registry doesn't recognize. Callers decide how to report that
+ * (`connection.ts` sends `UNKNOWN_MESSAGE`; `relay-adapter.ts` sends
+ * `UNSUPPORTED` naming the type) rather than this function picking one wire
+ * shape for both transports.
+ */
+export function routeClientMessage(msg: ProtocolMessage, handlers: ClientMessageHandlers): boolean {
+  if (!Object.prototype.hasOwnProperty.call(handlers, msg.type)) {
+    return false;
+  }
+  // `msg.type` was just proven, at runtime, to be a key of `handlers` — whose
+  // type is `MessageHandlers<ClientToDaemonType>`. TypeScript's control-flow
+  // analysis cannot express that narrowing for a generic union plus an
+  // `Object.prototype.hasOwnProperty` check, so this cast documents a
+  // runtime-proven invariant rather than assuming one.
+  dispatchMessage(msg as Extract<ProtocolMessage, { type: ClientToDaemonType }>, handlers);
+  return true;
+}

--- a/packages/daemon/tests/relay-adapter-binding.test.ts
+++ b/packages/daemon/tests/relay-adapter-binding.test.ts
@@ -170,15 +170,22 @@ describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
     expect(calls[0]?.claudeSessionId).toBe(CSID);
   });
 
-  test('non-string claudeSessionId is dropped to undefined (defensive)', () => {
-    const calls: Array<{ claudeSessionId: string | undefined }> = [];
+  // #899: routeMessage's ad-hoc `typeof claudeSessionId === 'string'` guard
+  // (pre-unification) is GONE, not relocated -- connection.ts's inbound
+  // switch never had an equivalent guard either (it forwards
+  // `message.claudeSessionId` straight from the parsed JSON, trusting the
+  // type system same as every other field). This test now pins the new,
+  // unified behavior instead of the old defensive one: a malformed field
+  // is forwarded as-is, matching the direct-WebSocket path exactly.
+  test('non-string claudeSessionId is forwarded as-is (#899 parity with connection.ts)', () => {
+    const calls: Array<{ claudeSessionId: unknown }> = [];
     const adapter = makeAdapter({
       onAnswer: (
         _connectionId: UUID,
         _sessionId: UUID,
         _questionId: UUID,
         _answer: string,
-        claudeSessionId?: string,
+        claudeSessionId?: unknown,
       ) => {
         calls.push({ claudeSessionId });
       },
@@ -193,7 +200,42 @@ describe('relay-adapter routeMessage forwards claudeSessionId (#429)', () => {
     });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.claudeSessionId).toBeUndefined();
+    expect(calls[0]?.claudeSessionId).toBe(42);
+  });
+
+  // #899: previously dropped over relay -- connection.ts's handleAnswer has
+  // always forwarded the structured AskUserQuestion selections/cancel
+  // (#627) alongside a plain answer, but the pre-unification relay switch
+  // never computed the equivalent `extra` argument at all. Found while
+  // unifying the two dispatchers onto the same handler body.
+  test('answer selections/cancel are forwarded as extra (#899: previously dropped over relay)', () => {
+    const calls: Array<{ extra: unknown }> = [];
+    const adapter = makeAdapter({
+      onAnswer: (
+        _connectionId: UUID,
+        _sessionId: UUID,
+        _questionId: UUID,
+        _answer: string,
+        _claudeSessionId?: string,
+        extra?: unknown,
+      ) => {
+        calls.push({ extra });
+      },
+    });
+
+    callRoute(adapter, {
+      type: 'answer',
+      sessionId: SID,
+      questionId: QID,
+      answer: '',
+      selections: [{ questionIndex: 0, optionIndices: [1] }],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.extra).toEqual({
+      selections: [{ questionIndex: 0, optionIndices: [1] }],
+      cancel: undefined,
+    });
   });
 });
 
@@ -278,17 +320,23 @@ describe('relay-adapter routeMessage no-longer-silently-drops requests (#453 pha
     expect(calls[0]?.platform).toBe('ios');
   });
 
-  test('register_device_token with invalid platform is NOT dispatched', () => {
-    const calls: Array<{ token: string }> = [];
+  // #899: routeMessage's ad-hoc `platform !== 'ios' && platform !== 'android'`
+  // guard (pre-unification) is GONE, not relocated -- connection.ts's
+  // handleRegisterDeviceToken never validated this field either. Pins the
+  // new, unified (permissive) behavior instead of the old defensive one.
+  test('register_device_token with an unrecognized platform is forwarded as-is (#899 parity)', () => {
+    const calls: Array<{ token: string; platform: unknown }> = [];
     const adapter = makeAdapter({
-      onRegisterDeviceToken: (_c: UUID, token: string) => {
-        calls.push({ token });
+      onRegisterDeviceToken: (_c: UUID, token: string, platform: unknown) => {
+        calls.push({ token, platform });
       },
     });
 
     callRoute(adapter, { type: 'register_device_token', token: 'abc123', platform: 'windows' });
 
-    expect(calls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.token).toBe('abc123');
+    expect(calls[0]?.platform).toBe('windows');
   });
 
   test('unregister_device_token dispatches onUnregisterDeviceToken (#690)', () => {
@@ -306,17 +354,24 @@ describe('relay-adapter routeMessage no-longer-silently-drops requests (#453 pha
     expect(calls[0]?.token).toBe('abc123');
   });
 
-  test('unregister_device_token with missing token is NOT dispatched', () => {
-    const calls: Array<{ token: string }> = [];
+  // #899: routeMessage's ad-hoc `typeof token !== 'string'` guard
+  // (pre-unification) is GONE, not relocated -- connection.ts's
+  // handleUnregisterDeviceToken never validated this field either
+  // (`this.events.onUnregisterDeviceToken?.(message.token)`, no check).
+  // Pins the new, unified (permissive) behavior instead of the old
+  // defensive one.
+  test('unregister_device_token with a missing token forwards undefined (#899 parity)', () => {
+    const calls: Array<{ token: unknown }> = [];
     const adapter = makeAdapter({
-      onUnregisterDeviceToken: (_c: UUID, token: string) => {
+      onUnregisterDeviceToken: (_c: UUID, token: unknown) => {
         calls.push({ token });
       },
     });
 
     callRoute(adapter, { type: 'unregister_device_token' });
 
-    expect(calls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.token).toBeUndefined();
   });
 
   test('unknown type now rejects via sendRelay with error + UNSUPPORTED (no silent drop)', () => {
@@ -339,6 +394,69 @@ describe('relay-adapter routeMessage no-longer-silently-drops requests (#453 pha
 
     callRoute(adapter, { type: 'ping', id: RID });
 
+    expect(sent).toHaveLength(0);
+  });
+
+  // #899's trap, pinned at the relay call site: before this unification,
+  // relay's routeMessage switch had no `case 'ack'` or `case 'pong'` at all,
+  // so both fell to the default branch and got rejected as UNSUPPORTED --
+  // even though `ack`/`pong` are legitimate client-to-daemon types
+  // (MESSAGE_DIRECTION tags both 'both', not 'd2c') and connection.ts's
+  // direct-WebSocket switch has always accepted them as no-ops. A
+  // `ClientToDaemonType` derived as "tagged c2d" (excluding 'both') would
+  // have reproduced exactly this bug in the unified router; deriving it as
+  // "not d2c" is what fixes it here.
+  test('ack is a no-op over relay: no UNSUPPORTED rejection (#899 trap)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'ack', id: RID, ack: { messageId: RID, state: 'delivered' } });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test('pong is a no-op over relay: no UNSUPPORTED rejection (#899 trap)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'pong', id: RID, pingId: RID });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test('hello is a no-op over relay (connection established via peer-connected, not message)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, { type: 'hello', id: RID });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  // In real operation, `handleRelayMessage` intercepts `auth_response`
+  // BEFORE `routeMessage` is ever called (state-gated, unconditional -- see
+  // relay-adapter.ts's `handleRelayMessage`), so the map's `auth_response`
+  // entry cannot be reached this way outside a test. This proves the entry
+  // itself is real (not missing / not silently rejected) by calling
+  // routeMessage directly, bypassing that earlier interception -- the entry
+  // exists purely for exhaustiveness + defense in depth (#899), and this is
+  // the only way to exercise it at all.
+  test('auth_response reaching routeMessage directly is routed, not rejected as UNSUPPORTED (#899)', () => {
+    const adapter = makeAdapter({});
+    const sent = attachSendRelaySpy(adapter);
+
+    callRoute(adapter, {
+      type: 'auth_response',
+      id: RID,
+      clientPublicKey: 'base64-pubkey',
+      signature: 'base64-sig',
+      clientFingerprint: 'AA:BB:CC:DD',
+    });
+
+    // handleAuthResponse's own state guard (authState is 'none' here, not
+    // 'challenging') makes it a no-op with a console.warn -- the point of
+    // this test is only that it got THAT far, i.e. NOT rejected as
+    // UNSUPPORTED the way a missing map entry would have been.
     expect(sent).toHaveLength(0);
   });
 });

--- a/packages/daemon/tests/relay-client-to-daemon-conformance.test.ts
+++ b/packages/daemon/tests/relay-client-to-daemon-conformance.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Two-sided conformance test for the C6 daemon inbound-dispatch unification
+ * (#899): the RELAY transport.
+ *
+ * Companion to `packages/web/tests/lib/client-to-daemon-conformance.test.ts`,
+ * which covers the same client-to-daemon fixture set over the direct
+ * WebSocket transport with a real daemon `WebSocketAdapter` AND a real web
+ * `WebSocketClient` on both ends.
+ *
+ * ## This is NOT an end-to-end relay test -- said plainly, per AGENTS.md
+ * "Verify before you describe"
+ *
+ * The relay has no real client-side implementation to drive the other end
+ * of the wire: #881 is that the web client's key-exchange half was never
+ * built, so a real remote client cannot complete the relay handshake this
+ * daemon-side adapter expects. Building a second, parallel client
+ * implementation just for this test would itself be exactly the kind of
+ * synthetic counterparty AGENTS.md warns about (`relay-encryption.test.ts`
+ * drove the daemon with a test-local client that performed a handshake step
+ * no real client did, and #543 shipped half-built as a result).
+ *
+ * Instead, this drives the REAL, shipping `RelayAdapter`
+ * (packages/daemon/src/remote/relay-adapter.ts) through its `createTransport`
+ * seam -- a `RelayTransport` stand-in, documented in relay-adapter.ts as
+ * existing "so a test can stand in for the transport without a network or a
+ * Worker" (#543). The daemon-side class, its handler map, and its dispatch
+ * logic are all real and unmodified; only the signaling Worker connection is
+ * replaced with a fake event emitter that a real client's traffic would look
+ * identical to on the wire (plain JSON `ProtocolMessage` payloads emitted on
+ * a `relay` event, matching what `handleRelayMessage` expects once
+ * authenticated). No `authenticator` is configured here (default
+ * rotating-code mode), so the adapter accepts the fake peer immediately on
+ * `peer-connected` without needing to fake the Ed25519 challenge-response.
+ *
+ * For every `ClientToDaemonType` this asserts the daemon's real
+ * `AdapterEvents` callback fires. `hello`/`ping`/`pong`/`ack` are explicit
+ * no-ops over relay by design (see relay-adapter.ts's handler map) and get
+ * dedicated tests instead of a generic "some event fired" assertion.
+ * `auth_response` is proven separately in `relay-adapter-binding.test.ts`
+ * (it is intercepted by `handleRelayMessage` before the unified router is
+ * ever reached in real operation, so it cannot be exercised through this
+ * `relay` event path at all).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MESSAGE_DIRECTION, deserialize } from '@remi/shared';
+import type { ProtocolMessage, ProtocolMessageMap, UUID } from '@remi/shared';
+import type { AdapterEvents } from '../src/adapters/connection-adapter.ts';
+import { RelayAdapter, type RelayTransport } from '../src/remote/relay-adapter.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(HERE, '../../shared/tests/fixtures/protocol');
+
+function loadFixture(type: string): ProtocolMessage {
+  const raw = readFileSync(join(FIXTURES_DIR, `${type}.json`), 'utf-8');
+  const msg = deserialize(raw);
+  if (!msg) throw new Error(`fixture ${type}.json failed to deserialize`);
+  return msg;
+}
+
+/** Every type the daemon can legitimately receive from a client (mirrors
+ *  ClientToDaemonType at runtime -- see the web-side conformance test's
+ *  identical definition for the full rationale). */
+const C2D_TYPES = (Object.keys(MESSAGE_DIRECTION) as (keyof ProtocolMessageMap)[]).filter(
+  (t) => MESSAGE_DIRECTION[t] !== 'd2c',
+);
+
+const EXPECTED_EVENT: Partial<Record<keyof ProtocolMessageMap, string>> = {
+  user_input: 'onUserInput',
+  answer: 'onAnswer',
+  bullet_expand_request: 'onBulletExpandRequest',
+  session_list_request: 'onSessionListRequest',
+  transcript_load_request: 'onTranscriptLoadRequest',
+  create_session_request: 'onCreateSessionRequest',
+  terminal_resize: 'onTerminalResize',
+  kill_session_request: 'onKillSessionRequest',
+  resume_session_request: 'onResumeSessionRequest',
+  session_history_request: 'onSessionHistoryRequest',
+  detach_session: 'onDetachSession',
+  register_device_token: 'onRegisterDeviceToken',
+  unregister_device_token: 'onUnregisterDeviceToken',
+};
+
+/**
+ * Stands in for `SignalingClient` (the real Worker transport) via the seam
+ * `RelayAdapter` already exposes for exactly this. A real client's traffic
+ * looks identical to `emitRelay` on the wire once past the handshake: plain
+ * JSON `ProtocolMessage` payloads. `sent` records everything the adapter
+ * tried to send back (`sendRelay`), the same seam production code uses for
+ * challenges, auth results, and error replies.
+ */
+class FakeRelayTransport implements RelayTransport {
+  readonly isConnected = true;
+  readonly connectionCode: string | null = 'TEST-CODE';
+  readonly sent: string[] = [];
+  // Matches RelayTransport's own catch-all `on` overload (`any[]`, same reason: the emitter is heterogeneous by design).
+  // biome-ignore lint/suspicious/noExplicitAny: matches RelayTransport's catch-all overload
+  private readonly listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: implements RelayTransport's catch-all overload signature
+  on(event: string, cb: (...args: any[]) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: forwarding whatever `on` was registered with
+  private fire(event: string, ...args: any[]): void {
+    for (const cb of this.listeners.get(event) ?? []) cb(...args);
+  }
+
+  sendRelay(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  connect(): void {}
+  close(): void {}
+
+  /** Simulate the peer (client) connecting -- fires the adapter's real
+   *  `peer-connected` handler. */
+  emitPeerConnected(): void {
+    this.fire('peer-connected');
+  }
+
+  /** Simulate the peer sending one plaintext protocol message -- fires the
+   *  adapter's real `relay` handler, exactly as an authenticated client's
+   *  traffic would (no `sessionKeys` here since no authenticator is
+   *  configured, so the adapter processes it as plaintext, matching #881:
+   *  the DEFAULT rotating-code path never derives session keys). */
+  emitRelay(message: ProtocolMessage): void {
+    this.fire('relay', JSON.stringify(message));
+  }
+}
+
+describe('daemon inbound dispatch: RelayAdapter transport-seam conformance (#899, NOT end-to-end)', () => {
+  let transport: FakeRelayTransport;
+  let adapter: RelayAdapter;
+  let connectionId: UUID | null = null;
+  const eventCalls: Array<{ event: string; args: unknown[] }> = [];
+
+  function record(event: string) {
+    return (...args: unknown[]) => {
+      eventCalls.push({ event, args });
+    };
+  }
+
+  beforeEach(async () => {
+    transport = new FakeRelayTransport();
+    connectionId = null;
+    eventCalls.length = 0;
+    const events: Partial<AdapterEvents> = {
+      onConnect: (id) => {
+        connectionId = id;
+        record('onConnect')(id);
+      },
+      onDisconnect: record('onDisconnect'),
+      onUserInput: record('onUserInput'),
+      onAnswer: record('onAnswer'),
+      onBulletExpandRequest: record('onBulletExpandRequest'),
+      onSessionListRequest: record('onSessionListRequest'),
+      onTranscriptLoadRequest: record('onTranscriptLoadRequest'),
+      onCreateSessionRequest: record('onCreateSessionRequest'),
+      onTerminalResize: record('onTerminalResize'),
+      onKillSessionRequest: record('onKillSessionRequest'),
+      onResumeSessionRequest: record('onResumeSessionRequest'),
+      onSessionHistoryRequest: record('onSessionHistoryRequest'),
+      onDetachSession: record('onDetachSession'),
+      onRegisterDeviceToken: record('onRegisterDeviceToken'),
+      onUnregisterDeviceToken: record('onUnregisterDeviceToken'),
+    };
+
+    adapter = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl: 'wss://ignored.example.com',
+        createTransport: () => transport,
+      },
+      events,
+    );
+    await adapter.start();
+    transport.emitPeerConnected();
+    if (!connectionId) throw new Error('peer-connected did not fire onConnect');
+    // Reset AFTER the connect handshake so each test's assertions only see
+    // calls caused by the message it emits, not the setup's own onConnect.
+    eventCalls.length = 0;
+  });
+
+  afterEach(async () => {
+    await adapter.stop();
+  });
+
+  test('every ClientToDaemonType has a fixture, and the set is exactly the 18 INBOUND_ROUTED types', () => {
+    for (const type of C2D_TYPES) {
+      expect(() => loadFixture(type)).not.toThrow();
+    }
+    expect(C2D_TYPES.length).toBe(18);
+  });
+
+  describe.each(C2D_TYPES.filter((t) => EXPECTED_EVENT[t]))('%s', (type) => {
+    test('emitted relay message is routed to the correct real AdapterEvents callback', () => {
+      const fixture = loadFixture(type);
+      transport.emitRelay(fixture);
+
+      expect(eventCalls).toHaveLength(1);
+      expect(eventCalls[0]?.event).toBe(EXPECTED_EVENT[type]);
+      expect(eventCalls[0]?.args[0]).toBe(connectionId);
+      // No rejection was sent back for a type the router does recognize.
+      expect(transport.sent).toHaveLength(0);
+    });
+  });
+
+  test('answer selections/cancel are forwarded as extra over relay (#899: previously dropped)', () => {
+    const fixture = loadFixture('answer');
+    if (fixture.type !== 'answer') throw new Error('unreachable');
+    const withSelections: ProtocolMessage = {
+      ...fixture,
+      answer: '',
+      selections: [{ questionIndex: 0, optionIndices: [1] }],
+    };
+    transport.emitRelay(withSelections);
+
+    expect(eventCalls).toHaveLength(1);
+    expect(eventCalls[0]?.event).toBe('onAnswer');
+    // onAnswer(connectionId, sessionId, questionId, answer, claudeSessionId, extra)
+    expect(eventCalls[0]?.args[5]).toEqual({
+      selections: [{ questionIndex: 0, optionIndices: [1] }],
+      cancel: undefined,
+    });
+  });
+
+  test('hello over relay is a no-op: connection is already established via peer-connected', () => {
+    const fixture = loadFixture('hello');
+    transport.emitRelay(fixture);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  test('ping over relay is a no-op: no reply needed', () => {
+    const fixture = loadFixture('ping');
+    transport.emitRelay(fixture);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  // #899's trap, pinned end-to-end through the real adapter's real 'relay'
+  // event path: before this unification, relay's routeMessage switch had no
+  // case for 'pong'/'ack' at all, so both were rejected as UNSUPPORTED even
+  // though MESSAGE_DIRECTION tags both 'both' (real client-to-daemon
+  // types) and connection.ts has always accepted them as no-ops.
+  test('pong over relay does not produce an UNSUPPORTED rejection (#899 trap)', () => {
+    const fixture = loadFixture('pong');
+    transport.emitRelay(fixture);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  test('ack over relay does not produce an UNSUPPORTED rejection (#899 trap)', () => {
+    const fixture = loadFixture('ack');
+    transport.emitRelay(fixture);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  test('a genuinely unregistered type is rejected as UNSUPPORTED, naming the type (control)', () => {
+    const bogus = {
+      type: 'totally_unknown_future_type',
+      id: 'bogus-id',
+      timestamp: new Date().toISOString(),
+    } as unknown as ProtocolMessage;
+    transport.emitRelay(bogus);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(1);
+    const parsed = JSON.parse(transport.sent[0] as string);
+    expect(parsed.type).toBe('error');
+    expect(parsed.code).toBe('UNSUPPORTED');
+    expect(parsed.message).toContain('totally_unknown_future_type');
+  });
+
+  test('a registered d2c-only type arriving over relay is rejected as UNSUPPORTED', () => {
+    // 'question' is a real registry type but tagged 'd2c' -- not a key in
+    // the relay's handler map. Preserves relay's pre-#899 behavior for this
+    // exact scenario (see connection.ts's analogous UNKNOWN_MESSAGE case in
+    // the web-side conformance test).
+    const fixture = loadFixture('question');
+    transport.emitRelay(fixture);
+
+    expect(eventCalls).toHaveLength(0);
+    expect(transport.sent).toHaveLength(1);
+    const parsed = JSON.parse(transport.sent[0] as string);
+    expect(parsed.code).toBe('UNSUPPORTED');
+    expect(parsed.message).toContain('question');
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ProtocolMessage,
   ProtocolMessageMap,
   MessageOf,
+  ClientToDaemonType,
   HelloMessage,
   HelloAckMessage,
   AgentOutputMessage,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -230,6 +230,26 @@ export const MESSAGE_DIRECTION = {
   question_snapshot: 'd2c',
 } as const satisfies Record<keyof ProtocolMessageMap, 'c2d' | 'd2c' | 'both'>;
 
+/**
+ * Every registry key the daemon can legitimately receive from a client:
+ * derived as "NOT `d2c`" (i.e. `c2d` or `both`), never as "tagged `c2d`" (#899).
+ *
+ * The distinction is `ack`: tagged `both` because `connection.ts`'s inbound
+ * routing has a real accepting case for it (an ack CAN arrive from a client,
+ * even though only the daemon currently constructs one — see the comment on
+ * `ack` in {@link MESSAGE_DIRECTION}). A `c2d`-only derivation would silently
+ * exclude `ack` and make the daemon reject a message it accepts today,
+ * surfacing as a hard-to-trace `UNKNOWN_MESSAGE`. `ping`/`pong` are `both`
+ * for the same structural reason (both sides construct and accept them).
+ *
+ * `packages/shared/tests/protocol-registry.test.ts`'s `INBOUND_ROUTED` list
+ * pins the exact 18-member set this type must resolve to, hand-transcribed
+ * from `connection.ts` independently of this derivation.
+ */
+export type ClientToDaemonType = {
+  [K in keyof ProtocolMessageMap]: (typeof MESSAGE_DIRECTION)[K] extends 'd2c' ? never : K;
+}[keyof ProtocolMessageMap];
+
 /** Client hello - initiates connection */
 export interface HelloMessage {
   readonly type: 'hello';

--- a/packages/web/tests/lib/client-to-daemon-conformance.test.ts
+++ b/packages/web/tests/lib/client-to-daemon-conformance.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Two-sided conformance test for the C6 daemon inbound-dispatch unification
+ * (#899): the DIRECT WEBSOCKET transport.
+ *
+ * Companion to `relay-client-to-daemon-conformance.test.ts`
+ * (packages/daemon/tests), which covers the same client-to-daemon fixture
+ * set over the relay transport via `RelayAdapter`'s `createTransport` seam
+ * -- documented there as NOT end-to-end (the relay has no real client
+ * implementation to drive the other side of the handshake, #881).
+ *
+ * This file drives the REAL daemon `WebSocketAdapter` and the REAL web
+ * `WebSocketClient` over one real Bun-native socket -- no synthetic
+ * counterparty on either side (AGENTS.md "Verify before you describe": #543
+ * shipped half-built because `relay-encryption.test.ts` drove the daemon
+ * with a test-local client that performed a handshake step no real client
+ * did; #881 found it). Both endpoints here are the actual shipping classes,
+ * imported directly: `packages/daemon/src/adapters/websocket-adapter.ts`
+ * and `packages/web/src/lib/websocket-client.ts`. This mirrors the pattern
+ * `message-dispatch-conformance.test.ts` (#897/#912) established for the
+ * opposite (daemon-to-client) direction.
+ *
+ * For every `ClientToDaemonType` (every `MESSAGE_DIRECTION` entry that is
+ * NOT `d2c` -- packages/shared/src/protocol.ts), this sends the checked-in
+ * golden fixture from the real client and asserts the daemon's real
+ * `AdapterEvents` callback fires with the right connection id. `hello`,
+ * `auth_response`, `ping`, `pong`, and `ack` have no app-level event (by
+ * design -- see `connection.ts`'s handler map) and get dedicated tests
+ * instead of a generic "some event fired" assertion.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ProtocolMessage, ProtocolMessageMap } from '@remi/shared/protocol.ts';
+import { MESSAGE_DIRECTION, createHello, deserialize, generateId } from '@remi/shared/protocol.ts';
+import type { AdapterEvents } from '../../../daemon/src/adapters/connection-adapter.ts';
+// Real daemon adapter -- not a test double. Relative import: packages/web has
+// no `@remi/daemon` path alias (only `packages/web/tests/**` is exempt from
+// both typecheck gates, so this resolves fine at `bun test` runtime; see
+// message-dispatch-conformance.test.ts's "conformance-test placement
+// decision" comment for the precedent this follows).
+import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
+import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
+import { WebSocketClient } from '../../src/lib/websocket-client.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(HERE, '../../../shared/tests/fixtures/protocol');
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!predicate() && Date.now() - start < timeoutMs) {
+    await wait(10);
+  }
+  if (!predicate()) {
+    throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+  }
+}
+
+/** Every type the daemon can legitimately receive from a client, per the
+ *  registry's own direction table -- 'c2d' or 'both', never 'd2c'. Mirrors
+ *  `ClientToDaemonType` (packages/shared/src/protocol.ts) at runtime; see
+ *  `protocol-registry.test.ts`'s independently hand-transcribed
+ *  `INBOUND_ROUTED` list for the pin on the type-level derivation itself. */
+const C2D_TYPES = (Object.keys(MESSAGE_DIRECTION) as (keyof ProtocolMessageMap)[]).filter(
+  (t) => MESSAGE_DIRECTION[t] !== 'd2c',
+);
+
+/** Types with no app-level `AdapterEvents` callback by design (connection
+ *  setup, liveness, or acknowledgment) -- covered by dedicated tests below
+ *  instead of the generic per-type loop. */
+const NO_EVENT_TYPES = new Set(['hello', 'auth_response', 'ping', 'pong', 'ack']);
+
+/** Maps each c2d type with a real handler to the `AdapterEvents` callback
+ *  name `connection.ts`'s (and the unified router's) handler map invokes. */
+const EXPECTED_EVENT: Partial<Record<keyof ProtocolMessageMap, string>> = {
+  user_input: 'onUserInput',
+  answer: 'onAnswer',
+  bullet_expand_request: 'onBulletExpandRequest',
+  session_list_request: 'onSessionListRequest',
+  transcript_load_request: 'onTranscriptLoadRequest',
+  create_session_request: 'onCreateSessionRequest',
+  terminal_resize: 'onTerminalResize',
+  kill_session_request: 'onKillSessionRequest',
+  resume_session_request: 'onResumeSessionRequest',
+  session_history_request: 'onSessionHistoryRequest',
+  detach_session: 'onDetachSession',
+  register_device_token: 'onRegisterDeviceToken',
+  unregister_device_token: 'onUnregisterDeviceToken',
+};
+
+function loadFixture(type: string): ProtocolMessage {
+  const raw = readFileSync(join(FIXTURES_DIR, `${type}.json`), 'utf-8');
+  const msg = deserialize(raw);
+  if (!msg) throw new Error(`fixture ${type}.json failed to deserialize`);
+  return msg;
+}
+
+describe('daemon inbound dispatch: real web client -> real daemon adapter conformance (#899)', () => {
+  let adapter: WebSocketAdapter;
+  let port: number;
+  let client: WebSocketClient;
+  let connectionId: string | null = null;
+  const eventCalls: Array<{ event: string; args: unknown[] }> = [];
+  const received: ProtocolMessage[] = [];
+
+  function record(event: string) {
+    return (...args: unknown[]) => {
+      eventCalls.push({ event, args });
+    };
+  }
+
+  beforeAll(async () => {
+    port = await reserveRange(1);
+    const events: Partial<AdapterEvents> = {
+      onConnect: (id) => {
+        connectionId = id;
+        record('onConnect')(id);
+      },
+      onDisconnect: record('onDisconnect'),
+      onUserInput: record('onUserInput'),
+      onAnswer: record('onAnswer'),
+      onBulletExpandRequest: record('onBulletExpandRequest'),
+      onSessionListRequest: record('onSessionListRequest'),
+      onTranscriptLoadRequest: record('onTranscriptLoadRequest'),
+      onCreateSessionRequest: record('onCreateSessionRequest'),
+      onTerminalResize: record('onTerminalResize'),
+      onKillSessionRequest: record('onKillSessionRequest'),
+      onResumeSessionRequest: record('onResumeSessionRequest'),
+      onSessionHistoryRequest: record('onSessionHistoryRequest'),
+      onDetachSession: record('onDetachSession'),
+      onRegisterDeviceToken: record('onRegisterDeviceToken'),
+      onUnregisterDeviceToken: record('onUnregisterDeviceToken'),
+      onError: record('onError'),
+    };
+    adapter = new WebSocketAdapter({ port }, events);
+    await adapter.start();
+
+    client = new WebSocketClient(
+      // 'localhost', not '127.0.0.1' -- see message-dispatch-conformance.test.ts.
+      { url: `ws://localhost:${port}/ws`, heartbeatInterval: 0, connectionTimeout: 2000 },
+      { onMessage: (msg) => received.push(msg) },
+    );
+    client.connect();
+    await waitFor(() => client.isConnected || client.isTransportOpen);
+
+    client.send(createHello(generateId(), '0.0.0-test'));
+    await waitFor(() => connectionId !== null);
+  });
+
+  afterAll(async () => {
+    client.disconnect();
+    await adapter.stop();
+  });
+
+  test('every ClientToDaemonType has a fixture, and the set is exactly the 18 INBOUND_ROUTED types', () => {
+    for (const type of C2D_TYPES) {
+      expect(() => loadFixture(type)).not.toThrow();
+    }
+    // Pinned count, independent of protocol-registry.test.ts's own
+    // hand-transcribed INBOUND_ROUTED list -- if this drifts, so should that
+    // list, and a mismatch between the two is exactly the kind of silent
+    // drift #899 exists to make loud.
+    expect(C2D_TYPES.length).toBe(18);
+  });
+
+  describe.each(C2D_TYPES.filter((t) => EXPECTED_EVENT[t]))('%s', (type) => {
+    test('real client send is routed to the correct real AdapterEvents callback', async () => {
+      const fixture = loadFixture(type);
+      const before = eventCalls.length;
+      client.send(fixture);
+
+      await waitFor(() => eventCalls.length > before);
+      const call = eventCalls[eventCalls.length - 1];
+      expect(call?.event).toBe(EXPECTED_EVENT[type]);
+      // First positional arg on every AdapterEvents callback is connectionId.
+      expect(call?.args[0]).toBe(connectionId);
+    });
+  });
+
+  test('sanity: every EXPECTED_EVENT key is a real c2d type covered by the loop above', () => {
+    for (const type of Object.keys(EXPECTED_EVENT)) {
+      expect(C2D_TYPES).toContain(type as keyof ProtocolMessageMap);
+    }
+  });
+
+  // --- Dedicated tests for the 5 no-app-event types ---
+
+  test('ping is routed to handlePing: the real client receives a real pong back', async () => {
+    const fixture = loadFixture('ping');
+    const before = received.length;
+    client.send(fixture);
+
+    await waitFor(() => received.slice(before).some((m) => m.type === 'pong'));
+    const pong = received.slice(before).find((m) => m.type === 'pong');
+    expect(pong?.type).toBe('pong');
+    if (pong?.type !== 'pong') throw new Error('unreachable');
+    expect(pong.pingId).toBe(fixture.id);
+  });
+
+  test('pong is a routed no-op: no error comes back', async () => {
+    const fixture = loadFixture('pong');
+    const beforeErrors = eventCalls.filter((c) => c.event === 'onError').length;
+    const beforeReceived = received.length;
+    client.send(fixture);
+
+    // No positive signal to wait on for a no-op -- give routing a beat, then
+    // assert nothing negative happened.
+    await wait(150);
+    expect(eventCalls.filter((c) => c.event === 'onError').length).toBe(beforeErrors);
+    const newErrors = received
+      .slice(beforeReceived)
+      .filter((m) => m.type === 'error' && m.code === 'UNKNOWN_MESSAGE');
+    expect(newErrors).toHaveLength(0);
+  });
+
+  // The direct #899 trap check: before this unification, deriving
+  // ClientToDaemonType as "tagged c2d" (excluding 'both') would have
+  // silently dropped `ack` from the handler map, and the unified router
+  // would then reject a real `ack` with UNKNOWN_MESSAGE -- a message
+  // connection.ts's switch has always accepted as a no-op. This pins that
+  // it still does not, against the REAL daemon over a REAL socket.
+  test('ack does not produce UNKNOWN_MESSAGE (#899 trap, pinned end-to-end)', async () => {
+    const fixture = loadFixture('ack');
+    const beforeReceived = received.length;
+    client.send(fixture);
+
+    await wait(150);
+    const unknownMessageErrors = received
+      .slice(beforeReceived)
+      .filter((m) => m.type === 'error' && m.code === 'UNKNOWN_MESSAGE');
+    expect(unknownMessageErrors).toHaveLength(0);
+  });
+
+  // auth_response arriving outside the authenticating state (this daemon
+  // has no authenticator configured) is routed to a REAL handler
+  // (`handleAuthResponse`, via connection.ts's `auth_response` map entry)
+  // that answers a specific INVALID_STATE, not the generic UNKNOWN_MESSAGE
+  // a missing/'ignore' entry would produce. This is the strongest available
+  // proof that auth_response is genuinely present in the unified router's
+  // handler map, not merely assumed to be.
+  test('auth_response outside the handshake is routed to a real handler (INVALID_STATE, not UNKNOWN_MESSAGE)', async () => {
+    const fixture = loadFixture('auth_response');
+    const beforeReceived = received.length;
+    client.send(fixture);
+
+    await waitFor(() => received.slice(beforeReceived).some((m) => m.type === 'error'));
+    const err = received.slice(beforeReceived).find((m) => m.type === 'error');
+    expect(err?.type).toBe('error');
+    if (err?.type !== 'error') throw new Error('unreachable');
+    expect(err.code).toBe('INVALID_STATE');
+  });
+
+  // hello is implicitly proven routed by the connection setup succeeding in
+  // beforeAll (onConnect fired). This proves it a second, independent way:
+  // resending it post-connect reaches handleHello's own state guard
+  // (INVALID_STATE) rather than falling through to UNKNOWN_MESSAGE, which
+  // is what a missing/'ignore' map entry would have produced instead.
+  test('a second hello post-connect is routed to a real handler (INVALID_STATE, not UNKNOWN_MESSAGE)', async () => {
+    const fixture = loadFixture('hello');
+    const beforeReceived = received.length;
+    client.send(fixture);
+
+    await waitFor(() => received.slice(beforeReceived).some((m) => m.type === 'error'));
+    const err = received.slice(beforeReceived).find((m) => m.type === 'error');
+    expect(err?.type).toBe('error');
+    if (err?.type !== 'error') throw new Error('unreachable');
+    expect(err.code).toBe('INVALID_STATE');
+  });
+
+  test('a genuinely unregistered type is rejected as UNKNOWN_MESSAGE (control: the default path still works)', async () => {
+    const bogus = {
+      type: 'totally_unknown_future_type',
+      id: generateId(),
+      timestamp: new Date().toISOString(),
+    } as unknown as ProtocolMessage;
+    const beforeReceived = received.length;
+    client.send(bogus);
+
+    await waitFor(() => received.slice(beforeReceived).some((m) => m.type === 'error'));
+    const err = received.slice(beforeReceived).find((m) => m.type === 'error');
+    expect(err?.type).toBe('error');
+    if (err?.type !== 'error') throw new Error('unreachable');
+    // Genuinely unregistered types never reach the router at all -- they
+    // fail `deserialize`'s envelope validation first (INVALID_MESSAGE), same
+    // as before #899. UNKNOWN_MESSAGE is reserved for registered-but-wrong-
+    // direction types (see the 'question' test below).
+    expect(err.code).toBe('INVALID_MESSAGE');
+  });
+
+  test('a registered d2c-only type arriving inbound is rejected as UNKNOWN_MESSAGE', async () => {
+    // 'question' is a real registry type (passes deserialize) but tagged
+    // 'd2c' -- not a key in ClientToDaemonType/the handler map at all. This
+    // is the one case that genuinely reaches routeClientMessage's "not
+    // found" path and gets UNKNOWN_MESSAGE, preserving connection.ts's
+    // pre-#899 behavior for this exact scenario.
+    const fixture = loadFixture('question');
+    const beforeReceived = received.length;
+    client.send(fixture);
+
+    await waitFor(() => received.slice(beforeReceived).some((m) => m.type === 'error'));
+    const err = received.slice(beforeReceived).find((m) => m.type === 'error');
+    expect(err?.type).toBe('error');
+    if (err?.type !== 'error') throw new Error('unreachable');
+    expect(err.code).toBe('UNKNOWN_MESSAGE');
+  });
+});


### PR DESCRIPTION
Closes #899 (C6, epic #883).

## Summary

Two hand-rolled inbound (client-to-daemon) dispatch switches did the same
job with different validation styles:
- `connection.ts:325-382` (direct WebSocket) — validated via `deserialize`/
  `isValidMessage` (envelope-only: type/id/timestamp), then a `switch`.
- `relay-adapter.ts:521-673` — reimplemented routing over
  `Record<string, unknown>` with ad-hoc `typeof` checks per field.

Replaced both with one `routeClientMessage(msg, handlers)`
(`packages/daemon/src/server/route-client-message.ts`), built on the
`MessageHandlers`/`dispatchMessage` mechanism from C2/C3 (#895/#896). Each
call site still builds its own handler map (closures over its own event
bag — `ConnectionEvents` has no `connectionId`, `AdapterEvents` does), but
the map's *type* and the dispatch mechanic are now shared and total: a new
registry key breaks both files' compile until decided.

The daemon's loud `UNKNOWN_MESSAGE` default is unchanged (still the correct
shape, per the issue).

## How `ClientToDaemonType` was derived, and `ack`

`ClientToDaemonType` did not exist (confirmed: `grep -rn "ClientToDaemonType" packages/`
returned nothing before this PR). Added to `packages/shared/src/protocol.ts`,
derived as **"not `d2c`"** (i.e. `c2d` or `both`), never as "tagged `c2d`":

```ts
export type ClientToDaemonType = {
  [K in keyof ProtocolMessageMap]: (typeof MESSAGE_DIRECTION)[K] extends 'd2c' ? never : K;
}[keyof ProtocolMessageMap];
```

This resolves to exactly the 18 types in `protocol-registry.test.ts`'s
hand-transcribed `INBOUND_ROUTED` list — **`ack` is one of them** (tagged
`both`), and is a real, explicit `'ignore'` entry in both handler maps, with
a comment pointing at the trap. Unlike C5 (#909), C6 does NOT have the
`ReplayBatchMessage.messages: readonly ProtocolMessage[]` recursion problem
(inbound messages never nest), so a genuinely narrowed type was the correct
choice here, not the full 45-key registry C5 used.

## `INBOUND_ROUTED` acceptance check: all 18 pass, both transports

Every type in `protocol-registry.test.ts`'s `INBOUND_ROUTED` list is
routable through the unified router on **both** transports, verified by two
new conformance suites (fixture set: `packages/shared/tests/fixtures/protocol/`):

- 13 types with a real `AdapterEvents` callback (`user_input`, `answer`,
  `bullet_expand_request`, `session_list_request`, `transcript_load_request`,
  `create_session_request`, `terminal_resize`, `kill_session_request`,
  `resume_session_request`, `session_history_request`, `detach_session`,
  `register_device_token`, `unregister_device_token`) — parameterized loop,
  asserts the correct callback fires with the right `connectionId`.
- `hello`, `ping`, `pong`, `ack`, `auth_response` — dedicated tests, since
  each is an explicit no-op or state-guarded reply rather than an app event.
  `ack` and `pong` specifically assert **no** `UNKNOWN_MESSAGE`/`UNSUPPORTED`
  rejection — the direct pin against this issue's trap.

`protocol-registry.test.ts` itself is unmodified and green (it doesn't
reference `ClientToDaemonType` — see "acceptance check" note below on why
that matters).

## Relay test: NOT end-to-end — stated per AGENTS.md "Verify before you describe"

`packages/daemon/tests/relay-client-to-daemon-conformance.test.ts` drives
the real, shipping `RelayAdapter` through its `createTransport` seam (a
`RelayTransport` stand-in), **not** a live Worker or a real remote client.
#881 (client-side key exchange never implemented) means there is no real
client to complete the relay handshake — building one just for this test
would itself be the synthetic-counterparty problem AGENTS.md warns about
(`relay-encryption.test.ts` drove the daemon with a test-local client
performing a handshake step no real client did, and #543 shipped
half-built as a result). The daemon-side class, handler map, and dispatch
logic are all real and unmodified; only the Worker connection is faked.
The file's module doc says this explicitly.

The direct-WebSocket companion test
(`packages/web/tests/lib/client-to-daemon-conformance.test.ts`) **is**
two real shipping endpoints: real daemon `WebSocketAdapter` + real web
`WebSocketClient` over one real Bun socket, mirroring the pattern
`message-dispatch-conformance.test.ts` (#897/#912) set for the opposite
direction.

## Break-it-then-fix-it (numbers)

Reproduced the exact trap the issue describes, in two stages:

1. **Compile-time**: changed the derivation to `extends 'c2d' ? K : never`
   (excluding `both`). `bun run typecheck` → **3 errors** (`TS2353` excess
   property `'ping'` in both `connection.ts` and `relay-adapter.ts`'s
   handler maps, plus one cascading `TS7006`). This alone would stop a
   PR before it merges.
2. **Runtime** (the issue's "hard to trace back" scenario): additionally
   removed the now-excess `ack`/`ping`/`pong` entries from both handler
   maps to match the wrong narrower type. Typecheck went clean again
   (0 errors) — but running the three trap-pinning suites produced
   **9 failures / 68 total** (`59 pass / 9 fail`), precisely on the
   ack/ping/pong assertions in `relay-client-to-daemon-conformance.test.ts`
   (3), `relay-adapter-binding.test.ts` (3), and
   `client-to-daemon-conformance.test.ts` (3). Every other test stayed
   green — the break was exactly as targeted as the fix.
3. Restored via `git checkout -- packages/shared/src/protocol.ts
   packages/daemon/src/server/connection.ts
   packages/daemon/src/remote/relay-adapter.ts` → clean diff against the
   commit, `bun run typecheck` 0 errors, **68 pass / 0 fail** again.

## Contradicting the issue text

- **The relay's own "no silent drop" contract (#453 phase 5) required NOT
  gating on `isValidMessage` before routing.** I initially planned to
  validate the relay's parsed payload the same way `deserialize` does
  before calling the router. That would have made a genuinely unregistered
  type (e.g. a client typo) get silently dropped with only a `console.warn`
  instead of the tested, deliberate `UNSUPPORTED` reply naming the type
  (`relay-adapter-binding.test.ts`, "no-longer-silently-drops-requests").
  Kept relay's existing loose upstream gate (`typeof message.type ===
  'string'`) exactly as-is; unification is scoped to *which handler fires
  for a known type*, not relay's separate envelope-validation pipeline.
- **Removing the ad-hoc per-field validation is a real, intentional
  behavior change**, not a no-op refactor: relay previously rejected
  malformed `register_device_token`/`unregister_device_token`/`answer`
  payloads (wrong `claudeSessionId` type, invalid `platform`, missing
  `token`) with a warning and no dispatch. `connection.ts` never validated
  these fields either (trusts the type system post-`deserialize`), so
  unifying means relay now matches that — a malformed field flows to the
  event handler instead of being dropped. Documented in `relay-adapter.ts`'s
  `routeMessage` doc comment and pinned by three rewritten tests in
  `relay-adapter-binding.test.ts` (kept, not deleted, with `#899 parity`
  in their names).
- **A real bug found while unifying, now fixed**: relay's `answer` case
  never forwarded structured AskUserQuestion `selections`/`cancel` (#627) —
  `connection.ts`'s `handleAnswer` always has. Relay clients silently lost
  multi-select/cancel answers. Fixed as part of the unification (same
  `extra` computation now runs on both transports); pinned by a new test
  on each side.
- **`auth_response` is technically unreachable through the relay's real
  `relay` event path**: `handleRelayMessage` intercepts it unconditionally
  before the router is ever consulted. Its entry in relay's handler map
  exists only for exhaustiveness/defense-in-depth; proven directly via
  `routeMessage` reflection in `relay-adapter-binding.test.ts` since the
  real-flow conformance test structurally cannot reach it.

## Concurrency / scope

Touched only `connection.ts`, `relay-adapter.ts`, `shared/protocol.ts`,
`shared/index.ts`, and a new `route-client-message.ts` — did not touch
`hook-event-bridge.ts`, `question-parser.ts`, `auto-approve-gate.ts`,
`question-trace.ts`, or `hook-bridge-setup.ts` (Q2/#887, Q7a/#891 surface).
Did not attempt C7 (#900, the `ConnectionEvents`/`ServerEvents`/
`AdapterEvents` collapse) — deliberately out of scope. This PR narrows
what C7 has to change: both transports now build the same
`ClientMessageHandlers` *type* even though their closures still differ by
event-bag shape, so C7's job is purely collapsing that event-bag shape,
not also re-deriving which types are routable.

## Testing

- `bun run typecheck` — clean (0 errors)
- `bun run typecheck:web` — clean (0 errors)
- `bunx biome check .` — 0 errors, 48 warnings (identical to the `develop`
  baseline, verified by diffing against a stash of this branch's changes)
- Full `packages/shared/tests/` — 424 pass / 0 fail
- Full `packages/daemon/tests/` except `auto-approve/` (per repo convention,
  untouched by this PR) — 2610 test executions across two batches, 0 fail
- Full `packages/web/tests/` — 502 pass / 0 fail (one isolated run hit a
  pre-existing, unrelated timing flake in `ack-gated-reregister.test.ts`;
  confirmed pre-existing by running against a full stash of this branch's
  changes, and passes cleanly both standalone and on a second full run)
- Break-it-then-fix-it: see above