### PR TITLE
Exclude generated trees from biome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,12 @@ playwright-report/
 # epic-dev local state (never committed)
 .claude/*.local.md
 
+# Agent worktrees: full checkouts of in-progress branches. Never committed. The
+# whole of `.claude` is also excluded from biome (biome.json) -- otherwise
+# `biome check .` lints every running agent's working tree and reports their
+# in-flight code as this tree's errors, and formats local settings files.
+.claude/worktrees/
+
 # macOS app (packages/macos): staged web bundle + Xcode build artifacts
 packages/macos/Remi/Resources/web/*
 !packages/macos/Remi/Resources/web/.gitkeep

--- a/biome.json
+++ b/biome.json
@@ -44,6 +44,17 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".git", "*.md", "packages/web", "packages/daemon/scripts"]
+    "ignore": [
+      "node_modules",
+      "dist",
+      ".git",
+      "*.md",
+      "packages/web",
+      "packages/daemon/scripts",
+      "packages/macos/Remi/Resources/web",
+      "packages/macos/DerivedData",
+      ".claude",
+      "build"
+    ]
   }
 }

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -444,8 +444,15 @@ describe('relayAnswerViaSignaling (#591)', () => {
         const result = await relayAnswerViaSignaling({
           signalingUrl: `http://127.0.0.1:${server.port}`,
           code: 'WXYZ-2345',
-          sessionId: 's1',
-          questionId: 'q1',
+          // Hyphenated UUIDs, NOT short tokens. The assertions below check the
+          // base64 envelope does not CONTAIN these. Base64's alphabet includes
+          // s, q and 1, so 's1'/'q1' appear in a ~250-char random envelope
+          // roughly 6% of the time each -- this test failed on unrelated PRs at
+          // about that rate. '-' is outside the base64 alphabet, so a
+          // hyphenated UUID can never occur by chance. `shared/tests/
+          // sealed-answer.test.ts` already used full UUIDs for this reason.
+          sessionId: '0199f3a1-0000-7000-8000-000000000001',
+          questionId: '0199f3a1-0000-7000-8000-000000000002',
           answer: 'Yes, deploy',
           authRequired: false,
           answerEncryptionKey: daemon.publicKeyBase64,
@@ -456,8 +463,8 @@ describe('relayAnswerViaSignaling (#591)', () => {
         const body = received as unknown as Record<string, unknown>;
         const wire = JSON.stringify(body);
         expect(wire).not.toContain('Yes, deploy');
-        expect(wire).not.toContain('s1');
-        expect(wire).not.toContain('q1');
+        expect(wire).not.toContain('0199f3a1-0000-7000-8000-000000000001');
+        expect(wire).not.toContain('0199f3a1-0000-7000-8000-000000000002');
         expect(typeof body['sealed']).toBe('string');
         expect(typeof body['ephemeralPublicKey']).toBe('string');
 
@@ -466,7 +473,7 @@ describe('relayAnswerViaSignaling (#591)', () => {
           daemon.privateKeyPkcs8Base64,
           body as unknown as { ephemeralPublicKey: string; sealed: string },
         )) as Record<string, unknown>;
-        expect(opened['sessionId']).toBe('s1');
+        expect(opened['sessionId']).toBe('0199f3a1-0000-7000-8000-000000000001');
         expect(opened['answer']).toBe('Yes, deploy');
       } finally {
         server.stop();


### PR DESCRIPTION
Fixes #911, and found two more instances of the same problem while verifying it.

## What was wrong

`bunx biome check .` was linting three trees it should never see:

| Path | What it is | Impact |
|---|---|---|
| `packages/macos/Remi/Resources/web` | staged web bundle (`scripts/stage-macos-web.sh`) | the original #911 report: thousands of diagnostics after any local macOS build |
| **`.claude/worktrees`** | **full checkouts of in-progress agent branches** | **`biome check .` reports OTHER agents in-flight code as this tree errors** |
| `build/` | TestFlight xcarchives with bundled web assets | 141 errors after any local `testflight:*` run |

All three are gitignored. Only the first was reported; the other two surfaced by actually running the check rather than trusting the issue.

The worktree one is the most disruptive in practice: during a parallel agent run, `biome check .` is not just noisy but actively misleading — it attributes another branch unfinished code to your working tree.

## Measured

```
before:  1394 files checked, 141 errors, 144 warnings
after:    458 files checked,   0 errors,  48 warnings
```

48 warnings is the documented pre-existing baseline that every agent report this week has cited. **The errors were never real** — they were entirely generated/foreign content.

## Verified, not assumed

Wrote a deliberately malformed `.js` into the staged web path, confirmed `biome check .` stayed clean while `biome check <that path>` reported "No files were processed in the specified paths" — i.e. the ignore is doing the work, not an accident of the file list.

## Scope note

`.claude` is excluded wholesale rather than just `.claude/worktrees`, because `.claude/settings.local.json` (a local Claude Code settings file, not repo content) was also being format-checked.

`.gitignore` gains `.claude/worktrees/` with a comment explaining the biome linkage, so the next person to add a generated path knows both lists exist.

## Not fixed here

The deeper issue: `.gitignore` and `biome.json` `files.ignore` are two hand-maintained lists that must agree, and nothing checks that they do — the same class of problem #883 addresses for protocol types. A test asserting "every gitignored path biome can reach is in files.ignore" would prevent the next recurrence. Left as a follow-up rather than expanded into this fix.