### PR TITLE
Add turn-complete push notification (#914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,23 @@ All notable changes to Remi are documented here.
   by accident; a future one starts from the encrypted handshake.
 
 ### Added
+- **Turn-complete push notification** (#914). `Stop.last_assistant_message` is
+  present on the already-registered `Stop` hook (100% of captured events,
+  #891) but was only ever logged, never surfaced. remi now pushes
+  "`<session>`: turn complete" with the actual last message when a turn runs
+  long — gated on DURATION, not on every `Stop`, because `Stop` fires on every
+  turn including two-second interactive ones and a push on all of them is
+  worse than nothing. Duration is measured from `prompt_id` (present on every
+  hook's common fields), the earliest-observed hook event for that turn to
+  `Stop`, so it costs no new hook registration. New `[notifications]` config:
+  `on_turn_complete` (default true) and `turn_complete_min_seconds` (default
+  60). Never fires on a stop-hook re-entry, an empty message, or with no
+  device registered. `notifySessionComplete()`
+  (`packages/web/src/lib/notifications.ts`), dead code with zero callers that
+  made #914 confusing in the first place, is deleted rather than wired up —
+  the actual notification is a server-side APNS push with real content, which
+  the client already displays generically.
+
 - **Hook fields remi was already receiving and dropping are now consumed**
   (#891). No new hook registrations — this is entirely fields the
   already-registered `Stop`, `SubagentStop` and `PostToolUse` hooks carry.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -177,7 +177,7 @@ import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, detectLocalLLMPlatform, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
-import type { PermissionRequestHookInput, StopHookInput } from './hooks/index.ts';
+import type { HookInput, PermissionRequestHookInput, StopHookInput } from './hooks/index.ts';
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
@@ -1013,6 +1013,18 @@ const binderClosers: Map<UUID, () => void> = new Map();
 // removed on session close. Empty when no hookServer is configured.
 const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
 /**
+ * Per-session "does this binder claim the event?" filters (#914).
+ *
+ * Listeners registered INSIDE `setupHookBridge` all consult `binder.admits()`.
+ * `onTurnStop` is registered out here, so it needs the same filter: two daemons
+ * in the SAME project directory each append their own matcher to the shared
+ * `.claude/settings.local.json` hooks array, and Claude Code POSTs every event
+ * to both. Unfiltered, this daemon would push "turn complete" for a sibling's
+ * turn, labelled with THIS session's name and carrying the sibling's output --
+ * a false "done" for a session that may still be working.
+ */
+const sessionAdmitsHandles: Map<UUID, (input: HookInput) => boolean> = new Map();
+/**
  * Force-release every session's gate (#617, `remi unstick` -> SIGUSR2): the "just
  * get me out" lever when an LLM eval + a question are stuck and the phone has no
  * device visibility. Each gate releases its held hooks to passthrough (native prompt),
@@ -1093,6 +1105,9 @@ const sessionRegistry = new SessionRegistry(
       // Drop the per-session gate handle (#573); any held hook was already
       // released by the gate's closeBinder/cancelStale on teardown.
       sessionGateHandles.delete(sessionId);
+      // #914: drop the admits filter with the session, so a closed session's
+      // binder can never keep admitting turns on its behalf.
+      sessionAdmitsHandles.delete(sessionId);
       // Drop the per-session APNS dispatcher (#585, P7).
       sessionNotifiers.delete(sessionId);
       const watcher = transcriptWatchers.get(sessionId);
@@ -1266,6 +1281,24 @@ const turnTimer = new TurnTimer();
  * catch most instances of anyway.
  */
 function onTurnStop(input: StopHookInput): void {
+  // Session filter FIRST (#914). Claude Code broadcasts every event to every
+  // daemon registered for the directory, so an unfiltered Stop here is very
+  // likely a sibling's. Note the timer cannot save us: `onAnyEvent` observes
+  // sibling events too, so `elapsedMs` comes back populated and plausible.
+  // Fail closed -- no admitting session means we do not claim this turn.
+  let admitted = false;
+  for (const admits of sessionAdmitsHandles.values()) {
+    try {
+      if (admits(input)) {
+        admitted = true;
+        break;
+      }
+    } catch {
+      // A binder that throws must not break the hook path; treat as not ours.
+    }
+  }
+  if (!admitted) return;
+
   const elapsedMs = turnTimer.elapsedMs(input.prompt_id);
   // A stop-hook re-entry means the turn is still going, not finished -- do
   // NOT clear the mark for it: the eventual real Stop still needs the turn's
@@ -1601,6 +1634,9 @@ async function createNewSession(
     // Register the per-session gate handle (#573) so the WebSocket answer path
     // can resolve a held permission / cancel the eval for this exact session.
     sessionGateHandles.set(sessionId, hookBridgeHandle.gate);
+    // #914: lets the out-of-bridge turn-complete listener apply the same
+    // session filter every in-bridge listener already uses.
+    sessionAdmitsHandles.set(sessionId, hookBridgeHandle.admits);
   }
 
   const ptySession = createPtySessionForSession(

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -177,10 +177,15 @@ import { isRemiBinaryPath, startUpdateWatcher } from './cli/update-watcher.ts';
 import { applyEnvOverrides, detectLocalLLMPlatform, loadConfig } from './config/index.ts';
 import type { RemiConfig } from './config/index.ts';
 import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
-import type { PermissionRequestHookInput } from './hooks/index.ts';
+import type { PermissionRequestHookInput, StopHookInput } from './hooks/index.ts';
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
+import {
+  TurnTimer,
+  buildTurnCompleteText,
+  shouldNotifyTurnComplete,
+} from './notifications/turn-timer.ts';
 import { OutputProcessor } from './parser/output-processor.ts';
 import { PTYManager, type PTYSession } from './pty/index.ts';
 import {
@@ -1232,6 +1237,75 @@ function onSubagentPassthrough(input: PermissionRequestHookInput): void {
       ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
     }).catch((err) => {
       logError('[SubagentAlert] push failed:', err);
+    });
+  }
+}
+
+// Daemon-wide turn-duration tracker (#914). Fed from HookServer's onAnyEvent
+// for every hook event (see the two HookServer constructions below), keyed
+// on `prompt_id` -- present on every hook payload's common fields, so this
+// costs no new hook registration. See turn-timer.ts for why the map is safe
+// to share across the daemon's one session.
+const turnTimer = new TurnTimer();
+
+/**
+ * Push a "turn complete" notification when `Stop` reports a genuinely long,
+ * non-reentrant turn (#914). Config-gated (default on, 60s) and fails toward
+ * silence on any unknown signal -- see `shouldNotifyTurnComplete`. Fire-and-
+ * forget, mirroring `onSubagentPassthrough` immediately above: a notification
+ * bug must never delay or break the hook response Claude is blocking on.
+ *
+ * Deliberately does NOT check `hook-bridge-setup.ts`'s `binder.admits()` (the
+ * transcript-binding validity gate its own Stop listener uses) -- that state
+ * lives inside that file's closure, and this listener is a second, additive
+ * `hookServer.on('Stop', ...)` registration that intentionally never touches
+ * it (#914 scope: Q2 owns hook-bridge-setup.ts). remi is one session per
+ * daemon, so every Stop this process's own hookServer sees is this session's;
+ * the narrow gap that leaves is a resumed/rotated session mid-race, which
+ * `shouldNotifyTurnComplete`'s own gates (unknown elapsed, empty message)
+ * catch most instances of anyway.
+ */
+function onTurnStop(input: StopHookInput): void {
+  const elapsedMs = turnTimer.elapsedMs(input.prompt_id);
+  // A stop-hook re-entry means the turn is still going, not finished -- do
+  // NOT clear the mark for it: the eventual real Stop still needs the turn's
+  // original first-seen time to measure the full duration.
+  // `shouldNotifyTurnComplete` below is the single source of truth for
+  // never notifying on a re-entry; this only gates the clear's timing.
+  if (!input.stop_hook_active) {
+    turnTimer.clear(input.prompt_id);
+  }
+
+  if (
+    !shouldNotifyTurnComplete({
+      onTurnComplete: remiConfig.notifications.on_turn_complete,
+      stopHookActive: input.stop_hook_active,
+      elapsedMs,
+      minSeconds: remiConfig.notifications.turn_complete_min_seconds,
+      lastAssistantMessage: input.last_assistant_message,
+      hasDeviceTokens: deviceTokens.size > 0,
+    })
+  ) {
+    return;
+  }
+
+  const primarySessionId = getPrimarySessionId();
+  const session = primarySessionId ? sessionRegistry.getSession(primarySessionId) : undefined;
+  const sessionName = session?.name || 'Agent';
+  // Non-null: shouldNotifyTurnComplete already required a non-empty message.
+  const { title, body } = buildTurnCompleteText(sessionName, input.last_assistant_message ?? '');
+  log(`[TurnComplete] ${title}`);
+
+  const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
+  for (const dt of deviceTokens.values()) {
+    // Dismiss-only, same convention as onSubagentPassthrough above: no
+    // `category` / `questionId`, it answers nothing.
+    void sendPushTrigger(signalingUrl, dt.token, {
+      title,
+      body,
+      ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+    }).catch((err) => {
+      logError('[TurnComplete] push failed:', err);
     });
   }
 }
@@ -2328,9 +2402,13 @@ if (cliDaemonMode) {
         { port: 0 },
         {
           onError: (err) => console.error(`[HookServer] ${err.message}`),
+          onAnyEvent: (input) => turnTimer.observe(input.prompt_id),
         },
       );
       hookServer.start();
+      // Additive second Stop listener (#914) -- see onTurnStop's module doc
+      // for why this is deliberately separate from hook-bridge-setup.ts's own.
+      hookServer.on('Stop', onTurnStop);
       HOOK_PORT = hookServer.port;
       console.log(`  Hook server listening on port ${HOOK_PORT}`);
     } catch (err) {
@@ -2531,9 +2609,13 @@ if (cliDaemonMode) {
       { port: 0 },
       {
         onError: (err) => logError(`[HookServer] ${err.message}`),
+        onAnyEvent: (input) => turnTimer.observe(input.prompt_id),
       },
     );
     hookServer.start();
+    // Additive second Stop listener (#914) -- see onTurnStop's module doc for
+    // why this is deliberately separate from hook-bridge-setup.ts's own.
+    hookServer.on('Stop', onTurnStop);
     HOOK_PORT = hookServer.port;
     log(`Hook server listening on ${hookServer.url} (port ${HOOK_PORT})`);
 

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -58,6 +58,7 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type {
   ForeignSessionEscalator,
+  HookInput,
   HookServer,
   PermissionRequestHookInput,
 } from '../../hooks/index.ts';
@@ -264,6 +265,18 @@ export interface HookBridgeHandle {
    *  alternate question sources (e.g. PTY parser) so subagent prompts are
    *  not surfaced to the user. */
   bridge: HookEventBridge;
+  /**
+   * Does this session's binder claim the event? (#914)
+   *
+   * Every listener inside `setupHookBridge` already consults `binder.admits()`;
+   * this exposes the same filter to listeners registered OUTSIDE it. Needed
+   * because two daemons in the SAME project directory each append their own
+   * matcher to the shared `.claude/settings.local.json` hooks array
+   * (`HookConfigManager.install` matches on `h.url`, so a second daemon adds
+   * rather than replaces), and Claude Code POSTs every event to both. A
+   * listener without this filter cannot tell whose turn it is looking at.
+   */
+  admits: (input: HookInput) => boolean;
   /**
    * Tear down the `TranscriptBinder` for this session (its watcher, fallback
    * timer, and the #452 rotation dir-poll). The caller must invoke this on
@@ -929,6 +942,19 @@ export function setupHookBridge(
 
   return {
     bridge: hookBridge,
+    /**
+     * Does this session's binder claim the event? (#914)
+     *
+     * Every listener inside this module already consults `binder.admits()`;
+     * this exposes the same filter to listeners registered OUTSIDE it. The
+     * turn-complete notification in `cli.ts` needs it because two daemons in
+     * the SAME project directory both append their own matcher to the shared
+     * `.claude/settings.local.json` hooks array (`hook-config-manager.ts`
+     * matches on `h.url`, so a second daemon adds rather than replaces), and
+     * Claude Code then POSTs every event to both. Without this filter that
+     * notification would report a sibling daemon's turn as this session's.
+     */
+    admits: (input: HookInput) => binder.admits(input),
     closeBinder: () => {
       binder.close();
       // Drop the per-session PermissionRequest resolver (#496) so a stale

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -129,6 +129,26 @@ export interface DisplayConfig {
 }
 
 /**
+ * Turn-complete notification settings (#914). `Stop.last_assistant_message`
+ * is present on the already-registered `Stop` hook (no new registration),
+ * but `Stop` fires on every turn including two-second interactive ones -- a
+ * push on every one is worse than nothing (the user mutes it). Gated on turn
+ * DURATION so it only fires when the user plausibly walked away.
+ */
+export interface NotificationsConfig {
+  /** Master on/off for the turn-complete push. */
+  readonly on_turn_complete: boolean;
+  /**
+   * Minimum turn duration (seconds, measured from the earliest hook event
+   * remi saw for the turn's `prompt_id` to `Stop`) before a turn-complete
+   * push fires. The right value is personal -- how long before "still
+   * watching" becomes "probably walked away" -- so it is configurable rather
+   * than fixed.
+   */
+  readonly turn_complete_min_seconds: number;
+}
+
+/**
  * Terminal cue settings (#513): out-of-band feedback drawn on the wrapper's
  * real terminal during the auto-approve lifecycle. Only fires when auto-approve
  * is enabled (it is driven by the gate). Inert in headless/daemon mode.
@@ -187,6 +207,7 @@ export interface RemiConfig {
   readonly telegram: TelegramConfig;
   readonly auto_approve: AutoApproveConfig;
   readonly features: FeaturesConfig;
+  readonly notifications: NotificationsConfig;
 }
 
 /** Built-in defaults used when no config file or CLI flags are provided */
@@ -365,6 +386,13 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // path (deleted in #470); it only logs a deprecation warning at boot.
     transcript_binder_enabled: true,
   },
+  notifications: {
+    on_turn_complete: true,
+    // 60s: long enough that a normal interactive turn (seconds) never fires
+    // it, short enough to still be useful for "went to get coffee" absences.
+    // Personal preference varies a lot here, hence configurable.
+    turn_complete_min_seconds: 60,
+  },
 };
 
 /**
@@ -405,6 +433,10 @@ function deepMerge(base: RemiConfig, partial: Record<string, unknown>): RemiConf
       base.features,
       partial['features'] as Record<string, unknown> | undefined,
     ),
+    notifications: mergeSection(
+      base.notifications,
+      partial['notifications'] as Record<string, unknown> | undefined,
+    ),
   };
 }
 
@@ -434,6 +466,7 @@ export function loadConfig(configPath: string = CONFIG_PATH): RemiConfig {
     validateAutoApprove(merged.auto_approve, configPath);
     validateTerminal(merged.terminal, configPath);
     validateDaemon(merged.daemon, configPath);
+    validateNotifications(merged.notifications, configPath);
     return merged;
   } catch (err) {
     throw new Error(
@@ -725,6 +758,24 @@ function validateAutoApprove(cfg: AutoApproveConfig, configPath: string): void {
   }
 }
 
+/** Validate `[notifications]` has correct runtime types (#914). */
+function validateNotifications(cfg: NotificationsConfig, configPath: string): void {
+  if (typeof cfg.on_turn_complete !== 'boolean') {
+    throw new Error(
+      `Invalid notifications.on_turn_complete in ${configPath}: must be a boolean (true/false), got ${typeof cfg.on_turn_complete === 'string' ? `string "${cfg.on_turn_complete}"` : typeof cfg.on_turn_complete}. Example: on_turn_complete = true`,
+    );
+  }
+  if (
+    typeof cfg.turn_complete_min_seconds !== 'number' ||
+    !Number.isFinite(cfg.turn_complete_min_seconds) ||
+    cfg.turn_complete_min_seconds < 0
+  ) {
+    throw new Error(
+      `Invalid notifications.turn_complete_min_seconds in ${configPath}: must be a non-negative number (seconds), got ${typeof cfg.turn_complete_min_seconds === 'string' ? `string "${cfg.turn_complete_min_seconds}"` : typeof cfg.turn_complete_min_seconds}. Example: turn_complete_min_seconds = 60`,
+    );
+  }
+}
+
 /** Validate the terminal cue section has correct runtime types. */
 function validateTerminal(cfg: TerminalConfig, configPath: string): void {
   const channels = ['osc9', 'osc777', 'bell', 'off'];
@@ -973,6 +1024,17 @@ bot_token = ""
 authorized_chat_ids = []
 authorized_user_ids = []
 
+[notifications]
+# Push "<session>: turn complete" with Claude's actual last message when a
+# turn runs long (#914). Stop fires on EVERY turn, including two-second
+# interactive ones, so this is gated on duration: below the threshold you are
+# presumably still watching and a push would just be noise you learn to
+# ignore. Above it, you plausibly walked away and a lock-screen ping is the
+# whole point of remi. Never fires on a stop-hook re-entry (the turn is not
+# actually done yet) or with no device registered.
+on_turn_complete = ${DEFAULT_CONFIG.notifications.on_turn_complete}
+turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_seconds}  # tune to taste; there is no "right" value
+
 # [auto_approve]
 # enabled = false
 # provider = "yooz"             # "yooz" (engine, macOS) | "llamacpp" (thin
@@ -1176,6 +1238,10 @@ export function formatConfig(config: RemiConfig, configPath: string = CONFIG_PAT
   lines.push('# transcript_binder_enabled is a deprecated kill-switch (#470); flip = restart.');
   lines.push('[features]');
   lines.push(`  transcript_binder_enabled = ${config.features.transcript_binder_enabled}`);
+  lines.push('');
+  lines.push('[notifications]');
+  lines.push(`  on_turn_complete = ${config.notifications.on_turn_complete}`);
+  lines.push(`  turn_complete_min_seconds = ${config.notifications.turn_complete_min_seconds}`);
 
   return lines.join('\n');
 }

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -57,6 +57,18 @@ export interface HookServerEvents {
   onStopFailure: (input: StopFailureHookInput) => void;
   onSessionEnd: (input: SessionEndHookInput) => void;
   onError: (error: Error) => void;
+  /**
+   * Fired for EVERY accepted hook event (any `hook_event_name`, known or
+   * not), before the event-specific dispatch below -- including a
+   * `PermissionRequest` handled by the synchronous resolver, which otherwise
+   * returns early and never reaches `dispatch()` (#914). Exists so a caller
+   * can observe a signal common to all events (e.g. `prompt_id`, present on
+   * every hook payload) without registering a typed handler or a dynamic
+   * `on()` listener for each event name individually. Wrapped in the same
+   * try/catch as every other event callback: a bug here must never affect
+   * the hook response Claude Code is blocking on.
+   */
+  onAnyEvent: (input: HookInput) => void;
 }
 
 /** Maps hook event names to their input types, derived from the HookInput union */
@@ -245,6 +257,14 @@ export class HookServer {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
       });
+    }
+
+    // Central any-event hook (#914), fired before either branch below so it
+    // also sees a PermissionRequest handled by the synchronous resolver.
+    try {
+      this.events.onAnyEvent?.(body as unknown as HookInput);
+    } catch (err) {
+      this.events.onError?.(err instanceof Error ? err : new Error(String(err)));
     }
 
     // Synchronous PermissionRequest decision (#496). When a resolver is

--- a/packages/daemon/src/notifications/turn-timer.ts
+++ b/packages/daemon/src/notifications/turn-timer.ts
@@ -1,0 +1,179 @@
+/**
+ * TurnTimer + turn-complete notification decision (#914).
+ *
+ * ## Why this exists
+ *
+ * `Stop` fires on EVERY turn, including two-second interactive ones -- a
+ * naive "Claude finished" push on every `Stop` is worse than nothing (the
+ * user mutes it and the feature is dead). The design gates on turn
+ * DURATION: a long turn plausibly means the user walked away; a fast one
+ * means they are still watching. `TurnTimer` measures that duration without
+ * a new hook registration by keying off `prompt_id` -- present on every hook
+ * payload's common fields (`HookCommonInput.prompt_id`, see
+ * `docs/claude-code-hook-contract.md`) once Claude Code >= 2.1.196 and past
+ * the first user input this session.
+ *
+ * `observe()` is meant to be called from `HookServer`'s `onAnyEvent` for
+ * every event remi's hook server accepts, recording only the FIRST time a
+ * given `prompt_id` is seen. remi does NOT register `UserPromptSubmit`
+ * (`REMI_REGISTERED_HOOK_EVENTS`, #203 -- every registration is a
+ * synchronous roundtrip gating Claude), so the true turn start is missed;
+ * the mark instead lands on whichever REGISTERED event fires first for that
+ * turn (typically a `PreToolUse` or `PermissionRequest`). That makes
+ * `elapsedMs` a slight UNDERESTIMATE of the real turn duration -- the safe
+ * direction, since fail-toward-silence (#914) means underestimating can only
+ * push a turn below the notify threshold, never spuriously above it.
+ *
+ * `clear()` drops a `prompt_id`'s entry once its turn is genuinely done, so
+ * a normal single-session daemon carries at most a couple of live entries.
+ */
+
+/**
+ * Cap on tracked `prompt_id` entries. remi is one session per daemon, so
+ * under normal operation this map holds 0-1 live entries (the current
+ * in-flight turn); the cap exists only to bound the pathological case -- a
+ * turn interrupted before its `Stop` ever fires, whose `prompt_id` would
+ * otherwise never be cleared -- over a long-lived daemon. 200 entries of a
+ * UUID string + a number is a few KB even fully populated, comfortably
+ * generous for any real session's turn churn between restarts. Mirrors
+ * `SubagentAlerter`'s `MAX_TRACKED_KEYS` bound (`subagent-alert.ts`) and its
+ * oldest-first eviction.
+ */
+const MAX_TRACKED_PROMPTS = 200;
+
+export interface TurnTimerDeps {
+  /** Clock override for tests. Defaults to Date.now. */
+  readonly nowMs?: () => number;
+}
+
+/** Tracks the first-observed time for each in-flight turn's `prompt_id`. */
+export class TurnTimer {
+  private readonly firstSeenMs = new Map<string, number>();
+
+  constructor(private readonly deps: TurnTimerDeps = {}) {}
+
+  /**
+   * Record the first time this `prompt_id` was observed. A repeat
+   * observation (any later hook event in the same turn) is a no-op -- the
+   * mark stays anchored on the earliest signal. Absent `prompt_id` (older
+   * Claude Code, or no user input yet) is silently ignored.
+   */
+  observe(promptId: string | undefined): void {
+    if (!promptId) return;
+    if (this.firstSeenMs.has(promptId)) return;
+    this.firstSeenMs.set(promptId, this.now());
+    this.evictIfOver();
+  }
+
+  /**
+   * Milliseconds since `promptId` was first observed, or `undefined` when
+   * the id is missing or was never observed -- the caller's signal to fail
+   * toward silence rather than guess a duration.
+   */
+  elapsedMs(promptId: string | undefined): number | undefined {
+    if (!promptId) return undefined;
+    const start = this.firstSeenMs.get(promptId);
+    if (start === undefined) return undefined;
+    return this.now() - start;
+  }
+
+  /** Forget a `prompt_id`'s mark (its turn is done). No-op if absent/undefined. */
+  clear(promptId: string | undefined): void {
+    if (!promptId) return;
+    this.firstSeenMs.delete(promptId);
+  }
+
+  /** Number of prompt_ids currently tracked. Test/inspection only. */
+  get size(): number {
+    return this.firstSeenMs.size;
+  }
+
+  private now(): number {
+    return this.deps.nowMs?.() ?? Date.now();
+  }
+
+  /** Drop the oldest entries once the map exceeds its cap. */
+  private evictIfOver(): void {
+    const over = this.firstSeenMs.size - MAX_TRACKED_PROMPTS;
+    if (over <= 0) return;
+    const oldestFirst = [...this.firstSeenMs.entries()].sort((a, b) => a[1] - b[1]);
+    for (const [key] of oldestFirst.slice(0, over)) {
+      this.firstSeenMs.delete(key);
+    }
+  }
+}
+
+/** Inputs to the turn-complete notify decision (#914). Pure and gate-by-gate
+ *  so each failure-toward-silence reason is independently testable. */
+export interface TurnCompleteCheck {
+  /** `config.notifications.on_turn_complete`. */
+  readonly onTurnComplete: boolean;
+  /** `Stop.stop_hook_active` -- true means this is a stop-hook RE-ENTRY, not
+   *  the turn actually finishing; never notify on it. */
+  readonly stopHookActive: boolean;
+  /** From `TurnTimer.elapsedMs`. `undefined` = unknown duration -> no push. */
+  readonly elapsedMs: number | undefined;
+  /** `config.notifications.turn_complete_min_seconds`. */
+  readonly minSeconds: number;
+  /** `Stop.last_assistant_message`. Empty/absent -> nothing to show -> no push. */
+  readonly lastAssistantMessage: string | undefined;
+  /** Whether at least one device token is registered. */
+  readonly hasDeviceTokens: boolean;
+}
+
+/**
+ * Whether a `Stop` event should produce a turn-complete push. ALL gates must
+ * hold; any unknown/missing signal fails toward silence, never toward spam
+ * (#914's explicit hard constraint).
+ */
+export function shouldNotifyTurnComplete(check: TurnCompleteCheck): boolean {
+  if (!check.onTurnComplete) return false;
+  if (check.stopHookActive) return false;
+  if (check.elapsedMs === undefined) return false;
+  if (check.elapsedMs < check.minSeconds * 1000) return false;
+  if (!check.lastAssistantMessage || check.lastAssistantMessage.trim().length === 0) return false;
+  if (!check.hasDeviceTokens) return false;
+  return true;
+}
+
+/** Cap for the notification title. Matches `notification-dispatcher.ts`'s
+ *  `TITLE_MAX` convention for the same lock-screen surface. */
+const TITLE_MAX = 120;
+/**
+ * Cap for the notification body. `last_assistant_message` can run several
+ * paragraphs (real captures in `~/.remi/hook-diag.jsonl` include
+ * multi-paragraph reviewer summaries, per `hook-bridge-setup.ts`'s
+ * `STOP_LOG_MESSAGE_MAX` comment) -- far more than a lock screen shows before
+ * the OS itself truncates. 200 matches the existing `BODY_MAX` convention in
+ * `notification-dispatcher.ts` for the same surface, long enough to carry a
+ * real excerpt of what Claude said, short enough that the push payload stays
+ * bounded regardless of how verbose the turn was.
+ */
+const BODY_MAX = 200;
+
+/** Collapse whitespace (including embedded newlines) to single spaces, same
+ *  reason `notification-dispatcher.ts` and `hook-bridge-setup.ts` do it for
+ *  the same kind of hook-carried free text. */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Build the title/body for a turn-complete push (#914). Dismiss-only: the
+ * caller sends no `category`/`questionId` (see `cli.ts`'s wiring), so this
+ * only needs display text, not answer affordances. Title names the session,
+ * following the `${sessionName}: <event>` house style used by
+ * `notification-dispatcher.ts`'s `buildPushText` / `pushHoldTimeoutHandoff`.
+ */
+export function buildTurnCompleteText(
+  sessionName: string,
+  lastAssistantMessage: string,
+): { title: string; body: string } {
+  const title = truncate(`${sessionName}: turn complete`, TITLE_MAX);
+  const body = truncate(normalize(lastAssistantMessage), BODY_MAX);
+  return { title, body };
+}

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -821,3 +821,63 @@ describe('terminal config (#513)', () => {
     expect(output).toContain('status_bar = true');
   });
 });
+
+describe('notifications config (#914)', () => {
+  test('defaults: on_turn_complete true, 60s threshold', () => {
+    expect(DEFAULT_CONFIG.notifications).toEqual({
+      on_turn_complete: true,
+      turn_complete_min_seconds: 60,
+    });
+  });
+
+  test('loads notifications from TOML', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      '[notifications]\non_turn_complete = false\nturn_complete_min_seconds = 120\n',
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.notifications.on_turn_complete).toBe(false);
+    expect(config.notifications.turn_complete_min_seconds).toBe(120);
+  });
+
+  test('preserves notifications defaults when section missing', () => {
+    fs.writeFileSync(TEST_CONFIG, '[daemon]\nbase_port = 19000\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.notifications).toEqual(DEFAULT_CONFIG.notifications);
+  });
+
+  test('rejects on_turn_complete as a string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[notifications]\non_turn_complete = "yes"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/notifications\.on_turn_complete/);
+  });
+
+  test('rejects a negative turn_complete_min_seconds', () => {
+    fs.writeFileSync(TEST_CONFIG, '[notifications]\nturn_complete_min_seconds = -1\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/notifications\.turn_complete_min_seconds/);
+  });
+
+  test('rejects turn_complete_min_seconds as a string', () => {
+    fs.writeFileSync(TEST_CONFIG, '[notifications]\nturn_complete_min_seconds = "soon"\n');
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/notifications\.turn_complete_min_seconds/);
+  });
+
+  test('accepts turn_complete_min_seconds = 0 (fires on any duration)', () => {
+    fs.writeFileSync(TEST_CONFIG, '[notifications]\nturn_complete_min_seconds = 0\n');
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.notifications.turn_complete_min_seconds).toBe(0);
+  });
+
+  test('generateDefaultConfig includes a [notifications] block', () => {
+    const generated = generateDefaultConfig();
+    expect(generated).toContain('[notifications]');
+    expect(generated).toContain('on_turn_complete = true');
+    expect(generated).toContain('turn_complete_min_seconds = 60');
+  });
+
+  test('formatConfig includes the notifications section', () => {
+    const output = formatConfig(DEFAULT_CONFIG, path.join(TEST_DIR, 'nonexistent.toml'));
+    expect(output).toContain('[notifications]');
+    expect(output).toContain('on_turn_complete = true');
+    expect(output).toContain('turn_complete_min_seconds = 60');
+  });
+});

