### PR TITLE
Re-touch the dir while waiting for collect

### DIFF
--- a/packages/daemon/tests/cli/live-sessions-watcher.test.ts
+++ b/packages/daemon/tests/cli/live-sessions-watcher.test.ts
@@ -213,14 +213,24 @@ describe('startLiveSessionsWatcher (#542)', () => {
           startedAt: new Date().toISOString(),
         });
 
-        // Wait for THE collect error specifically, not merely for any log line.
-        // `register()` writes a `.json.tmp` and renames it, and on Linux the
-        // watcher can emit ENOENT for the vanished temp path; its handler then
-        // logs first and `errors[0]` is that, not this test's subject (#903).
-        await waitFor(
-          () => errors.some((e) => e.includes('collect exploded')),
-          'the throwing collect to be logged',
-        );
+        // Wait for THE collect error specifically, not merely for any log line
+        // (#903): an unrelated watcher error can otherwise satisfy the wait,
+        // which is how this test used to pass without its subject ever running.
+        //
+        // Re-touch the directory while waiting. On Linux `register()`'s
+        // `.json.tmp` write+rename can make the watcher emit ENOENT; its
+        // handler closes and re-arms (`live-sessions-watcher.ts`), but the
+        // event that would have triggered the flush is already gone by the time
+        // the new watcher is listening. Without a fresh event `collect` is
+        // never called and the wait hangs to timeout -- observed in CI, never
+        // locally. The re-arm and the re-touch are both required; neither alone
+        // is sufficient.
+        const deadline = Date.now() + TEST_TIMEOUT_MS - 2000;
+        let touch = 0;
+        while (Date.now() < deadline && !errors.some((e) => e.includes('collect exploded'))) {
+          fs.writeFileSync(path.join(tmpDir, `touch-${touch++}.json`), '{}');
+          await new Promise((r) => setTimeout(r, 100));
+        }
 
         expect(broadcasts).toEqual([]);
         expect(errors.some((e) => e.includes('collect exploded'))).toBe(true);


### PR DESCRIPTION
Fixes the CI-only failure in `live-sessions-watcher.test.ts > a collect that throws is caught`, which is currently blocking #922.

## Why the earlier fix was insufficient

`4085761` (on develop) added a bounded re-arm to the watcher, which is a real product fix: a transient ENOENT was permanently disabling sibling-daemon broadcasts for a daemon lifetime. But it does not fix this test, and the failing run proved it.

Re-arming brings the watcher back after 250ms. By then the `register()` write+rename that would have triggered the flush is **already over**. A new watcher with no new event never flushes, so `collect` is never called and the wait hangs to timeout.

**Both changes are required; neither alone is sufficient.** I closed #921 (the re-touch half) prematurely, believing the re-arm covered it.

## This change

Re-touch the directory on a 100ms interval while waiting, bounded by the test timeout. A re-armed watcher then sees a fresh event and flushes. The assertion still fails honestly if `collect` is genuinely never reached, so this does not paper over a real regression.

## Honest limit on verification

**I cannot reproduce the CI condition locally.** macOS does not emit the ENOENT that Linux inotify reports for the vanished `.json.tmp`, which is why this test has always passed locally and failed in CI.

I tried simulating it by forcing the watcher to emit `error` on its first event. That simulation is harsher than reality — it re-kills after every re-arm, exhausting the 5-attempt budget, so nothing gets through and 4 tests fail. It does not model a single transient race, so I am not presenting it as validation.

Local: 6 pass, 0 fail, 3 consecutive runs. That was also true before, so it proves nothing about the failure mode. **CI is the actual test here**, and I would rather say that than imply a verification I do not have.

One thing the simulation did establish: if watcher errors recur on every re-arm, the budget exhausts and broadcasts degrade permanently, logging so explicitly. That is the intended design, not a new failure.

## Context

This test had been passing on the wrong log line before #907 — it waited for `errors.length >= 1`, which an unrelated watcher-error log satisfied, so its subject may never have run. Tightening it exposed a genuine product defect. I have now called this a "flaky test" twice and been wrong both times; the cause was in the source each time.