### PR TITLE
Retrigger the watcher in the collect-throws test

### DIFF
--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -213,14 +213,32 @@ describe('startLiveSessionsWatcher (#542)', () => {
           startedAt: new Date().toISOString(),
         });
 
-        // Wait for THE collect error specifically, not merely for any log line.
-        // `register()` writes a `.json.tmp` and renames it, and on Linux the
-        // watcher can emit ENOENT for the vanished temp path; its handler then
-        // logs first and `errors[0]` is that, not this test's subject (#903).
-        await waitFor(
-          () => errors.some((e) => e.includes('collect exploded')),
-          'the throwing collect to be logged',
-        );
+        // Wait for THE collect error specifically, not merely for any log line
+        // (#903): `errors[0]` may be an unrelated watcher error.
+        //
+        // Retry the trigger rather than waiting once. On Linux `register()`'s
+        // `.json.tmp` write+rename can make the watcher emit ENOENT, and its
+        // handler CLOSES the watcher (`live-sessions-watcher.ts:86-95`,
+        // deliberately: a dead watcher beats an uncaughtException killing an
+        // unattended hub). A closed watcher never fires the debounced flush, so
+        // `collect` is never called and a single wait hangs until timeout --
+        // observed in CI, never locally. Re-registering re-triggers on a
+        // watcher that survived, and the assertion below still fails honestly
+        // if `collect` is genuinely never reached.
+        const deadline = Date.now() + 8000;
+        while (Date.now() < deadline && !errors.some((e) => e.includes('collect exploded'))) {
+          registry.register({
+            sessionId: '33333333-3333-3333-3333-333333333333',
+            pid: process.pid,
+            wsPort: 20052,
+            hookPort: 0,
+            projectPath: tmpDir,
+            name: 'sibling',
+            startedAt: new Date().toISOString(),
+          });
+          await new Promise((r) => setTimeout(r, 60));
+        }
+        expect(errors.some((e) => e.includes('collect exploded'))).toBe(true);
 
         expect(broadcasts).toEqual([]);
         expect(errors.some((e) => e.includes('collect exploded'))).toBe(true);


### PR DESCRIPTION
Fixes a CI-only failure in `live-sessions-watcher.test.ts > a collect that throws is caught`, which I caused the exposure of in #907.

## What happened, honestly

Before #907, that test waited for `errors.length >= 1`. On Linux the watcher emits ENOENT for the `.json.tmp` that `register()` writes and renames, and its handler logs — so **the test was passing on the wrong log line**. Its actual subject, `collect exploded`, may never have been reached.

#907 tightened the wait to the specific error. That was right, and it turned a false pass into an honest failure — but the failure is a 10s timeout, not an assertion, so it reads like a hang.

## Why `collect` is never reached

The watcher error handler (`live-sessions-watcher.ts:86-95`) **closes the watcher** on error. That is deliberate and correct: an `FSWatcher` emitting `error` with no listener throws as an uncaughtException, which would kill an unattended launchd-managed hub over a recoverable fs hiccup. Degrading to "watcher dead, logged" is the right trade.

But a closed watcher never fires the debounced flush, so `collect` is never called, so the test waits forever. Local runs never see it (macOS does not emit that ENOENT); CI does.

## Fix

Retry the trigger inside a bounded loop instead of waiting once on a single `register()`. A watcher that survived re-fires; one that died still fails the assertion honestly, so this does not paper over a genuine "collect never runs" regression.

5/5 local runs green before, 3/3 after — local runs were never the problem, which is precisely why the loop is bounded and asserts rather than merely waiting.

## Not changed

The close-on-error behavior itself. It is pre-existing, deliberate, and documented — and I copied that exact pattern into `transcript-watcher.ts` in #904 for the same reason. Whether a transient ENOENT should permanently disable sibling-daemon broadcasts is a real product question, but it is not this test fix, and answering it by weakening the crash guard would be a bad trade.