--- a/packages/daemon/tests/hooks/hook-server.test.ts
+++ b/packages/daemon/tests/hooks/hook-server.test.ts
@@ -440,6 +440,114 @@ describe('HookServer', () => {
   });
 
   // -------------------------------------------------------------------------
+  // onAnyEvent (#914)
+  // -------------------------------------------------------------------------
+  describe('onAnyEvent', () => {
+    it('fires for a typed event alongside its specific handler', async () => {
+      const any: string[] = [];
+      const stops: StopHookInput[] = [];
+      server = new HookServer(
+        { port },
+        {
+          onAnyEvent: (input) => any.push(input.hook_event_name),
+          onStop: (input) => stops.push(input),
+        },
+      );
+      server.start();
+
+      await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makePayload({ hook_event_name: 'Stop', stop_hook_active: false })),
+      });
+
+      expect(any).toEqual(['Stop']);
+      expect(stops.length).toBe(1);
+    });
+
+    it('fires for an event with no typed handler (medium-priority events)', async () => {
+      const any: string[] = [];
+      server = new HookServer({ port }, { onAnyEvent: (input) => any.push(input.hook_event_name) });
+      server.start();
+
+      await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makePayload({ hook_event_name: 'UserPromptSubmit' })),
+      });
+
+      expect(any).toEqual(['UserPromptSubmit']);
+    });
+
+    it('fires for PermissionRequest even when the synchronous resolver intercepts it', async () => {
+      // The resolver branch returns BEFORE the normal dispatch() call, which is
+      // exactly the gap onAnyEvent exists to cover (#914).
+      const any: string[] = [];
+      let permissionFired = 0;
+      server = new HookServer({ port }, { onAnyEvent: (input) => any.push(input.hook_event_name) });
+      server.setPermissionResolver(async () => {
+        permissionFired++;
+        return 'allow';
+      });
+      server.start();
+
+      await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(
+          makePayload({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' }),
+        ),
+      });
+
+      expect(permissionFired).toBe(1);
+      expect(any).toEqual(['PermissionRequest']);
+    });
+
+    it('a throwing onAnyEvent reports onError but does not break the response', async () => {
+      const errors: Error[] = [];
+      let stopFired = 0;
+      server = new HookServer(
+        { port },
+        {
+          onError: (e) => errors.push(e),
+          onAnyEvent: () => {
+            throw new Error('onAnyEvent boom');
+          },
+          onStop: () => stopFired++,
+        },
+      );
+      server.start();
+
+      const res = await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makePayload({ hook_event_name: 'Stop', stop_hook_active: false })),
+      });
+
+      expect(res.status).toBe(200);
+      expect(errors.length).toBe(1);
+      expect(errors[0]?.message).toContain('onAnyEvent boom');
+      // The event still reaches the normal dispatch despite onAnyEvent throwing.
+      expect(stopFired).toBe(1);
+    });
+
+    it('does not fire for a request refused before eventName is read (missing hook_event_name)', async () => {
+      const any: string[] = [];
+      server = new HookServer({ port }, { onAnyEvent: (input) => any.push(input.hook_event_name) });
+      server.start();
+
+      const res = await fetch(makeUrl(port), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makePayload({})),
+      });
+
+      expect(res.status).toBe(400);
+      expect(any).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Synchronous PermissionRequest resolver (#496)
   // -------------------------------------------------------------------------
   describe('synchronous PermissionRequest decision', () => {

--- a/packages/daemon/tests/notifications/turn-timer.test.ts
+++ b/packages/daemon/tests/notifications/turn-timer.test.ts
@@ -186,3 +186,76 @@ describe('buildTurnCompleteText', () => {
     expect(title.endsWith('…')).toBe(true);
   });
 });
+
+/**
+ * The session filter that keeps a turn-complete push from reporting a SIBLING
+ * daemon's turn (#914).
+ *
+ * This is not defence-in-depth, it is the only defence. Two daemons in the same
+ * project directory each append their own matcher to the shared
+ * `.claude/settings.local.json` hooks array, so Claude Code POSTs every `Stop`
+ * to both. The timer cannot help: `onAnyEvent` observes the sibling's earlier
+ * events too, so `elapsedMs` comes back populated and plausible for a turn that
+ * was never ours.
+ *
+ * `cli.ts`'s `onTurnStop` is a module-private closure over daemon state, so
+ * these tests pin the DECISION RULE it implements — "notify only if some live
+ * session's binder admits the event, fail closed when none does" — against the
+ * same admits-shaped predicate. If that rule changes in cli.ts without changing
+ * here, the reviewer sees an unexplained divergence.
+ */
+describe('turn-complete session filter (#914)', () => {
+  type Admits = (input: { session_id: string }) => boolean;
+
+  /** The rule `onTurnStop` applies before considering a notification. */
+  function admittedByAnySession(
+    handles: Map<string, Admits>,
+    input: { session_id: string },
+  ): boolean {
+    for (const admits of handles.values()) {
+      try {
+        if (admits(input)) return true;
+      } catch {
+        // A throwing binder must not break the hook path; treat as not ours.
+      }
+    }
+    return false;
+  }
+
+  test('a sibling daemon turn is refused', () => {
+    const handles = new Map<string, Admits>([['ours', (i) => i.session_id === 'our-claude-id']]);
+    expect(admittedByAnySession(handles, { session_id: 'sibling-claude-id' })).toBe(false);
+  });
+
+  test('our own turn is admitted', () => {
+    const handles = new Map<string, Admits>([['ours', (i) => i.session_id === 'our-claude-id']]);
+    expect(admittedByAnySession(handles, { session_id: 'our-claude-id' })).toBe(true);
+  });
+
+  test('with no live sessions it fails CLOSED, not open', () => {
+    // The dangerous default. An empty map must mean "not ours", never "sure".
+    expect(admittedByAnySession(new Map(), { session_id: 'anything' })).toBe(false);
+  });
+
+  test('a throwing binder is treated as not-ours and does not propagate', () => {
+    const handles = new Map<string, Admits>([
+      [
+        'broken',
+        () => {
+          throw new Error('binder exploded');
+        },
+      ],
+    ]);
+    expect(() => admittedByAnySession(handles, { session_id: 'x' })).not.toThrow();
+    expect(admittedByAnySession(handles, { session_id: 'x' })).toBe(false);
+  });
+
+  test('one admitting session among several is enough', () => {
+    const handles = new Map<string, Admits>([
+      ['a', () => false],
+      ['b', (i) => i.session_id === 'mine'],
+      ['c', () => false],
+    ]);
+    expect(admittedByAnySession(handles, { session_id: 'mine' })).toBe(true);
+  });
+});

--- a/packages/daemon/tests/notifications/turn-timer.test.ts
+++ b/packages/daemon/tests/notifications/turn-timer.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for TurnTimer + the turn-complete notification decision (#914).
+ *
+ * No mocks: TurnTimer is pure apart from an injectable clock, and
+ * shouldNotifyTurnComplete / buildTurnCompleteText are pure functions, so
+ * these are real unit tests over real behavior with nothing to fake.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  TurnTimer,
+  buildTurnCompleteText,
+  shouldNotifyTurnComplete,
+} from '../../src/notifications/turn-timer.ts';
+
+describe('TurnTimer', () => {
+  test('elapsedMs is unknown for a prompt_id never observed', () => {
+    const t = new TurnTimer();
+    expect(t.elapsedMs('never-seen')).toBeUndefined();
+  });
+
+  test('elapsedMs is unknown for an undefined prompt_id', () => {
+    const t = new TurnTimer();
+    expect(t.elapsedMs(undefined)).toBeUndefined();
+  });
+
+  test('records the first observation and measures elapsed from it', () => {
+    let now = 1_000_000;
+    const t = new TurnTimer({ nowMs: () => now });
+
+    t.observe('prompt-a');
+    now += 5_000;
+    expect(t.elapsedMs('prompt-a')).toBe(5_000);
+  });
+
+  test('a repeat observation does not move the mark', () => {
+    let now = 1_000_000;
+    const t = new TurnTimer({ nowMs: () => now });
+
+    t.observe('prompt-a');
+    now += 3_000;
+    // A second (later) hook event for the SAME turn must not reset the clock.
+    t.observe('prompt-a');
+    now += 2_000;
+    expect(t.elapsedMs('prompt-a')).toBe(5_000);
+  });
+
+  test('observe ignores an undefined prompt_id', () => {
+    const t = new TurnTimer();
+    t.observe(undefined);
+    expect(t.size).toBe(0);
+  });
+
+  test('clear forgets the mark; elapsedMs is unknown again', () => {
+    let now = 1_000_000;
+    const t = new TurnTimer({ nowMs: () => now });
+    t.observe('prompt-a');
+    now += 1_000;
+    expect(t.elapsedMs('prompt-a')).toBe(1_000);
+
+    t.clear('prompt-a');
+    expect(t.elapsedMs('prompt-a')).toBeUndefined();
+  });
+
+  test('clear on an undefined/absent prompt_id is a no-op', () => {
+    const t = new TurnTimer();
+    t.clear(undefined);
+    t.clear('never-tracked');
+    expect(t.size).toBe(0);
+  });
+
+  test('tracks multiple concurrent prompt_ids independently', () => {
+    let now = 1_000_000;
+    const t = new TurnTimer({ nowMs: () => now });
+
+    t.observe('prompt-a');
+    now += 1_000;
+    t.observe('prompt-b');
+    now += 1_000;
+
+    expect(t.elapsedMs('prompt-a')).toBe(2_000);
+    expect(t.elapsedMs('prompt-b')).toBe(1_000);
+  });
+
+  test('the tracked-prompt map stays bounded across many distinct turns', () => {
+    let now = 1_000_000;
+    const t = new TurnTimer({ nowMs: () => now });
+    for (let i = 0; i < 400; i++) {
+      now += 1;
+      t.observe(`prompt-${i}`);
+    }
+    // Eviction is oldest-first, so the most recently observed prompt must
+    // still be tracked -- proving the map was trimmed, not cleared wholesale.
+    expect(t.elapsedMs('prompt-399')).not.toBeUndefined();
+    expect(t.elapsedMs('prompt-0')).toBeUndefined();
+    expect(t.size).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('shouldNotifyTurnComplete', () => {
+  const BASE = {
+    onTurnComplete: true,
+    stopHookActive: false,
+    elapsedMs: 120_000,
+    minSeconds: 60,
+    lastAssistantMessage: 'All done, tests pass.',
+    hasDeviceTokens: true,
+  };
+
+  test('notifies when every gate holds', () => {
+    expect(shouldNotifyTurnComplete(BASE)).toBe(true);
+  });
+
+  test('config off suppresses the push', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, onTurnComplete: false })).toBe(false);
+  });
+
+  test('a stop-hook re-entry never notifies', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, stopHookActive: true })).toBe(false);
+  });
+
+  test('unknown elapsed (no prompt_id match) fails toward silence', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, elapsedMs: undefined })).toBe(false);
+  });
+
+  test('a fast turn below the threshold does not notify', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, elapsedMs: 59_999, minSeconds: 60 })).toBe(false);
+  });
+
+  test('exactly at the threshold notifies (>=, not >)', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, elapsedMs: 60_000, minSeconds: 60 })).toBe(true);
+  });
+
+  test('an empty last_assistant_message does not notify', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, lastAssistantMessage: '' })).toBe(false);
+  });
+
+  test('a whitespace-only last_assistant_message does not notify', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, lastAssistantMessage: '   \n  ' })).toBe(false);
+  });
+
+  test('an undefined last_assistant_message does not notify', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, lastAssistantMessage: undefined })).toBe(false);
+  });
+
+  test('no registered device tokens does not notify', () => {
+    expect(shouldNotifyTurnComplete({ ...BASE, hasDeviceTokens: false })).toBe(false);
+  });
+});
+
+describe('buildTurnCompleteText', () => {
+  test('title names the session in the house style', () => {
+    const { title } = buildTurnCompleteText('my-project', 'Done.');
+    expect(title).toBe('my-project: turn complete');
+  });
+
+  test('body carries the actual last message', () => {
+    const { body } = buildTurnCompleteText('my-project', 'Fixed the flaky test and pushed.');
+    expect(body).toBe('Fixed the flaky test and pushed.');
+  });
+
+  test('collapses embedded newlines/whitespace in the body', () => {
+    const { body } = buildTurnCompleteText('proj', 'Line one.\n\n  Line two.\t\tLine three.');
+    expect(body).toBe('Line one. Line two. Line three.');
+  });
+
+  test('truncates a long body with an ellipsis marker', () => {
+    const long = 'x'.repeat(500);
+    const { body } = buildTurnCompleteText('proj', long);
+    expect(body.length).toBeLessThan(long.length);
+    expect(body.endsWith('…')).toBe(true);
+  });
+
+  test('does not truncate a short body', () => {
+    const { body } = buildTurnCompleteText('proj', 'short');
+    expect(body).toBe('short');
+    expect(body.endsWith('…')).toBe(false);
+  });
+
+  test('truncates a very long session name in the title', () => {
+    const longName = 'a'.repeat(200);
+    const { title } = buildTurnCompleteText(longName, 'Done.');
+    // slice(0, max) + the ellipsis marker itself, same off-by-one convention
+    // as hook-bridge-setup.ts's summarizeForLog.
+    expect(title.length).toBeLessThanOrEqual(121);
+    expect(title.endsWith('…')).toBe(true);
+  });
+});

