### PR TITLE
Collapse client-to-daemon event interfaces (C7, #900)

### DIFF
--- a/packages/daemon/src/adapters/adapter-registry.ts
+++ b/packages/daemon/src/adapters/adapter-registry.ts
@@ -4,7 +4,7 @@
  * Allows the daemon to run WebSocket, Telegram, etc. simultaneously.
  */
 
-import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
 import type { AdapterEvents, ConnectionAdapter } from './connection-adapter.ts';
 
 /** Events emitted by the registry */
@@ -177,46 +177,6 @@ export class AdapterRegistry {
    */
   getAdapter(adapterType: string): ConnectionAdapter | undefined {
     return this.adapters.get(adapterType);
-  }
-
-  /**
-   * Send a message to a specific connection.
-   * Automatically routes to the correct adapter.
-   */
-  sendMessage(connectionId: UUID, message: Message): boolean {
-    const adapterType = this.connectionToAdapter.get(connectionId);
-    if (!adapterType) {
-      return false;
-    }
-
-    const adapter = this.adapters.get(adapterType);
-    return adapter?.sendMessage(connectionId, message) ?? false;
-  }
-
-  /**
-   * Send a question to a specific connection.
-   */
-  sendQuestion(connectionId: UUID, question: Question, sessionId: UUID): boolean {
-    const adapterType = this.connectionToAdapter.get(connectionId);
-    if (!adapterType) {
-      return false;
-    }
-
-    const adapter = this.adapters.get(adapterType);
-    return adapter?.sendQuestion(connectionId, question, sessionId) ?? false;
-  }
-
-  /**
-   * Send a status update to a specific connection.
-   */
-  sendStatus(connectionId: UUID, status: AgentStatus, context?: string): boolean {
-    const adapterType = this.connectionToAdapter.get(connectionId);
-    if (!adapterType) {
-      return false;
-    }
-
-    const adapter = this.adapters.get(adapterType);
-    return adapter?.sendStatus(connectionId, status, context) ?? false;
   }
 
   /**

--- a/packages/daemon/src/adapters/connection-adapter.ts
+++ b/packages/daemon/src/adapters/connection-adapter.ts
@@ -5,14 +5,8 @@
  * without coupling to a specific transport.
  */
 
-import type {
-  AgentStatus,
-  AnswerExtras,
-  Message,
-  ProtocolMessage,
-  Question,
-  UUID,
-} from '@remi/shared';
+import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
+import type { ClientMessageEventsWithConnectionId } from '../server/client-message-events.ts';
 
 /**
  * Adapter-specific metadata, discriminated by `kind`.
@@ -75,36 +69,24 @@ export interface AdapterMetadata {
   readonly platformData?: AdapterPlatformData;
 }
 
-/** Events emitted from adapter to daemon */
-export interface AdapterEvents {
+/**
+ * Events emitted from adapter to daemon. The per-message portion
+ * (`onUserInput`, `onAnswer`, ...) is declared once in
+ * `client-message-events.ts` (#900) and inherited here with `connectionId`
+ * first -- one adapter instance serves many peers.
+ *
+ * Deliberately kept SEMANTIC, not wire-shaped: the Telegram adapter
+ * synthesizes `onUserInput` directly from chat text, with no
+ * `ProtocolMessage` anywhere in that path (`telegram-adapter.ts`'s
+ * `handleTextMessage`). A contract shaped like the wire protocol (e.g. a
+ * single `onMessage(msg: ProtocolMessage)`) would break that adapter.
+ */
+export interface AdapterEvents extends ClientMessageEventsWithConnectionId {
   /** New connection established */
   onConnect: (connectionId: UUID, metadata: AdapterMetadata) => void;
 
   /** Connection closed */
   onDisconnect: (connectionId: UUID, reason: string) => void;
-
-  /** User input received. `messageId` is the wire message's own id (#681),
-   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
-   *  specific bubble that was dropped. */
-  onUserInput: (
-    connectionId: UUID,
-    sessionId: UUID,
-    content: string,
-    raw?: boolean,
-    claudeSessionId?: UUID,
-    messageId?: UUID,
-  ) => void;
-
-  /** Answer to question received. `extra` carries structured AskUserQuestion
-   *  selections / cancel (#627); omitted for a plain single answer. */
-  onAnswer: (
-    connectionId: UUID,
-    sessionId: UUID,
-    questionId: UUID,
-    answer: string,
-    claudeSessionId?: UUID,
-    extra?: AnswerExtras,
-  ) => void;
 
   /**
    * Connection-independent answer relay (#575, P4a). Used by the HTTP /answer
@@ -118,48 +100,6 @@ export interface AdapterEvents {
     answer: string,
     claudeSessionId?: UUID,
   ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
-
-  /** Bullet expand request received */
-  onBulletExpandRequest: (
-    connectionId: UUID,
-    sessionId: UUID,
-    bulletId: number,
-    requestId: UUID,
-  ) => void;
-
-  /** Session list request received */
-  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => void;
-
-  /** Transcript load request received */
-  onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
-
-  /** Create session request received */
-  onCreateSessionRequest: (
-    connectionId: UUID,
-    directory: string | undefined,
-    requestId: UUID,
-  ) => void;
-
-  /** Terminal resize from attached CLI client */
-  onTerminalResize: (connectionId: UUID, cols: number, rows: number) => void;
-
-  /** Kill session request received */
-  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
-
-  /** Resume session request received */
-  onResumeSessionRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
-
-  /** Session history request received */
-  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
-
-  /** Detach session request received (tmux-style) */
-  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
-
-  /** Device token registered for push notifications */
-  onRegisterDeviceToken: (connectionId: UUID, token: string, platform: 'ios' | 'android') => void;
-
-  /** Device token unregistered — explicit user removal of this server (#690) */
-  onUnregisterDeviceToken: (connectionId: UUID, token: string) => void;
 
   /** Error occurred */
   onError: (connectionId: UUID, error: Error) => void;

--- a/packages/daemon/src/adapters/websocket-adapter.ts
+++ b/packages/daemon/src/adapters/websocket-adapter.ts
@@ -8,6 +8,7 @@
 import type { AgentStatus, Message, ProtocolMessage, Question, UUID } from '@remi/shared';
 import { createAgentOutput, createQuestion, createSessionUpdate } from '@remi/shared';
 import type { Authenticator } from '../auth/authenticator.ts';
+import { pickClientMessageEvents } from '../server/client-message-events.ts';
 import {
   type ServerConfig,
   type ServerEvents,
@@ -125,75 +126,23 @@ export class WebSocketAdapter implements ConnectionAdapter {
         this.events.onDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (connectionId, sessionId, content, raw, claudeSessionId, messageId) => {
-        this.events.onUserInput?.(
-          connectionId,
-          sessionId,
-          content,
-          raw,
-          claudeSessionId,
-          messageId,
-        );
-      },
-
-      onAnswer: (connectionId, sessionId, questionId, answer, claudeSessionId, extra) => {
-        this.events.onAnswer?.(connectionId, sessionId, questionId, answer, claudeSessionId, extra);
-      },
-
       onAnswerRelay: async (sessionId, questionId, answer, claudeSessionId) =>
         // No relay handler wired => behave like an unknown session rather than
         // throwing inside the HTTP route.
         (await this.events.onAnswerRelay?.(sessionId, questionId, answer, claudeSessionId)) ??
         'session-not-found',
 
-      onBulletExpandRequest: (connectionId, sessionId, bulletId, requestId) => {
-        this.events.onBulletExpandRequest?.(connectionId, sessionId, bulletId, requestId);
-      },
-
-      onSessionListRequest: (connectionId, requestId, includeExternal) => {
-        this.events.onSessionListRequest?.(connectionId, requestId, includeExternal);
-      },
-
-      onTranscriptLoadRequest: (connectionId, sessionId, requestId) => {
-        this.events.onTranscriptLoadRequest?.(connectionId, sessionId, requestId);
-      },
-
-      onCreateSessionRequest: (connectionId, directory, requestId) => {
-        this.events.onCreateSessionRequest?.(connectionId, directory, requestId);
-      },
-
-      onTerminalResize: (connectionId, cols, rows) => {
-        this.events.onTerminalResize?.(connectionId, cols, rows);
-      },
-
-      onKillSessionRequest: (connectionId, sessionId, requestId) => {
-        this.events.onKillSessionRequest?.(connectionId, sessionId, requestId);
-      },
-
-      onResumeSessionRequest: (connectionId, sessionId, requestId) => {
-        this.events.onResumeSessionRequest?.(connectionId, sessionId, requestId);
-      },
-
-      onSessionHistoryRequest: (connectionId, requestId, limit) => {
-        this.events.onSessionHistoryRequest?.(connectionId, requestId, limit);
-      },
-
-      onDetachSession: (connectionId, sessionId, requestId) => {
-        this.events.onDetachSession?.(connectionId, sessionId, requestId);
-      },
-
-      onRegisterDeviceToken: (connectionId, token, platform) => {
-        this.events.onRegisterDeviceToken?.(connectionId, token, platform);
-      },
-
-      onUnregisterDeviceToken: (connectionId, token) => {
-        this.events.onUnregisterDeviceToken?.(connectionId, token);
-      },
-
       onError: (error) => {
         // For server-level errors, use a dummy connection ID
         this.events.onError?.('server' as UUID, error);
       },
+
+      // Every per-message event (onUserInput, onAnswer, ...) is an identical
+      // connectionId-prefixed forward from `ServerEvents` to `AdapterEvents`
+      // (#900) -- both derive from the same declaration in
+      // `client-message-events.ts`, so this one call replaces what used to
+      // be 13 hand-written one-line forwarders.
+      ...pickClientMessageEvents(this.events),
     };
 
     const serverConfig: Partial<ServerConfig> = {

--- a/packages/daemon/src/server/client-message-events.ts
+++ b/packages/daemon/src/server/client-message-events.ts
@@ -1,0 +1,229 @@
+/**
+ * The one declaration of the client-to-daemon per-message event contract
+ * (#900, C7 of epic #883).
+ *
+ * Every inbound (client-to-daemon) message that reaches app code as a named
+ * event -- as opposed to `hello`/`ack`/`ping`/`pong`/`auth_response`, which
+ * stay protocol-only and are handled inline by `connection.ts` /
+ * `route-client-message.ts` -- had its argument list declared four times:
+ * `ConnectionEvents` (connection.ts), `ServerEvents` (websocket-server.ts),
+ * `AdapterEvents` (connection-adapter.ts), and the shape `sharedEvents`
+ * (cli.ts) is assembled to satisfy. `ClientMessageEventArgs` below is the
+ * ONE place that lists each event name and its arguments; the other three
+ * derive from it via `extends`.
+ *
+ * Deliberately NOT collapsed into a single interface used everywhere.
+ * `AdapterEvents` (and `ServerEvents`, which shares its shape) must stay
+ * **semantic**, keyed by event name with `connectionId` first -- one
+ * adapter/server instance serves many peers, and the Telegram adapter
+ * synthesizes `onUserInput` straight from chat text with no `ProtocolMessage`
+ * anywhere in the path (see `telegram-adapter.ts`'s `handleTextMessage`). A
+ * wire-shaped `onMessage(msg: ProtocolMessage)` contract would break that.
+ * `ConnectionEvents` has NO `connectionId` -- one `Connection` instance is
+ * already scoped to a single peer, and adding a redundant id there would
+ * invite a future implementation to forward the wrong one. The two shapes
+ * are related by simple prepending, not identical, so they stay two derived
+ * types rather than one.
+ *
+ * Adding a new client-to-daemon event: add one key to `ClientMessageEventArgs`
+ * and to `CLIENT_MESSAGE_EVENT_KEYS`. `ConnectionEvents`, `ServerEvents`, and
+ * `AdapterEvents` all pick it up through `extends`; the generic forwarders
+ * below (`pickClientMessageEvents`, `bindConnectionId`) require no changes,
+ * and neither does `websocket-adapter.ts` (it forwards through
+ * `pickClientMessageEvents`) or `websocket-server.ts`'s `handleOpen` (it
+ * forwards through `bindConnectionId`). Only the real handler implementations
+ * still need per-type logic: a dispatch case in `connection.ts`'s handler map
+ * (mandated separately by `route-client-message.ts`, #899/C6) and a producer
+ * in `cli.ts`'s `sharedEvents` assembly. That work is inherent business
+ * logic, not the duplication this module removes.
+ */
+import type { AnswerExtras, UUID } from '@remi/shared';
+
+/**
+ * Every client-to-daemon event's argument list, WITHOUT `connectionId`.
+ * `messageId` / `extra` document the #627/#681 history: optional trailing
+ * args added later to carry structured AskUserQuestion answers and
+ * message-id echoing without breaking existing positional callers.
+ */
+export interface ClientMessageEventArgs {
+  /** User input received. `messageId` is the wire message's own id (#681),
+   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
+   *  specific bubble that was dropped. */
+  onUserInput: [
+    sessionId: UUID,
+    content: string,
+    raw?: boolean,
+    claudeSessionId?: UUID,
+    messageId?: UUID,
+  ];
+
+  /** Answer to question received. `extra` carries the structured AskUserQuestion
+   *  selections / cancel flag (#627); omitted for a plain single answer. */
+  onAnswer: [
+    sessionId: UUID,
+    questionId: UUID,
+    answer: string,
+    claudeSessionId?: UUID,
+    extra?: AnswerExtras,
+  ];
+
+  /** Bullet expand request received. */
+  onBulletExpandRequest: [sessionId: UUID, bulletId: number, requestId: UUID];
+
+  /** Session list request received. */
+  onSessionListRequest: [requestId: UUID, includeExternal: boolean];
+
+  /** Transcript load request received. */
+  onTranscriptLoadRequest: [sessionId: string, requestId: UUID];
+
+  /** Create session request received. */
+  onCreateSessionRequest: [directory: string | undefined, requestId: UUID];
+
+  /** Terminal resize from attached CLI client. */
+  onTerminalResize: [cols: number, rows: number];
+
+  /** Kill session request received. */
+  onKillSessionRequest: [sessionId: UUID, requestId: UUID];
+
+  /** Resume session request received. */
+  onResumeSessionRequest: [sessionId: string, requestId: UUID];
+
+  /** Session history request received. */
+  onSessionHistoryRequest: [requestId: UUID, limit: number | undefined];
+
+  /** Detach session request received (tmux-style). */
+  onDetachSession: [sessionId: UUID, requestId: UUID];
+
+  /** Device token registered for push notifications. */
+  onRegisterDeviceToken: [token: string, platform: 'ios' | 'android'];
+
+  /** Device token unregistered -- explicit user removal of this server (#690). */
+  onUnregisterDeviceToken: [token: string];
+}
+
+/**
+ * Hand-transcribed key list, deliberately not derived from
+ * `ClientMessageEventArgs` at runtime (types don't exist at runtime) -- the
+ * runtime companion to the type above, in the same spirit as `GOLDEN_TYPES` /
+ * `INBOUND_ROUTED` elsewhere in this epic: it drives the generic forwarders
+ * below, and `client-message-events.test.ts` pins it against
+ * `ClientMessageEventArgs`'s keys (via a `satisfies`-checked exhaustiveness
+ * assertion) so the two cannot silently drift apart.
+ */
+export const CLIENT_MESSAGE_EVENT_KEYS = [
+  'onUserInput',
+  'onAnswer',
+  'onBulletExpandRequest',
+  'onSessionListRequest',
+  'onTranscriptLoadRequest',
+  'onCreateSessionRequest',
+  'onTerminalResize',
+  'onKillSessionRequest',
+  'onResumeSessionRequest',
+  'onSessionHistoryRequest',
+  'onDetachSession',
+  'onRegisterDeviceToken',
+  'onUnregisterDeviceToken',
+] as const satisfies readonly (keyof ClientMessageEventArgs)[];
+
+/**
+ * Compile-time proof `CLIENT_MESSAGE_EVENT_KEYS` covers EVERY key of
+ * `ClientMessageEventArgs`, not just valid ones (the `satisfies` clause above
+ * only rules out extra/misspelled keys, not missing ones). Without this, a
+ * key added to the interface but forgotten in the array would compile clean
+ * everywhere else -- `ConnectionEvents` / `ServerEvents` / `AdapterEvents`
+ * all `extends` the interface directly, not this array -- but
+ * `pickClientMessageEvents` / `bindConnectionId` would silently stop
+ * forwarding that one event. That is exactly the silent-drop failure mode
+ * this epic exists to close (see #883's "duplicated implementations drift
+ * silently, and the drift is invisible" finding).
+ *
+ * Mapped to `true`/`false` rather than `never` for the same reason
+ * `protocol.ts`'s `_DiscriminantsMatch` is: `true | never` collapses to
+ * `true`, so a single missing key would be silently absorbed by the other
+ * (correct) ones instead of breaking the assignment below.
+ */
+type _AllKeysCovered = {
+  [K in keyof ClientMessageEventArgs]: K extends (typeof CLIENT_MESSAGE_EVENT_KEYS)[number]
+    ? true
+    : false;
+}[keyof ClientMessageEventArgs];
+const _allKeysCovered: true = true as _AllKeysCovered;
+void _allKeysCovered;
+
+/** `ClientMessageEventArgs` as callback signatures -- what a single
+ *  `Connection` (already scoped to one peer) exposes. */
+export type ClientMessageEvents = {
+  [K in keyof ClientMessageEventArgs]: (...args: ClientMessageEventArgs[K]) => void;
+};
+
+/** `ClientMessageEvents` with `connectionId` prepended -- what a fan-out
+ *  layer (`WebSocketServer`, any `ConnectionAdapter`) exposes, since one
+ *  instance serves many peers and a consumer needs to know which one. */
+export type ClientMessageEventsWithConnectionId = {
+  [K in keyof ClientMessageEventArgs]: (
+    connectionId: UUID,
+    ...args: ClientMessageEventArgs[K]
+  ) => void;
+};
+
+/**
+ * Forwards the client-message-event subset of `source` unchanged onto a
+ * fresh object. Used where two connectionId-prefixed event bags need every
+ * per-message event passed straight through -- `ServerEvents` ->
+ * `AdapterEvents` in `websocket-adapter.ts`'s `start()` -- replacing what
+ * used to be 13 hand-written one-line forwarders that differed only in
+ * which event name they named twice.
+ *
+ * Not a plain object spread: `source` (e.g. `Partial<ServerEvents>`) also
+ * carries transport-lifecycle keys (`onStart`, `onClientConnect`, ...) with
+ * signatures the target (`Partial<AdapterEvents>`) does not share, and a raw
+ * `{ ...source }` would carry those through with the wrong shape.
+ */
+export function pickClientMessageEvents(
+  source: Partial<ClientMessageEventsWithConnectionId>,
+): Partial<ClientMessageEventsWithConnectionId> {
+  const result: Partial<ClientMessageEventsWithConnectionId> = {};
+  for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+    const handler = source[key];
+    if (handler) {
+      // `key` ranges over a union of literal keys inside this loop; nothing
+      // in the type system correlates "the handler read from `source[key]`"
+      // with "the slot `result[key]` expects" across that union the way a
+      // single fixed key would. Each iteration's `handler` is real, though:
+      // it came from indexing `source` with this exact `key`, at this exact
+      // `key`'s position in the target. The cast documents that
+      // runtime-proven correspondence rather than assuming one blind.
+      (result as Record<string, unknown>)[key] = handler;
+    }
+  }
+  return result;
+}
+
+/**
+ * Binds `connectionId` onto a connectionId-prefixed sink, producing the
+ * connectionId-free shape a single `Connection` needs. Used by
+ * `WebSocketServer.handleOpen` to turn its own `Partial<ServerEvents>` into
+ * the `Partial<ConnectionEvents>` a `Connection` instance is constructed
+ * with, replacing what used to be 13 hand-written closures that each
+ * re-implemented "call the server-level handler with this connection's id
+ * prepended."
+ */
+export function bindConnectionId(
+  connectionId: UUID,
+  sink: Partial<ClientMessageEventsWithConnectionId>,
+): Partial<ClientMessageEvents> {
+  const result: Partial<ClientMessageEvents> = {};
+  for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+    const handler = sink[key];
+    if (handler) {
+      // See `pickClientMessageEvents` above for why this needs a cast: `key`
+      // ranges over a union inside the loop, and TypeScript does not
+      // correlate a per-iteration `handler`'s specific member type with the
+      // matching member type of `result` at that same runtime key.
+      (result as Record<string, (...args: unknown[]) => void>)[key] = (...args: unknown[]) =>
+        (handler as (connectionId: UUID, ...args: unknown[]) => void)(connectionId, ...args);
+    }
+  }
+  return result;
+}

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -49,72 +49,24 @@ import type {
   UserInputMessage,
 } from '@remi/shared';
 import type { Authenticator } from '../auth/authenticator.ts';
+import type { ClientMessageEvents } from './client-message-events.ts';
 import { type ClientMessageHandlers, routeClientMessage } from './route-client-message.ts';
 
 /** Connection state */
 export type ConnectionState = 'connecting' | 'authenticating' | 'connected' | 'disconnected';
 
-/** Events emitted by connection */
-export interface ConnectionEvents {
+/**
+ * Events emitted by a connection. The per-message portion (`onUserInput`,
+ * `onAnswer`, ...) is declared once in `client-message-events.ts` (#900) and
+ * inherited here without a `connectionId` -- a `Connection` is already
+ * scoped to one peer.
+ */
+export interface ConnectionEvents extends ClientMessageEvents {
   /** Connection established */
   onConnect: (sessionId: UUID) => void;
 
   /** Connection closed */
   onDisconnect: (reason: string) => void;
-
-  /** User input received. `messageId` is the wire message's own id (#681),
-   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
-   *  specific bubble that was dropped. */
-  onUserInput: (
-    sessionId: UUID,
-    content: string,
-    raw?: boolean,
-    claudeSessionId?: UUID,
-    messageId?: UUID,
-  ) => void;
-
-  /** Answer to question received. `extra` carries the structured AskUserQuestion
-   *  selections / cancel flag (#627); omitted for a plain single answer. */
-  onAnswer: (
-    sessionId: UUID,
-    questionId: UUID,
-    answer: string,
-    claudeSessionId?: UUID,
-    extra?: AnswerExtras,
-  ) => void;
-
-  /** Bullet expand request received */
-  onBulletExpandRequest: (sessionId: UUID, bulletId: number, requestId: UUID) => void;
-
-  /** Session list request received */
-  onSessionListRequest: (requestId: UUID, includeExternal: boolean) => void;
-
-  /** Transcript load request received */
-  onTranscriptLoadRequest: (sessionId: string, requestId: UUID) => void;
-
-  /** Create session request received */
-  onCreateSessionRequest: (directory: string | undefined, requestId: UUID) => void;
-
-  /** Terminal resize from attached CLI client */
-  onTerminalResize: (cols: number, rows: number) => void;
-
-  /** Kill session request received */
-  onKillSessionRequest: (sessionId: UUID, requestId: UUID) => void;
-
-  /** Resume session request received */
-  onResumeSessionRequest: (sessionId: string, requestId: UUID) => void;
-
-  /** Session history request received */
-  onSessionHistoryRequest: (requestId: UUID, limit: number | undefined) => void;
-
-  /** Detach session request received (tmux-style) */
-  onDetachSession: (sessionId: UUID, requestId: UUID) => void;
-
-  /** Device token registered for push notifications */
-  onRegisterDeviceToken: (token: string, platform: 'ios' | 'android') => void;
-
-  /** Device token unregistered — explicit user removal of this server (#690) */
-  onUnregisterDeviceToken: (token: string) => void;
 
   /** Authentication succeeded */
   onAuthSuccess: (clientFingerprint: string) => void;

--- a/packages/daemon/src/server/websocket-server.ts
+++ b/packages/daemon/src/server/websocket-server.ts
@@ -6,8 +6,12 @@
  */
 
 import { generateId } from '@remi/shared';
-import type { AnswerExtras, ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
 import { CAPABILITY_HEADER, capabilityTokenMatches } from '../auth/capability-token.ts';
+import {
+  type ClientMessageEventsWithConnectionId,
+  bindConnectionId,
+} from './client-message-events.ts';
 import { Connection, type ConnectionConfig, type ConnectionEvents } from './connection.ts';
 import { corsHeadersForOrigin, isAllowedOrigin, rejectionNotice } from './origin-policy.ts';
 import { shouldSkipAuthForPeer } from './peer-helpers.ts';
@@ -52,8 +56,12 @@ export interface ServerConfig {
   readonly requireLocalAuth?: boolean;
 }
 
-/** Server events */
-export interface ServerEvents {
+/**
+ * Server events. The per-message portion (`onUserInput`, `onAnswer`, ...) is
+ * declared once in `client-message-events.ts` (#900) and inherited here with
+ * `connectionId` first -- one server serves many peers.
+ */
+export interface ServerEvents extends ClientMessageEventsWithConnectionId {
   /** Server started listening */
   onStart: (port: number) => void;
 
@@ -65,29 +73,6 @@ export interface ServerEvents {
 
   /** Client disconnected */
   onClientDisconnect: (connectionId: UUID, reason: string) => void;
-
-  /** User input from client. `messageId` is the wire message's own id (#681),
-   *  carried so a rejection (e.g. NOT_ACTIVE_CONNECTION) can name the
-   *  specific bubble that was dropped. */
-  onUserInput: (
-    connectionId: UUID,
-    sessionId: UUID,
-    content: string,
-    raw?: boolean,
-    claudeSessionId?: UUID,
-    messageId?: UUID,
-  ) => void;
-
-  /** Answer from client. `extra` carries structured AskUserQuestion selections /
-   *  cancel (#627); omitted for a plain single answer. */
-  onAnswer: (
-    connectionId: UUID,
-    sessionId: UUID,
-    questionId: UUID,
-    answer: string,
-    claudeSessionId?: UUID,
-    extra?: AnswerExtras,
-  ) => void;
 
   /**
    * Connection-independent answer relay over HTTP POST /answer (#575, P4a).
@@ -101,48 +86,6 @@ export interface ServerEvents {
     answer: string,
     claudeSessionId?: UUID,
   ) => Promise<'delivered' | 'session-not-found' | 'stale-binding' | 'stale'>;
-
-  /** Bullet expand request from client */
-  onBulletExpandRequest: (
-    connectionId: UUID,
-    sessionId: UUID,
-    bulletId: number,
-    requestId: UUID,
-  ) => void;
-
-  /** Session list request from client */
-  onSessionListRequest: (connectionId: UUID, requestId: UUID, includeExternal: boolean) => void;
-
-  /** Transcript load request from client */
-  onTranscriptLoadRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
-
-  /** Create session request from client */
-  onCreateSessionRequest: (
-    connectionId: UUID,
-    directory: string | undefined,
-    requestId: UUID,
-  ) => void;
-
-  /** Terminal resize from attached CLI client */
-  onTerminalResize: (connectionId: UUID, cols: number, rows: number) => void;
-
-  /** Kill session request from client */
-  onKillSessionRequest: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
-
-  /** Resume session request from client */
-  onResumeSessionRequest: (connectionId: UUID, sessionId: string, requestId: UUID) => void;
-
-  /** Session history request from client */
-  onSessionHistoryRequest: (connectionId: UUID, requestId: UUID, limit: number | undefined) => void;
-
-  /** Detach session request from client (tmux-style) */
-  onDetachSession: (connectionId: UUID, sessionId: UUID, requestId: UUID) => void;
-
-  /** Device token registered for push notifications */
-  onRegisterDeviceToken: (connectionId: UUID, token: string, platform: 'ios' | 'android') => void;
-
-  /** Device token unregistered — explicit user removal of this server (#690) */
-  onUnregisterDeviceToken: (connectionId: UUID, token: string) => void;
 
   /** Error occurred */
   onError: (error: Error) => void;
@@ -617,6 +560,11 @@ export class WebSocketServer {
   }
 
   private handleOpen(ws: { data: WSData }): void {
+    // The per-message forwarding (onUserInput, onAnswer, ...) is generic:
+    // every one of them just needs this connection's id prepended before
+    // reaching `this.events` (#900). `bindConnectionId` does that once for
+    // every key in `client-message-events.ts`'s single declaration, instead
+    // of 13 hand-written closures that each re-implemented the same prepend.
     const connectionEvents: Partial<ConnectionEvents> = {
       onConnect: (_sessionId) => {
         const connection = this.connections.get(ws.data.connectionId);
@@ -631,75 +579,11 @@ export class WebSocketServer {
         this.events.onClientDisconnect?.(connectionId, reason);
       },
 
-      onUserInput: (sessionId, content, raw, claudeSessionId, messageId) => {
-        this.events.onUserInput?.(
-          ws.data.connectionId,
-          sessionId,
-          content,
-          raw,
-          claudeSessionId,
-          messageId,
-        );
-      },
-
-      onAnswer: (sessionId, questionId, answer, claudeSessionId, extra) => {
-        this.events.onAnswer?.(
-          ws.data.connectionId,
-          sessionId,
-          questionId,
-          answer,
-          claudeSessionId,
-          extra,
-        );
-      },
-
-      onBulletExpandRequest: (sessionId, bulletId, requestId) => {
-        this.events.onBulletExpandRequest?.(ws.data.connectionId, sessionId, bulletId, requestId);
-      },
-
-      onSessionListRequest: (requestId, includeExternal) => {
-        this.events.onSessionListRequest?.(ws.data.connectionId, requestId, includeExternal);
-      },
-
-      onTranscriptLoadRequest: (sessionId, requestId) => {
-        this.events.onTranscriptLoadRequest?.(ws.data.connectionId, sessionId, requestId);
-      },
-
-      onCreateSessionRequest: (directory, requestId) => {
-        this.events.onCreateSessionRequest?.(ws.data.connectionId, directory, requestId);
-      },
-
-      onTerminalResize: (cols, rows) => {
-        this.events.onTerminalResize?.(ws.data.connectionId, cols, rows);
-      },
-
-      onKillSessionRequest: (sessionId, requestId) => {
-        this.events.onKillSessionRequest?.(ws.data.connectionId, sessionId, requestId);
-      },
-
-      onResumeSessionRequest: (sessionId, requestId) => {
-        this.events.onResumeSessionRequest?.(ws.data.connectionId, sessionId, requestId);
-      },
-
-      onSessionHistoryRequest: (requestId, limit) => {
-        this.events.onSessionHistoryRequest?.(ws.data.connectionId, requestId, limit);
-      },
-
-      onDetachSession: (sessionId, requestId) => {
-        this.events.onDetachSession?.(ws.data.connectionId, sessionId, requestId);
-      },
-
-      onRegisterDeviceToken: (token, platform) => {
-        this.events.onRegisterDeviceToken?.(ws.data.connectionId, token, platform);
-      },
-
-      onUnregisterDeviceToken: (token) => {
-        this.events.onUnregisterDeviceToken?.(ws.data.connectionId, token);
-      },
-
       onError: (error) => {
         this.events.onError?.(error);
       },
+
+      ...bindConnectionId(ws.data.connectionId, this.events),
     };
 
     // Localhost-no-auth (#257): even when an authenticator is configured,

--- a/packages/daemon/tests/adapter-registry.test.ts
+++ b/packages/daemon/tests/adapter-registry.test.ts
@@ -266,104 +266,11 @@ describe('AdapterRegistry', () => {
   });
 
   describe('message routing', () => {
-    test('sendMessage routes to correct adapter', () => {
-      const registry = new AdapterRegistry();
-      const adapter = new TestAdapter('ws');
-      const connId = generateId();
-      adapter.addConnection(connId);
-      registry.register(adapter);
-      registry.trackConnection(connId, 'ws');
-
-      const message: Message = {
-        id: generateId(),
-        sessionId: generateId(),
-        sender: 'agent',
-        content: 'Hello',
-        createdAt: new Date().toISOString(),
-        state: 'sent',
-        stateChangedAt: new Date().toISOString(),
-        isEditing: false,
-      };
-
-      const result = registry.sendMessage(connId, message);
-      expect(result).toBe(true);
-      expect(adapter.sentMessages.length).toBe(1);
-      expect(adapter.sentMessages[0]?.message.content).toBe('Hello');
-    });
-
-    test('sendMessage returns false for unknown connection', () => {
-      const registry = new AdapterRegistry();
-      const message: Message = {
-        id: generateId(),
-        sessionId: generateId(),
-        sender: 'agent',
-        content: 'Hello',
-        createdAt: new Date().toISOString(),
-        state: 'sent',
-        stateChangedAt: new Date().toISOString(),
-        isEditing: false,
-      };
-
-      const result = registry.sendMessage(generateId(), message);
-      expect(result).toBe(false);
-    });
-
-    test('sendQuestion routes to correct adapter', () => {
-      const registry = new AdapterRegistry();
-      const adapter = new TestAdapter('ws');
-      const connId = generateId();
-      adapter.addConnection(connId);
-      registry.register(adapter);
-      registry.trackConnection(connId, 'ws');
-
-      const question: Question = {
-        id: generateId(),
-        text: 'Continue?',
-        allowsFreeText: false,
-        isAnswered: false,
-        options: [
-          { label: 'Yes', value: 'y', isRecommended: true, isYes: true, isNo: false },
-          { label: 'No', value: 'n', isRecommended: false, isYes: false, isNo: true },
-        ],
-      };
-
-      const result = registry.sendQuestion(connId, question, generateId());
-      expect(result).toBe(true);
-      expect(adapter.sentQuestions.length).toBe(1);
-    });
-
-    test('sendQuestion returns false for unknown connection', () => {
-      const registry = new AdapterRegistry();
-      const question: Question = {
-        id: generateId(),
-        text: 'Continue?',
-        allowsFreeText: false,
-        isAnswered: false,
-        options: [],
-      };
-
-      expect(registry.sendQuestion(generateId(), question, generateId())).toBe(false);
-    });
-
-    test('sendStatus routes to correct adapter', () => {
-      const registry = new AdapterRegistry();
-      const adapter = new TestAdapter('ws');
-      const connId = generateId();
-      adapter.addConnection(connId);
-      registry.register(adapter);
-      registry.trackConnection(connId, 'ws');
-
-      const result = registry.sendStatus(connId, 'thinking');
-      expect(result).toBe(true);
-      expect(adapter.sentStatuses.length).toBe(1);
-      expect(adapter.sentStatuses[0]?.status).toBe('thinking');
-    });
-
-    test('sendStatus returns false for unknown connection', () => {
-      const registry = new AdapterRegistry();
-      expect(registry.sendStatus(generateId(), 'idle')).toBe(false);
-    });
-
+    // sendMessage/sendQuestion/sendStatus were removed from AdapterRegistry
+    // (#900, C7 of epic #883): a fresh grep at implementation time found zero
+    // callers outside this file (`grep -rn "registry\.sendMessage\|registry\.sendQuestion\|registry\.sendStatus"
+    // packages/ tests/` matched only this test file). `sendRaw` is the
+    // registry-level send path production code actually uses.
     test('sendRaw routes to correct adapter', () => {
       const registry = new AdapterRegistry();
       const adapter = new TestAdapter('ws');

--- a/packages/daemon/tests/server/client-message-events.test.ts
+++ b/packages/daemon/tests/server/client-message-events.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the single client-to-daemon per-message event declaration
+ * (#900, C7 of epic #883): `ClientMessageEventArgs`, the generic key list
+ * that drives it, and the two forwarders (`pickClientMessageEvents`,
+ * `bindConnectionId`) that replaced 13 hand-written per-event closures each
+ * in `websocket-adapter.ts` and `websocket-server.ts`.
+ *
+ * `GOLDEN_KEYS` below is a hand-transcribed copy of the 13 event names,
+ * deliberately NOT imported from `CLIENT_MESSAGE_EVENT_KEYS` -- the same
+ * reason `protocol-registry.test.ts`'s `GOLDEN_TYPES` isn't derived from
+ * `MESSAGE_DIRECTION`: a test that reads its expectation from the thing it's
+ * checking can't fail when that thing is wrong.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import {
+  CLIENT_MESSAGE_EVENT_KEYS,
+  type ClientMessageEventsWithConnectionId,
+  bindConnectionId,
+  pickClientMessageEvents,
+} from '../../src/server/client-message-events.ts';
+
+/** Hand-transcribed, verbatim, from the pre-#900 `ConnectionEvents` /
+ *  `ServerEvents` / `AdapterEvents` per-message field names. */
+const GOLDEN_KEYS = [
+  'onUserInput',
+  'onAnswer',
+  'onBulletExpandRequest',
+  'onSessionListRequest',
+  'onTranscriptLoadRequest',
+  'onCreateSessionRequest',
+  'onTerminalResize',
+  'onKillSessionRequest',
+  'onResumeSessionRequest',
+  'onSessionHistoryRequest',
+  'onDetachSession',
+  'onRegisterDeviceToken',
+  'onUnregisterDeviceToken',
+];
+
+describe('CLIENT_MESSAGE_EVENT_KEYS', () => {
+  test('has exactly 13 entries with no duplicates', () => {
+    expect(CLIENT_MESSAGE_EVENT_KEYS.length).toBe(13);
+    expect(new Set(CLIENT_MESSAGE_EVENT_KEYS).size).toBe(13);
+  });
+
+  test('is exactly the golden key set, no more, no fewer', () => {
+    const actual: string[] = [...CLIENT_MESSAGE_EVENT_KEYS].sort();
+    expect(actual).toEqual([...GOLDEN_KEYS].sort());
+  });
+});
+
+describe('pickClientMessageEvents', () => {
+  test('forwards every present client-message-event key unchanged', () => {
+    const onUserInput = () => {};
+    const onAnswer = () => {};
+    const source: Partial<ClientMessageEventsWithConnectionId> = { onUserInput, onAnswer };
+
+    const result = pickClientMessageEvents(source);
+
+    expect(result.onUserInput).toBe(onUserInput);
+    expect(result.onAnswer).toBe(onAnswer);
+  });
+
+  test('omits keys the source never set', () => {
+    const result = pickClientMessageEvents({ onUserInput: () => {} });
+
+    expect(Object.keys(result)).toEqual(['onUserInput']);
+    for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+      if (key !== 'onUserInput') {
+        expect(result[key]).toBeUndefined();
+      }
+    }
+  });
+
+  test('does not leak non-client-message-event keys from the source', () => {
+    // `source` stands in for a `Partial<ServerEvents>`, which also carries
+    // onStart/onClientConnect/onError -- keys `AdapterEvents` doesn't share
+    // the same signature for. A naive `{ ...source }` would carry them
+    // through with the wrong shape; `pickClientMessageEvents` must not.
+    const source = {
+      onUserInput: () => {},
+      onStart: (_port: number) => {},
+      onClientConnect: () => {},
+      onError: (_err: Error) => {},
+    } as unknown as Partial<ClientMessageEventsWithConnectionId>;
+
+    const result = pickClientMessageEvents(source);
+
+    expect(Object.keys(result).sort()).toEqual(['onUserInput']);
+  });
+
+  test('round-trips every one of the 13 keys with connectionId-prefixed args intact', () => {
+    for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+      const calls: unknown[][] = [];
+      const source: Partial<ClientMessageEventsWithConnectionId> = {
+        [key]: (...args: unknown[]) => {
+          calls.push(args);
+        },
+      } as Partial<ClientMessageEventsWithConnectionId>;
+
+      const result = pickClientMessageEvents(source);
+      const handler = result[key];
+      expect(handler).toBeDefined();
+
+      const connId = generateId();
+      const sentinel = `sentinel-${key}`;
+      // biome-ignore lint/suspicious/noExplicitAny: exercising the forwarder generically across all 13 differently-shaped handlers.
+      (handler as any)(connId, sentinel);
+
+      expect(calls).toEqual([[connId, sentinel]]);
+    }
+  });
+});
+
+describe('bindConnectionId', () => {
+  test('prepends connectionId and forwards the rest of the args unchanged', () => {
+    const calls: unknown[][] = [];
+    const sink: Partial<ClientMessageEventsWithConnectionId> = {
+      onUserInput: (...args: unknown[]) => {
+        calls.push(args);
+      },
+    } as Partial<ClientMessageEventsWithConnectionId>;
+
+    const connId = generateId();
+    const bound = bindConnectionId(connId, sink);
+    bound.onUserInput?.('session-1' as UUID, 'hello', true, undefined, undefined);
+
+    expect(calls).toEqual([[connId, 'session-1', 'hello', true, undefined, undefined]]);
+  });
+
+  test('omits keys the sink never set', () => {
+    const connId = generateId();
+    const bound = bindConnectionId(connId, { onAnswer: () => {} });
+
+    expect(Object.keys(bound)).toEqual(['onAnswer']);
+    for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+      if (key !== 'onAnswer') {
+        expect(bound[key]).toBeUndefined();
+      }
+    }
+  });
+
+  test('binds every one of the 13 keys to the SAME connectionId', () => {
+    for (const key of CLIENT_MESSAGE_EVENT_KEYS) {
+      const calls: unknown[][] = [];
+      const sink: Partial<ClientMessageEventsWithConnectionId> = {
+        [key]: (...args: unknown[]) => {
+          calls.push(args);
+        },
+      } as Partial<ClientMessageEventsWithConnectionId>;
+
+      const connId = generateId();
+      const bound = bindConnectionId(connId, sink);
+      const handler = bound[key];
+      expect(handler).toBeDefined();
+
+      const sentinel = `sentinel-${key}`;
+      // biome-ignore lint/suspicious/noExplicitAny: exercising the binder generically across all 13 differently-shaped handlers.
+      (handler as any)(sentinel);
+
+      expect(calls).toEqual([[connId, sentinel]]);
+    }
+  });
+
+  test('two different connections never cross-contaminate the bound id', () => {
+    const calls: Array<{ connId: UUID; sessionId: string }> = [];
+    const sink: Partial<ClientMessageEventsWithConnectionId> = {
+      onTerminalResize: (connId, cols, _rows) => {
+        calls.push({ connId, sessionId: String(cols) });
+      },
+    };
+
+    const connA = generateId();
+    const connB = generateId();
+    const boundA = bindConnectionId(connA, sink);
+    const boundB = bindConnectionId(connB, sink);
+
+    boundA.onTerminalResize?.(80, 24);
+    boundB.onTerminalResize?.(100, 40);
+
+    expect(calls).toEqual([
+      { connId: connA, sessionId: '80' },
+      { connId: connB, sessionId: '100' },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #900 (C7, epic #883). Depends on C6 (#899/#915, merged).

## What changed

Four places built the same client-to-daemon per-message event shape by hand:
`ConnectionEvents` (`connection.ts`), `ServerEvents` (`websocket-server.ts`),
`AdapterEvents` (`connection-adapter.ts`), and 26 hand-written forwarding
closures (13 in `websocket-server.ts`'s `handleOpen`, 13 in
`websocket-adapter.ts`'s `start()`) that translated between them one field at
a time.

Added `packages/daemon/src/server/client-message-events.ts`:
`ClientMessageEventArgs` declares each of the 13 event's arguments **once**.
`ConnectionEvents`, `ServerEvents`, and `AdapterEvents` each `extends` a
derived shape (`ClientMessageEvents` / `ClientMessageEventsWithConnectionId`)
instead of re-listing the fields. Two generic forwarders,
`bindConnectionId` (prepends `connectionId`, used by `websocket-server.ts`)
and `pickClientMessageEvents` (identity-forwards the shared subset, used by
`websocket-adapter.ts`), replace all 26 hand-written closures.

A compile-time check (`_AllKeysCovered`, same `true`/`false`-not-`never`
pattern as `protocol.ts`'s `_DiscriminantsMatch`) keeps the forwarders' key
list exhaustive against the interface, so a key added to
`ClientMessageEventArgs` but forgotten in `CLIENT_MESSAGE_EVENT_KEYS` is a
build error, not a silently-unforwarded event.

Also removed the dead `AdapterRegistry.sendMessage`/`sendQuestion`/`sendStatus`
fan-out wrappers (see "Fresh caller grep" below).

**`sharedEvents` in `cli.ts` needed zero changes** — it was never a fourth
hand-declared interface, just an object literal duck-typed against
`Partial<AdapterEvents>`. The issue's "four … declarations" framing is
slightly imprecise; see "Something the issue got right, and one thing
imprecise" below.

## Measured edit-site count (the acceptance evidence)

Per the epic's halfway-checkpoint comment, the file-count grep is not the
metric — it stayed flat through six merged issues because exhaustiveness
makes consumers mention types *more*, not less. The real question is: how
many files does a developer have to **edit** to add one client-to-daemon
message end to end?

Measured directly, twice, on the same scratch message
(`scratch_test_request` / `onScratchTestRequest`, connectionId + sessionId +
requestId), verified compiling both times with `bun run typecheck`, then
reverted (not part of this diff):

**Before** (stashed this PR's diff, added the scratch message to `develop`
HEAD, `git status --short` after a clean compile):

```
 M packages/daemon/src/adapters/connection-adapter.ts   (AdapterEvents field)
 M packages/daemon/src/adapters/websocket-adapter.ts    (start() forward closure)
 M packages/daemon/src/cli.ts                           (producer)
 M packages/daemon/src/cli/attach-client.ts             (pre-existing C4/C5 registry exhaustiveness)
 M packages/daemon/src/remote/relay-adapter.ts           (wire->semantic handler)
 M packages/daemon/src/server/connection.ts              (ConnectionEvents field + handler)
 M packages/daemon/src/server/websocket-server.ts        (ServerEvents field + handleOpen forward closure)
 M packages/shared/src/index.ts                          (pre-existing C2 export list)
 M packages/shared/src/protocol.ts                       (pre-existing C2 registration)
 M packages/shared/tests/fixtures/protocol/builders.ts   (pre-existing C2/C5 fixture registry)
```
**10 files.**

**After** (this PR's code, same scratch message, same clean compile):

```
 M packages/daemon/src/cli.ts                           (producer)
 M packages/daemon/src/cli/attach-client.ts             (pre-existing C4/C5 registry exhaustiveness)
 M packages/daemon/src/remote/relay-adapter.ts           (wire->semantic handler)
 M packages/daemon/src/server/client-message-events.ts   (ClientMessageEventArgs + key list, once)
 M packages/daemon/src/server/connection.ts              (handler only, no interface field)
 M packages/shared/src/index.ts                          (pre-existing C2 export list)
 M packages/shared/src/protocol.ts                       (pre-existing C2 registration)
 M packages/shared/tests/fixtures/protocol/builders.ts   (pre-existing C2/C5 fixture registry)
```
**8 files.**

`websocket-server.ts`, `websocket-adapter.ts`, and `connection-adapter.ts`
drop out entirely (their forwarders/interfaces auto-inherit);
`client-message-events.ts` is the one new site. Net **10 → 8 files (-20%)**,
concentrated exactly on the boilerplate this PR targets: 4 of the 10 files
in "before" (`shared/src/index.ts`, `shared/src/protocol.ts`,
`attach-client.ts`, `builders.ts`) are pre-existing C2/C4/C5 registry
machinery, unrelated to C7 and identical in both columns — the entire delta
is the three files this PR collapses away.

Both experiments were performed for real (`git diff --stat` captured, `bun
run typecheck` run clean) and then reverted with `git checkout` /
`git stash pop`; no scratch code ships in this PR.

## `AdapterEvents` stayed semantic — evidence

`telegram-adapter.ts:924` (`handleTextMessage`):
```ts
this.events.onUserInput?.(session.connectionId, session.sessionId, text);
```
`text` is `ctx.message?.text` — plain chat text, no `ProtocolMessage`
anywhere in the call path (confirmed: `grep -n "ProtocolMessage" telegram-adapter.ts`
only matches `sendRaw`/`broadcast`, the *outbound* direction). `AdapterEvents`
extends `ClientMessageEventsWithConnectionId` (named methods, connectionId +
positional args) rather than a wire-shaped `onMessage(msg: ProtocolMessage)`,
so this compiles unchanged. `telegram-adapter.test.ts` is unmodified and
green (part of the daemon test run below).

## Fresh caller grep — `AdapterRegistry` dead surface

Re-grepped at implementation time per AGENTS.md rule 2, against the commit
right before the removal (`5be2584`, this PR's own prior commit — i.e. the
state right after the interface collapse, before deletion):

```
$ git grep -n "registry\.sendMessage\|registry\.sendQuestion\|registry\.sendStatus" 5be2584 -- packages/ tests/
5be2584:packages/daemon/tests/adapter-registry.test.ts:288: ... registry.sendMessage(connId, message);
5be2584:packages/daemon/tests/adapter-registry.test.ts:307: ... registry.sendMessage(generateId(), message);
5be2584:packages/daemon/tests/adapter-registry.test.ts:330: ... registry.sendQuestion(connId, question, generateId());
5be2584:packages/daemon/tests/adapter-registry.test.ts:345: ... registry.sendQuestion(generateId(), ...));
5be2584:packages/daemon/tests/adapter-registry.test.ts:356: ... registry.sendStatus(connId, 'thinking');
5be2584:packages/daemon/tests/adapter-registry.test.ts:364: ... registry.sendStatus(generateId(), 'idle'));
```
Every match is inside `adapter-registry.test.ts` itself — the only thing
calling `registry.sendMessage`/`sendQuestion`/`sendStatus` was the test that
exists to test them. `cli.ts` (the only place that constructs the real
`AdapterRegistry`) calls `registry.broadcast`/`sendRaw`/`trackConnection`/
`untrackConnection`/`register`/`startAll`/`startAllExcept`/`stopAll` and
nothing else. Removed the three methods and the six tests that only proved
they routed to the right adapter; replaced with a comment naming the grep and
its result. **Left `ConnectionAdapter.sendMessage/sendQuestion/sendStatus`
(the per-adapter interface members) untouched** — `TelegramAdapter.sendRaw`
still calls its own `sendMessage`/`sendQuestion`/`sendStatus` internally to
translate a generic `ProtocolMessage` into Telegram-specific sends, so those
are real, just not reachable through the registry wrapper. That is a
separate, larger, riskier removal the issue didn't ask for.

## Break-it-then-fix-it evidence

**1. Compile-time exhaustiveness guard** (`_AllKeysCovered` in
`client-message-events.ts`): removed `'onRegisterDeviceToken'` from
`CLIENT_MESSAGE_EVENT_KEYS` only —

```
$ bun run typecheck
packages/daemon/src/server/client-message-events.ts(150,7): error TS2322:
  Type '_AllKeysCovered' is not assignable to type 'true'.
```
Restored; `bun run typecheck` clean again.

**2. Runtime forwarding** (`bindConnectionId` in the same file): changed the
wrapped call from `handler(connectionId, ...args)` to `handler(...args)`
(dropping the id) —

- Dedicated unit suite (`client-message-events.test.ts`): **7 pass, 3 fail**
  (was 10/0). Failures pinpoint the exact broken invariant (`connId` missing
  from the recorded call args).
- Real two-sided suite (`packages/web/tests/lib/client-to-daemon-conformance.test.ts`,
  real `WebSocketAdapter` + real web `WebSocketClient` over one real socket):
  **9 pass, 13 fail** (was 22/0) — every one of the 13 per-message event types
  failed with `connectionId` mismatches, confirming the break is visible end
  to end, not just at the unit level.

Restored; both suites back to green (10/0 and 22/0 respectively — see
"Testing" below for the exact numbers on the restored code).

## Testing

Ran in the foreground (none backgrounded):

- `bun run typecheck` — clean.
- `bun run typecheck:web` — clean.
- `bunx biome check .` — **0 errors, 48 warnings** (matches the #918 baseline
  exactly; checked 460 files, one more than baseline for the new test file).
- `bun test` on every daemon subdirectory except `auto-approve/` (LLM tests,
  per repo convention) and the `shell-path.test.ts` known flake:
  **1895 pass, 0 fail**, 111 files, ~33s.
- `bun test packages/shared` — **424 pass, 0 fail**, 16 files.
- `bun test` in `packages/web` (full suite, including the two-sided
  conformance suites) — **502 pass, 0 fail**, 29 files.
- New `packages/daemon/tests/server/client-message-events.test.ts` — **10
  pass, 0 fail**: pins `CLIENT_MESSAGE_EVENT_KEYS` against an independently
  hand-transcribed golden list, and exercises `pickClientMessageEvents` /
  `bindConnectionId` directly (forwarding, key omission, no-leak of
  non-message keys, per-connection isolation).

Did not run: Docker integration suite (`tests/integration/run-tests.sh`,
unrelated to this change) or the macOS Swift tests (no Swift touched).

## Something the issue got right, and one thing imprecise

- **Got right**: the "AdapterEvents must stay semantic" constraint was the
  correct one to hold the line on — see Telegram evidence above.
- **Imprecise**: "four near-verbatim per-message interface declarations"
  undercounts the actual duplication and miscounts one entry. There are only
  **three** hand-declared interfaces (`ConnectionEvents`, `ServerEvents`,
  `AdapterEvents`) — `sharedEvents` in `cli.ts` is an assembled object
  literal, not a fourth declared interface, and needed zero edits in this PR.
  The bulk of the actual line-count reduction (net ~400 deletions across the
  two commits) came from the 26 hand-written **forwarding closures** in
  `websocket-server.ts` and `websocket-adapter.ts` that the issue's "Problem"
  section doesn't mention at all — those were arguably worse than the
  interface duplication itself, since a closure that forwards the wrong
  argument order is a runtime bug a type-only duplication can't produce (and
  unlike the interfaces, nothing would have caught a swapped
  `sessionId`/`bulletId` in a copy-pasted closure until a wrong value showed
  up over the wire).
- **On "if the collapse turns out not worth it"**: worth stating for the
  record — it was. The measured 10→8 edit-site delta plus a net ~400-line
  deletion concentrated in exactly the three files with the failure-prone
  hand-copied boilerplate is a real result, not marginal. I did not find a
  seam here that should have been left alone.

## Concurrency

Rebased against `develop` immediately before pushing
(`git merge-base HEAD origin/develop` == `origin/develop` HEAD, `89bdd78` —
no rebase needed, `develop` had not moved since branching). This PR's diff in
`cli.ts` is a no-op (0 lines changed). `#919`'s stated surface
(`question-presence-tracker.ts`, `auto-approve-gate.ts`,
`hook-event-bridge.ts`, `question-trace.ts`, `shared/src/types.ts`) does not
overlap this PR's files.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run typecheck:web` clean
- [x] `bunx biome check .` — 0 errors / 48 warnings
- [x] `bun test` — daemon (1895/0), shared (424/0), web (502/0)
- [x] New unit suite for the collapsed module (10/0)
- [x] Break-it-then-fix-it on both the compile-time guard and the runtime
      forwarder, against both a unit suite and a real two-sided conformance
      suite
- [x] Measured edit-site count before/after with real file lists
- [x] Fresh caller grep for the `AdapterRegistry` deletion, quoted above
- [x] Confirmed Telegram's semantic (non-wire) `AdapterEvents` usage still
      compiles and its test suite is green