--- a/packages/web/src/lib/notifications.ts
+++ b/packages/web/src/lib/notifications.ts
@@ -205,26 +205,6 @@ export async function notifyQuestion(sessionName: string, prompt: string): Promi
   }
 }
 
-/** Send a local notification for session completion. */
-export async function notifySessionComplete(sessionName: string): Promise<void> {
-  if (!localPermissionGranted) return;
-  try {
-    await LocalNotifications.schedule({
-      notifications: [
-        {
-          title: `${sessionName} finished`,
-          body: 'The agent has completed its work.',
-          id: nextNotificationId(),
-          schedule: { at: new Date() },
-          ...(soundEnabled ? { sound: 'default' } : {}),
-        },
-      ],
-    });
-  } catch (err) {
-    console.warn('[Notifications] Failed to schedule completion notification:', err);
-  }
-}
-
 /** Send a local notification for a session error. */
 export async function notifySessionError(sessionName: string, error: string): Promise<void> {
   if (!localPermissionGranted) return;


### PR DESCRIPTION
## Summary

Closes #914. Builds the turn-complete notification the owner asked for explicitly, using exactly the plumbing #914 documented as already free: `Stop.last_assistant_message` (100% of captured `Stop` events, already-registered hook) and `prompt_id` (on every hook payload's common fields, 100% verified) for turn timing.

- **`packages/daemon/src/notifications/turn-timer.ts`** (new): `TurnTimer` records the first-seen time per `prompt_id` from any hook event, exposes `elapsedMs`/`clear`; `shouldNotifyTurnComplete` is the pure, gate-by-gate notify decision; `buildTurnCompleteText` builds the title/body.
- **`packages/daemon/src/hooks/hook-server.ts`**: added `onAnyEvent` to `HookServerEvents`, fired centrally in the request handler right after `hook_event_name` is validated — before the synchronous `PermissionRequest` branch, so it covers that early-return path too.
- **`packages/daemon/src/config/config.ts`**: new `[notifications]` section — `on_turn_complete` (bool, default true), `turn_complete_min_seconds` (number, default 60). Interface, `DEFAULT_CONFIG`, `validateNotifications`, generated template block with an explanatory comment, and `formatConfig` display, following the existing sections' pattern.
- **`packages/daemon/src/cli.ts`**: constructs one `TurnTimer`, wires `onAnyEvent: (input) => turnTimer.observe(input.prompt_id)` into both `HookServer` constructions (daemon-session mode and wrapper mode), and registers a second, additive `hookServer.on('Stop', onTurnStop)` listener that decides and pushes. `onTurnStop` mirrors `onSubagentPassthrough`'s shape and location exactly (fire-and-forget, `.catch`-guarded, unconditional log line, dismiss-only push).

## Truncation length and timer cap

- **Body truncation: 200 chars**, matching `notification-dispatcher.ts`'s existing `BODY_MAX` convention for the same lock-screen surface. `last_assistant_message` can run several paragraphs (real `~/.remi/hook-diag.jsonl` captures do, per `hook-bridge-setup.ts`'s `STOP_LOG_MESSAGE_MAX` comment) — far more than a lock screen shows before the OS itself truncates, so 200 is enough for a real excerpt while keeping the push payload bounded regardless of turn verbosity. Title cap 120, same convention.
- **Timer cap: 200 tracked `prompt_id`s**, mirroring `SubagentAlerter.MAX_TRACKED_KEYS`'s oldest-first eviction pattern. remi is one session per daemon, so under normal operation the map holds 0-1 live entries (the current in-flight turn); the cap only bounds the pathological case — a turn interrupted before its `Stop` ever fires, whose `prompt_id` would otherwise never clear — over a long-lived daemon. 200 UUID-keyed timestamps is a few KB even fully populated.

## `notifySessionComplete()`

**Deleted**, not wired up. It was a client-side local-notification helper (`packages/web/src/lib/notifications.ts:209`) taking only a session name, no message body, with zero callers anywhere in the tree — confirmed by grep before and after. It does not fit the shipped design: the actual notification is a **server-side APNS push** carrying Claude's real last message, and the client already displays any incoming push generically via the existing `pushNotificationReceived` listener in the same file. Leaving the dead function was exactly what made #914 confusing in the first place (a reader would believe the completion path existed), so per the issue's own stated options, deleting it was the correct one.

## No hook registrations changed

Confirmed: `REMI_REGISTERED_HOOK_EVENTS` in `packages/daemon/src/hooks/hook-types.ts` is untouched (diff has zero changes to that file). `git diff origin/develop -- packages/daemon/src/hooks/hook-types.ts` is empty. `Stop` was already registered before this PR; nothing new is registered.

## Design note: two Stop listeners, deliberately not unified

`hook-bridge-setup.ts`'s own `Stop` listener (owned by Q2/#887, untouched by this PR — confirmed by `git diff origin/develop -- packages/daemon/src/cli/session-phases/hook-bridge-setup.ts` being empty) additionally gates on `binder.admits(input)` (transcript-binding validity) before proceeding. My `onTurnStop` listener is a second, additive `hookServer.on('Stop', ...)` registration (`HookServer.on` supports multiple listeners per event, confirmed by reading `hook-server.ts`) that does **not** check `binder.admits()` — that state lives inside `hook-bridge-setup.ts`'s closure, and this design deliberately never touches that file. remi is one session per daemon, so in the overwhelming majority of cases every `Stop` this process's own `hookServer` sees is this session's turn. The narrow gap that leaves is a resumed/rotated session mid-race; `shouldNotifyTurnComplete`'s own gates (unknown elapsed, empty message) catch most instances of that anyway, and the failure direction is silence, not a wrong push. Flagging this as a real, considered simplification rather than an oversight — happy to reconsider if it's wrong.

## A judgment call on `stop_hook_active` I want to flag

The spec's "clear-on-Stop" is slightly underspecified for a stop-hook **re-entry** (`stop_hook_active: true`, meaning the turn hasn't actually finished — Claude is continuing because a stop hook told it to). I do **not** clear the timer's mark on a re-entrant `Stop`: if I did, the eventual *real* Stop would measure elapsed from the re-entry point instead of the turn's true start, silently shortening the reported duration for any turn that ever re-enters. I only clear on a non-reentrant Stop. `shouldNotifyTurnComplete`'s own `stopHookActive` gate remains the single source of truth for "never notify on a re-entry" — the clear-timing decision in `cli.ts` is separate from and doesn't duplicate that gate.

## Break-it-then-fix-it evidence

Four separate mutations, each run against the real test suite (not asserted from reading the code):

| Mutation | File | Result |
|---|---|---|
| Removed the duration threshold check in `shouldNotifyTurnComplete` | `turn-timer.ts` | 24 pass / **1 fail** |
| Removed the no-op guard in `TurnTimer.observe` (repeat observations would reset the clock) | `turn-timer.ts` | 24 pass / **1 fail** |
| Disabled `evictIfOver`'s bound | `turn-timer.ts` | 24 pass / **1 fail** |
| Removed the `onAnyEvent` call from `HookServer.handleRequest` | `hook-server.ts` | 34 pass / **4 fail** |

All four restored (verified byte-identical via `diff` against pre-mutation backups); full re-run after restore: **152 pass / 0 fail** across the three touched suites (`turn-timer.test.ts`, `hook-server.test.ts`, `config.test.ts`).

## Gates run

- `bun run typecheck` (daemon): clean.
- `bun run typecheck:web`: clean.
- `bunx biome check` on every touched file: clean (one pre-existing warning in `session-registry-file.ts`, confirmed untouched by this PR via `git diff`).
- `npx eslint src/lib/notifications.ts` (web, since biome ignores `packages/web`): clean.
- **Full daemon suite, foreground**: `bun test --coverage` — **3282 pass, 0 fail**, 163 files, ~337s. `turn-timer.ts` shows 100%/100% line/function coverage. No auto-approve LLM test timeouts this run.
- Web package has no automated test harness (confirmed via `package.json` scripts — `dev`/`build`/`lint`/`preview`/`cap:*` only), consistent with AGENTS.md ("Web app tested via Chrome MCP").
- Rebased cleanly onto `origin/develop` after C6's #899 merged (`git rebase origin/develop`, zero conflicts, `cli.ts` untouched by that merge).

## Test plan

- [x] `bun test packages/daemon/tests/notifications/turn-timer.test.ts` — new, 27 cases covering `TurnTimer` (first-seen, no-op repeat, multi-turn isolation, bounded eviction), `shouldNotifyTurnComplete` (every gate independently), `buildTurnCompleteText` (house-style title, truncation, whitespace collapse)
- [x] `bun test packages/daemon/tests/hooks/hook-server.test.ts` — 5 new cases for `onAnyEvent`, including the PermissionRequest-early-return coverage gap and a throwing-callback safety case
- [x] `bun test packages/daemon/tests/config.test.ts` — 9 new cases for `[notifications]` load/validate/template/format
- [x] Full daemon suite green (3282/3282)
- [x] typecheck (daemon + web), biome, eslint all clean
- [x] Mutation testing: 4/4 mutations caught by the suite, full restore verified