### PR TITLE
C9: ADRs 0012-0014 for the protocol contract

### DIFF
--- a/.context/decisions/0011-verify-before-you-describe.md
+++ b/.context/decisions/0011-verify-before-you-describe.md
@@ -15,7 +15,7 @@ hid a real defect, and two of them hid it for months.
 | "peer-to-peer, TURN relays encrypted blobs" (`AGENTS.md`) | no WebRTC exists; the Worker was the plaintext data path | #543 |
 | "auto = based on bind address" (`AuthConfig.enabled`) | resolves to `false` on every bind including `0.0.0.0` | #880 |
 | allow patterns match tool names (`config.ts`) | substring match; `Read` covered `cat x \| sh` | #536 (P0) |
-| `relay-adapter-auth.test.ts` "tests the relay adapter" | never constructs one; 29 tests that could not fail | — |
+| `relay-adapter-auth.test.ts` "tests the relay adapter" | never constructs one; 8 tests that could not fail on that claim | — |
 | "the relay is end-to-end encrypted now" | the client half was never implemented | #881 |
 
 The mechanism is consistent: **a wrong security description reads as "this is

--- a/.context/decisions/0012-protocol-message-registry.md
+++ b/.context/decisions/0012-protocol-message-registry.md
@@ -1,0 +1,118 @@
+# ADR 0012: Protocol message registry as the single source of truth
+
+**Status:** accepted
+**Date:** 2026-07-29
+**Owner:** Yahya
+
+## Context
+
+Before this change, `packages/shared/src/protocol.ts` maintained the
+`ProtocolMessage` discriminated union and the `validTypes` allowlist inside
+`isValidMessage` as two independently hand-written 45-entry lists, with
+nothing checking them against each other. Adding a message type meant
+remembering to edit both. Forgetting the second one failed silently:
+`deserialize` just returns `null` for that type, repo-wide, with no
+exception and no log line pointing at the cause.
+
+This is the type-system version of the pattern `AGENTS.md` → "Verify before
+you describe" already names for prose: two descriptions of the same thing,
+kept in sync by discipline, drift, and the drift is invisible until
+something downstream breaks.
+
+## Decision
+
+**One registration point; everything else is derived from it.**
+
+`ProtocolMessageMap` (`packages/shared/src/protocol.ts:73-119`) maps each
+wire `type` discriminant to its message interface. `ProtocolMessage` is now
+`ProtocolMessageMap[keyof ProtocolMessageMap]` (`protocol.ts:153`) instead
+of a hand-written union, so a new registry entry joins it automatically.
+`isValidMessage`'s runtime allowlist is `new Set(Object.keys(MESSAGE_DIRECTION))`
+(`VALID_TYPES`, `protocol.ts:1137`) instead of a second hand-written array.
+`MESSAGE_DIRECTION` (`protocol.ts:179-231`) tags every key `c2d` / `d2c` /
+`both`, derived from observed dispatch sites (`connection.ts`'s inbound
+switch, `App.tsx`'s and `attach-client.ts`'s handler maps), not invented —
+its own doc comment states the rule and the `ack` exception (tagged `both`
+because the daemon's router has a real accepting case for it even though
+only the daemon currently constructs one).
+
+A compile-time check, `_DiscriminantsMatch` (`protocol.ts:136-145`), proves
+every entry's interface `type` literal matches the key it is registered
+under. The obvious implementation maps a mismatch to `never` and indexes the
+whole mapped type by `keyof ProtocolMessageMap`; that does **not** work,
+because TypeScript drops `never` out of a union (`true | never` simplifies
+to `true`), so one wrong entry among 44 correct ones is silently absorbed
+and the check passes anyway — verified with `tsc --strict` against a
+deliberately mismatched two-entry registry: zero diagnostics. The issue
+text for C2 (#895) specified this broken `never` version; the implementer
+caught it during the work and proved the failure mode before shipping the
+fix. The working version maps a mismatch to `false` instead: `true | false`
+is `boolean`, not assignable to a `const _discriminantsMatch: true`
+annotation, so a mismatch is a real compile error (`protocol.ts:144`).
+
+**The golden-equality guard is hand-transcribed, not derived, on purpose.**
+`packages/shared/tests/protocol-registry.test.ts`'s `GOLDEN_TYPES`
+(lines 21-67) is the exact pre-#895 `validTypes` array, copied by hand and
+frozen. It is deliberately not imported from `MESSAGE_DIRECTION` or anything
+else in the registry, because a list generated from the thing it guards
+cannot catch that thing being wrong — if the derivation ever silently drops
+a type, a list derived from the same derivation would drop right along with
+it and the test would stay green. The same reasoning produced
+`INBOUND_ROUTED` (`protocol-registry.test.ts:104-123`), a second
+hand-transcribed list pinning which types `connection.ts`'s inbound switch
+actually accepts, used by C6 (#899) to gate `ClientToDaemonType`. This
+"pin a hand-written snapshot next to a derivation, never let the derivation
+check itself" shape is the most reusable output of the epic — it applies
+anywhere a mapped/derived type stands in for a list a human used to
+maintain by hand.
+
+## Consequences
+
+Easier: adding a message type has one canonical edit point for its wire
+definition (`ProtocolMessageMap`, plus a `MESSAGE_DIRECTION` entry).
+`ProtocolMessage` and the runtime allowlist can no longer disagree with each
+other, because there is only one list left to disagree with. A wrong
+discriminant on a new entry is now a build error instead of a message that
+silently fails to deserialize months later.
+
+Harder: `GOLDEN_TYPES` and `INBOUND_ROUTED` are frozen snapshots that must
+be updated by hand, deliberately, whenever the registry legitimately grows —
+that edit is the point, not friction to engineer away. A reviewer who
+doesn't understand why those two lists exist may look at them next to a
+freshly "derived" system and propose deleting them as redundant; that
+proposal reopens the exact hole this ADR closes.
+
+New obligation: any future derived-from-a-single-source mechanism in this
+codebase that replaces a hand-maintained list should get its own frozen,
+hand-transcribed golden test, not reuse or extend `GOLDEN_TYPES`/
+`INBOUND_ROUTED` by import.
+
+## Alternatives considered
+
+- **Status quo: keep the two hand-maintained 45-entry lists in sync by
+  discipline.** This was the defect being fixed, not a real alternative —
+  it is the exact shape that let `validTypes` silently drift from
+  `ProtocolMessage` with no test catching it.
+- **Codegen from an IDL** (e.g. generate `protocol.ts` from a schema file).
+  Rejected: it replaces one hand-maintained description with two —
+  the schema and the generated code — which is a second description that
+  can drift, the documented failure mode this repo keeps producing (see
+  ADR 0011 and the `AGENTS.md` table it codifies). A registry inside the
+  same file the types already live in has no second artifact to fall out
+  of sync.
+
+## Receipts
+
+- `packages/shared/src/protocol.ts:61-251` — `ProtocolMessageMap`,
+  `_DiscriminantsMatch`, `ProtocolMessage`, `MESSAGE_DIRECTION`,
+  `ClientToDaemonType`
+- `packages/shared/src/protocol.ts:1129-1137` — `VALID_TYPES` derivation
+- `packages/shared/tests/protocol-registry.test.ts` — `GOLDEN_TYPES`
+  (lines 21-67), `INBOUND_ROUTED` (lines 104-123), both explicitly
+  documented as not derived from the registry they guard
+- #895 (C2), #896 (C3), PR #906 (implements both; the `never`-vs-`false`
+  sentinel correction is documented in the PR body)
+- #883 (epic), comment: "The `INBOUND_ROUTED`-style pinning is the pattern
+  worth generalizing... Used twice now (`GOLDEN_TYPES` in C2,
+  `INBOUND_ROUTED` in C6-prep) and it caught the `ack` trap."
+- `AGENTS.md` → "Verify before you describe"

--- a/.context/decisions/0013-total-dispatch-handle-or-ignore.md
+++ b/.context/decisions/0013-total-dispatch-handle-or-ignore.md
@@ -1,0 +1,177 @@
+# ADR 0013: Total dispatch — every consumer declares handle-or-ignore
+
+**Status:** accepted
+**Date:** 2026-07-29
+**Owner:** Yahya
+
+## Context
+
+Before this change, every consumer of `ProtocolMessage` routed on
+`message.type` with a `switch` that had a catch-all `default`, and every
+`default` was silent: `App.tsx:1627-1630` logged `console.debug` and
+dropped the message; `attach-client.ts:252-253` was `default: break;`;
+`packages/web/src/lib/websocket-client.ts:369-371` returns from
+`deserialize` with no `else` branch when the type is unrecognized. One
+direction was already loud: `connection.ts` replies `UNKNOWN_MESSAGE` to
+the client when its inbound switch has no case for a type
+(`connection.ts:380-381` at the time of the epic's plan, now
+`route-client-message.ts` + `connection.ts:312-315`).
+
+The defect this exposes: **forgetting to handle a new message type and
+deciding that a consumer should ignore it produce identical code** — both
+are nothing. A reviewer reading a `switch` with no case for `question_snapshot`
+cannot tell whether that was a decision or an oversight, and the type
+checker cannot tell either, because a `switch` over a union does not require
+covering every member unless something in the `default` branch forces it.
+
+## Decision
+
+**Every consumer of `ProtocolMessage` must declare, for every registry key,
+either a real handler or the literal string `'ignore'`.** `MessageHandlers<TType, R>`
+(`packages/shared/src/dispatch.ts:25-27`) is a mapped type requiring one
+entry per key of `TType`; `dispatchMessage` (`dispatch.ts:33-39`) routes to
+it, returning `undefined` when the entry is `'ignore'`. Adding a key to
+`ProtocolMessageMap` breaks every `MessageHandlers<keyof ProtocolMessageMap>`
+object's compile (`Property '<type>' is missing`) until each consumer
+decides.
+
+Two equivalent shapes exist in shipped code, both migrated as part of this
+epic and both total by construction:
+
+- **Object-literal total map + `dispatchMessage`**: `attach-client.ts:234-314`
+  builds a `MessageHandlers<keyof ProtocolMessageMap, void>` with a real
+  closure per handled type and `'ignore'` for the rest (`agent_output`,
+  `hello`, `ack`, ... — lines 270-312), then calls `dispatchMessage(msg, handlers)`
+  (line 314). `route-client-message.ts` wraps the same mechanism narrowed to
+  `ClientToDaemonType` (`ClientMessageHandlers`) and is shared by
+  `connection.ts:276-311` and the relay adapter, each building its own
+  handler map over its own event bag (`ClientMessageHandlers` doc comment,
+  `route-client-message.ts:12-21`).
+- **Exhaustive `switch` + `assertNever`**: `App.tsx`'s `handleMessage`
+  (around line 1580 through 1715) keeps a `switch` but every case is now
+  explicit — including no-op groups with a comment explaining *why* they're
+  no-ops (e.g. `case 'hello': case 'user_input': ... break;` at lines
+  1648-1663, commented as "this client SENDS every one of these... should
+  never actually observe one arriving here") — and the `default` branch
+  calls `assertNever(message)` (`App.tsx:1713`, helper at `dispatch.ts:48-50`),
+  which only type-checks if every member of the union was already narrowed
+  away by an earlier `case`. A missing case is a `tsc` error, not a runtime
+  no-op.
+
+Both shapes satisfy the same property — "the compiler will not let a new
+registry key go unmentioned" — via different syntax. `App.tsx`'s explicit
+`break` groups are the `'ignore'` equivalent for a `switch`-based consumer;
+they read differently but decide the same thing.
+
+**The daemon's inbound `UNKNOWN_MESSAGE` default is deliberately kept, not
+migrated away.** `connection.ts:312-315` still sends
+`sendError('UNKNOWN_MESSAGE', ...)` when `routeClientMessage` returns
+`false`; `relay-adapter.ts`'s equivalent path replies `UNSUPPORTED` naming
+the type. This is correct because the daemon is a *server* answering a live
+peer at runtime: an unrecognized inbound type might be a real client running
+an older or newer protocol version, and the peer benefits from an explicit,
+immediate reply it can act on (log it, warn the user, fall back). A
+d2c-facing consumer like the web app has no equivalent peer to answer — the
+"error" would have to become a user-visible bug report for what is, by
+construction, a bug in shipped code (a registry key the app was never told
+about), not a live protocol negotiation. Total dispatch moves that failure
+from a silent runtime drop to a compile-time refusal to ship, which is the
+correct fix for a build-time-knowable problem; a runtime loud default
+remains the correct fix for the daemon's problem, because the daemon cannot
+know at build time what a not-yet-built client will someday send it.
+
+## Consequences
+
+Easier: a reviewer can grep `'ignore'` (or an explicit no-op `case`/`break`
+group) and see every deliberate no-delivery decision in one pass, with the
+reasoning attached as a comment at the point of decision. Adding a message
+type is now guaranteed to touch every consumer's source, even if the touch
+is one line reading `'ignore'`.
+
+Harder: the mechanical fallout of "every consumer mentions every type" is
+verbose handler maps and switches — `attach-client.ts`'s handler map alone
+is ~80 lines, most of it `'ignore'`. That verbosity is deliberate friction,
+not an oversight to clean up.
+
+**The real acceptance criterion, and that the original one was wrong.**
+#883's stated criterion was "the file count drops" — measured as
+`grep -rln "question_resolved" ... | wc -l`, which stood at 13 in the issue
+body. It was re-measured after C1-C5 and C8 landed and **had not moved**:
+still 13. The epic's own halfway-checkpoint comment records the
+correction directly: *"The file count was a bad proxy and I should not have
+written it as the criterion... exhaustiveness makes every consumer mention
+it more explicitly, not less. A file that previously swallowed the message
+in a silent `default` now names it. That is the improvement, and it looks
+identical to the grep."* A wrong metric that survives into an ADR is worse
+than no metric — it launders a discredited number into a document with
+implied authority — so it is recorded here as wrong, not restated as fact.
+
+The criterion that actually mattered was **edit sites**, measured directly
+rather than inferred from a grep on an existing type: C7 (#900, PR #922)
+added a real scratch inbound message type end-to-end twice — once on
+pristine `develop` (10 files touched) and once on the post-C7 branch
+(8 files) — then reverted both, with the drop attributed specifically to
+`websocket-server.ts`, `websocket-adapter.ts`, and `connection-adapter.ts`
+falling out of the edit set entirely once the event-interface duplication
+they carried was collapsed. That is a measured result, not an assertion.
+
+**A guard can be load-bearing and still never run on the change it guards.**
+C8 (#901, PR #910) found that `.github/workflows/macos-app.yml` is
+path-filtered to `packages/macos/**`, `packages/web/src/lib/native-host.ts`,
+`scripts/stage-macos-web.sh`, and the workflow file itself — `protocol.ts`
+is not in that list — and the workflow's own header comment states it is
+"NOT a required gate (plan decision: promote once flake behavior on macos
+runners is known)". A change to `packages/shared/src/protocol.ts` alone
+never triggers the Swift-side conformance tests C8 added at all. The TS
+mirror test (`packages/shared/tests/macos-fixture-conformance.test.ts`,
+running under the ordinary `bun test` gate) is therefore the only guard an
+ordinary protocol PR actually exercises; the Swift suite is real, correctly
+written, and currently exercised by nothing an ordinary PR triggers. This is
+a distinct failure mode from ADR 0011's "decorative-in-code" (a test that
+does not construct the thing it is named for): here the test is correct and
+would catch the break, but CI configuration keeps it from running on the
+diff that needs it. Both are worth checking for separately.
+
+## Alternatives considered
+
+- **Keep silent defaults and rely on code review to catch missed cases.**
+  This was the status quo; it already failed once in shipped code (see ADR
+  0014's `useConnectionManager.ts` case) and offers no mechanical signal —
+  a missed case and a reviewed-and-intended no-op are visually identical in
+  a diff.
+- **A runtime warning instead of a compile-time requirement** (e.g. log
+  `console.warn` for any unhandled type at dispatch time). Rejected: this
+  still ships the bug; it only makes the bug noisier after the fact instead
+  of preventing it from shipping. The whole point is to move the failure to
+  build time, when it is free to fix.
+- **One shared dispatch shape for every consumer** (force `App.tsx` onto
+  `MessageHandlers`/`dispatchMessage` instead of a `switch`+`assertNever`).
+  Not pursued: `App.tsx`'s replay/recursion handling
+  (`replay_batch` re-entering `handleMessage`, `inReplay` flag,
+  `useCallback([])` plus refs) is easier to reason about as a switch in
+  place than as an object of closures, and the compile-time guarantee is
+  identical either way. Forcing a single shape would have been uniformity
+  for its own sake, not for a functional reason — the same style of
+  rejection ADR 0009 gives for uniform transport encryption.
+
+## Receipts
+
+- `packages/shared/src/dispatch.ts` — `MessageHandlers`, `dispatchMessage`,
+  `assertNever`, all with doc comments explaining the `'ignore'` rationale
+- `packages/daemon/src/cli/attach-client.ts:234-314` — object-literal total
+  map over the full 45-key registry
+- `packages/web/src/App.tsx` (`handleMessage`, ~lines 1580-1715) —
+  exhaustive `switch` + `assertNever`, including the commented no-op groups
+- `packages/daemon/src/server/route-client-message.ts` — `ClientMessageHandlers`,
+  `routeClientMessage`, shared by `connection.ts:276-315` (loud
+  `UNKNOWN_MESSAGE`) and `relay-adapter.ts` (loud `UNSUPPORTED`)
+- `.github/workflows/macos-app.yml` — path filter and the "NOT a required
+  gate" header comment C8 cites
+- #883 (epic), halfway-checkpoint comment: the file-count criterion
+  correction, quoted above
+- #900 (C7), PR #922: the 10 → 8 measurement, and the three files
+  (`websocket-server.ts`, `websocket-adapter.ts`, `connection-adapter.ts`)
+  that dropped out of the edit set entirely
+- #901 (C8), PR #910: the macOS CI-gate finding
+- ADR 0011 — "Verify before you describe"; this ADR's CI-gate finding is a
+  sibling failure mode, not a restatement of it

--- a/.context/decisions/0014-two-sided-conformance-tests.md
+++ b/.context/decisions/0014-two-sided-conformance-tests.md
@@ -1,0 +1,188 @@
+# ADR 0014: Contract tests must construct the shipping implementation of both endpoints
+
+**Status:** accepted
+**Date:** 2026-07-29
+**Owner:** Yahya
+
+## Context
+
+Two protocol bugs shipped, live, in the same file this epic set out to
+unify — and neither was found by review, by the existing test suite, or by
+real use. Both are worth reading before the principle, because the
+principle alone undersells how ordinary each failure looked from inside its
+own PR.
+
+**Case 1 — the relay key exchange (#543, #881).** #543 shipped the
+daemon-side half of a signed ephemeral-key exchange for relay traffic.
+`createAuthResponse` (`packages/shared/src/protocol.ts:1753-1770`) takes an
+optional fourth argument, `relayKex`, carrying the client's signed ephemeral
+public key. The only production call site,
+`packages/web/src/hooks/useConnectionManager.ts:213`
+(`return createAuthResponse(identity.publicKeyRaw, signature, identity.fingerprint);`),
+never passes it. **The client half of the exchange was never written.** The
+daemon therefore rejects every real client's key exchange as
+`RELAY_KEX_FAILED`.
+
+`packages/daemon/tests/remote/relay-encryption.test.ts` stayed green
+throughout. Its `completeHandshake` helper (lines 118-171) is a test-local
+stand-in for "the way a current web client would" answer a challenge (its
+own doc comment, line 115) — and unlike the real client, it *does* build a
+`relayKex` object and pass it as the fourth argument to `createAuthResponse`
+(lines 138-149, 161-166). The test asserts the daemon's handshake logic is
+correct. It cannot, by construction, notice that nothing shipping calls
+that logic with the arguments the test supplies.
+
+**Case 2 — the relay answer handler (#915).** `connection.ts`'s
+`handleAnswer` (`connection.ts:455-475`) has forwarded structured
+AskUserQuestion `selections`/`cancel` fields since #627 — the daemon uses
+them to drive a TUI's multi-select or to escape it. `relay-adapter.ts`'s
+parallel `answer` case, a second hand-rolled implementation of the same
+routing, forwarded only `questionId`/`answer`/`claudeSessionId` — **it
+silently dropped `selections` and `cancel` for every answer that arrived
+over the relay.** Answering a multi-select question from a relay-connected
+client (the primary use case for the relay: a phone, off the LAN) silently
+lost the user's selection. This was found only when C6 (#899, PR #915) put
+the two switches next to each other in order to merge them into
+`route-client-message.ts`; the fix is now shared code
+(`connection.ts:455-475` and `relay-adapter.ts:563-579` compute the same
+`extra` shape), and `relay-adapter.ts:564-566`'s comment names the bug
+explicitly: "previously dropped over relay (found while unifying this
+dispatch)".
+
+## Decision
+
+**A contract test must construct the shipping implementation of both
+endpoints of the contract it claims to cover.** A synthetic counterparty —
+a test-local stand-in that plays "the way a real client would" without
+being the real client — silently converts a two-sided test into a one-sided
+one. The test still exercises real logic and can still fail; what it cannot
+do is notice that the *other*, real side never matches the behavior it
+assumed.
+
+The general lesson, stated plainly because it is worth more than either
+case alone: **a duplicated protocol implementation does not stay
+duplicated. It drifts, and the drift is invisible because each copy is
+individually plausible and individually tested.** Both cases above were
+live in shipped code for real users. Neither was caught by code review,
+by the pre-existing test suite, or by anyone using the feature — only by
+directly unifying the two implementations and finding they disagreed.
+
+**Honest test labelling is part of the same discipline.** C6's relay
+conformance suite,
+`packages/daemon/tests/relay-client-to-daemon-conformance.test.ts`, drives
+the real, shipping `RelayAdapter` through its `createTransport` seam (a
+fake transport standing in for the signaling Worker connection) rather than
+a real remote client, because #881 means no real client can complete a
+relay handshake — building one just for this test would itself be the
+synthetic-counterparty problem this ADR describes. Rather than let the test
+imply more coverage than it has, its module doc says so directly ("This is
+NOT an end-to-end relay test — said plainly, per AGENTS.md 'Verify before
+you describe'") and its `describe` title repeats it verbatim:
+`describe('daemon inbound dispatch: RelayAdapter transport-seam conformance (#899, NOT end-to-end)', ...)`
+(`relay-client-to-daemon-conformance.test.ts:138`). Mislabelling this test
+as end-to-end would have been the same failure this ADR exists to prevent,
+just moved one level up — a test whose name overclaims what it covers, the
+same shape as `relay-adapter-auth.test.ts` below.
+
+**`relay-adapter-auth.test.ts` remains the canonical example of the
+shape**, with one correction to how it has been described. The file has
+**8** tests (`bun test packages/daemon/tests/relay-adapter-auth.test.ts` →
+`8 pass, 0 fail`), not the 29 previously recorded for it — see "Correction"
+below. What holds regardless of count: it names `RelayAdapter` in its
+header comment ("Tests for RelayAdapter authentication and code rotation")
+and in a `describe` title ("RelayAdapter auth flow",
+`relay-adapter-auth.test.ts:53`), and never imports or constructs one — it
+tests `Authenticator` and `SignalingClient` directly. A reader who trusts
+the file name or the `describe` title over the imports would believe this
+covers `RelayAdapter`; it does not construct the thing it is named for.
+
+### Correction to prior art
+
+ADR 0011's table (`.context/decisions/0011-verify-before-you-describe.md`)
+and this epic's own issue text (#883, #902) both state
+`relay-adapter-auth.test.ts` has "29 tests that could not fail." Verified
+against the file while writing this ADR: it has 8 (`grep -c "^\s*test("
+packages/daemon/tests/relay-adapter-auth.test.ts` → 8;
+`git log -p --follow` shows only 8 `test(` lines were ever added across the
+file's history — it did not shrink during this epic). The core claim — the
+file is named for `RelayAdapter` and never constructs one — holds regardless
+of count and is the one that matters; the number was wrong and is corrected
+in the same change here and in ADR 0011, per `AGENTS.md` rule 3 ("when code
+and comment disagree, fix the comment in the same change, even when the
+behavior fix belongs to someone else"). This correction is itself a small
+instance of the pattern this ADR is about: an unverified number about test
+coverage, repeated across two documents, neither of which had run the
+suite.
+
+## Consequences
+
+Easier: a future reader can trust "N tests" and "this covers X" claims about
+a test file enough to build on them, and a reviewer has a concrete question
+to ask of any new contract test — "does this construct both real
+endpoints, or does one side pretend?" — instead of relying on the test's
+name or its green checkmark.
+
+Harder: two-sided conformance tests cost more to write than a synthetic
+counterparty, because they require the real implementation of both sides to
+be constructible in a test process at all (a real `WebSocketAdapter` and a
+real `WebSocketClient` over one real `Bun.serve` socket, in
+`client-to-daemon-conformance.test.ts` and its predecessor
+`message-dispatch-conformance.test.ts`, is the pattern this repo already
+had available before the epic — `websocket-client.test.ts` proved the seam
+years earlier). When a real second side does not exist yet — the relay's
+web client, per #881 — the honest choice is a labelled transport-seam test,
+not a synthetic client dressed up as one.
+
+New obligation: any new wire contract between two components in this repo
+gets a test that constructs both shipping sides, or an explicitly labelled
+partial test stating which side is faked and why (module doc plus
+`describe` title, matching `relay-client-to-daemon-conformance.test.ts`'s
+shape). "It has tests" is not sufficient evidence a contract is covered;
+what constructed the other end is the question that matters.
+
+## Alternatives considered
+
+- **Trust test names and `describe` titles as documentation of coverage.**
+  This was the status quo and is what let both cases above ship
+  undetected — `relay-adapter-auth.test.ts` has looked like `RelayAdapter`
+  coverage since it was written (#22).
+- **Require 100% two-sided coverage before allowing any transport-seam
+  test.** Rejected as impractical here: #881 means a real relay client does
+  not exist yet, so a strict rule would have blocked C6 (#899) entirely
+  rather than let it ship the daemon-side unification with an honestly
+  labelled gap. The labelling requirement gets the same transparency
+  without blocking work that is genuinely one-sided today for a real,
+  external reason.
+- **Fix the two found bugs and move on without a policy.** Rejected: the
+  epic's own comments call this out directly — both bugs were found by
+  coincidence, during unification work aimed at something else, using a
+  suite that had been green the whole time. Without naming the pattern,
+  the next duplicated implementation drifts the same way and gets found the
+  same way: by luck, or not at all.
+
+## Receipts
+
+- `packages/web/src/hooks/useConnectionManager.ts:213` — the missing fourth
+  argument
+- `packages/shared/src/protocol.ts:1753-1770` — `createAuthResponse`'s
+  optional `relayKex` parameter
+- `packages/daemon/tests/remote/relay-encryption.test.ts:114-171` — the
+  test-local `completeHandshake` client that offers `relayKex` when no
+  shipping client does
+- `packages/daemon/src/server/connection.ts:455-475` — `handleAnswer`,
+  forwarding `selections`/`cancel` since #627
+- `packages/daemon/src/remote/relay-adapter.ts:563-579` — the fixed relay
+  `answer` handler, comment naming the bug found during C6
+- `packages/daemon/tests/relay-client-to-daemon-conformance.test.ts:1-40,138`
+  — the module doc and `describe` title stating "NOT end-to-end"
+- `packages/daemon/tests/relay-adapter-auth.test.ts` — 8 tests (verified by
+  running the file), `RelayAdapter` named in comment and `describe` title,
+  never imported
+- #543 (relay encryption shipped), #881 (the client half never
+  implemented, found while writing an unrelated README fix)
+- #899 (C6), PR #915 — "A real bug found while unifying, now fixed"
+- #883 (epic), third comment ("The finding that actually justifies this
+  epic") — states both cases and the general lesson this ADR restates
+- `.context/decisions/0011-verify-before-you-describe.md` — corrected in
+  this change (test count)
+- `AGENTS.md` → "Verify before you describe"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ real problems for months. Known cases, all confirmed:
 | "peer-to-peer, TURN relays encrypted blobs" (this file) | no WebRTC exists; the Worker was the data path in plaintext | #543, unnoticed for months |
 | "auto = based on bind address" (`AuthConfig.enabled`) | `'auto'` resolves to `false` on every bind, `0.0.0.0` included | #880, still open |
 | allow-patterns match tool names (`config.ts`) | substring match, so `Read` covered `cat x \| sh` | #536, a P0 |
-| `relay-adapter-auth.test.ts` "tests the relay adapter" | never constructed one; 29 tests that could not fail | mandatory kex shipped uncovered |
+| `relay-adapter-auth.test.ts` "tests the relay adapter" | never constructed one; 8 tests that could not fail on that claim (corrected from a stale "29" — ADR 0014) | mandatory kex shipped uncovered |
 | "the relay is now end-to-end encrypted" (#543, believed done) | engages only when an authenticator exists, i.e. never by default | #881, found while *writing the README fix for the previous row* |
 
 The pattern is what matters: **a wrong security description reads as "this is
@@ -64,6 +64,9 @@ up", and the cleanup would reopen a security hole.
 | [0009](.context/decisions/0009-transport-encryption-scope.md) | Encryption is scoped to the relay; direct connections carry none |
 | [0010](.context/decisions/0010-allow-deny-matching-asymmetry.md) | Allow matching is precise, deny is broad — on purpose |
 | [0011](.context/decisions/0011-verify-before-you-describe.md) | Security descriptions must be verified against code |
+| [0012](.context/decisions/0012-protocol-message-registry.md) | Protocol message registry is the single source of truth |
+| [0013](.context/decisions/0013-total-dispatch-handle-or-ignore.md) | Every protocol consumer declares handle-or-ignore, total over the registry |
+| [0014](.context/decisions/0014-two-sided-conformance-tests.md) | Contract tests must construct both shipping endpoints |
 
 ## Quick Start
 


### PR DESCRIPTION
Closes #902 (C9, epic #883). Documentation only — no source changes.

## Summary

Three ADRs recording the decisions behind the protocol-contract epic, written
after every child (C1-C8, #894/#906/#912/#909/#915/#922/#910) had already
shipped, per `AGENTS.md` → "Verify before you describe": an ADR describing a
mechanism that doesn't exist yet is the exact drift this repo keeps producing.

- **[0012](.context/decisions/0012-protocol-message-registry.md)** — the
  `ProtocolMessageMap` registry as the single source of truth for
  `ProtocolMessage` and the runtime `validTypes` allowlist; the `false`-vs-`never`
  discriminant-check sentinel; why the golden-equality guard is hand-transcribed
  and deliberately not derived.
- **[0013](.context/decisions/0013-total-dispatch-handle-or-ignore.md)** —
  `MessageHandlers`/`dispatchMessage`/`assertNever` total dispatch; why
  `'ignore'` is the load-bearing idea; why the daemon's loud `UNKNOWN_MESSAGE`
  default stays while the client-facing silent ones were removed; the wrong
  acceptance criterion (file count) versus the one that mattered (edit sites,
  10 → 8); C8's finding that the macOS CI gate never runs on a `protocol.ts`
  change.
- **[0014](.context/decisions/0014-two-sided-conformance-tests.md)** — the
  policy that a contract test must construct the shipping implementation of
  both endpoints, led by the two cases that actually justify it: the relay
  key exchange (#543/#881, client half never written) and the relay answer
  handler (#915, silently dropped `selections`/`cancel`).

Also updates the ADR index table in `AGENTS.md` and fixes a stale "29 tests"
claim about `relay-adapter-auth.test.ts` in both `AGENTS.md` and ADR 0011
(details below).

## Verification against shipped code (not against the issue text)

Every claim in these three ADRs was checked against the code on `develop`
(commit `db548dd`, after PR #922/C7 merged), not copied from #883's or #902's
issue text. A sample of what was verified, with the file:line the ADR cites:

- `packages/shared/src/protocol.ts:73-119,136-153,179-231,1129-1137` — read
  `ProtocolMessageMap`, `_DiscriminantsMatch`, the derived `ProtocolMessage`,
  `MESSAGE_DIRECTION`, and `VALID_TYPES` directly; confirmed the `false`
  sentinel (not `never`) is what's actually shipped.
- `packages/shared/tests/protocol-registry.test.ts` — read `GOLDEN_TYPES`
  (lines 21-67) and `INBOUND_ROUTED` (lines 104-123) and their doc comments
  confirming both are hand-transcribed, not derived.
- `packages/daemon/src/cli/attach-client.ts:234-314` and
  `packages/web/src/App.tsx` (`handleMessage`, ~1580-1715) — read both
  consumer migrations directly. They use *different* mechanisms to reach the
  same total-dispatch property (`MessageHandlers`+`dispatchMessage` vs. an
  exhaustive `switch`+`assertNever`) — ADR 0013 was corrected mid-draft to
  describe both shapes accurately instead of assuming attach-client's shape
  applied to App.tsx too.
- `packages/daemon/src/server/connection.ts:455-475` and
  `packages/daemon/src/remote/relay-adapter.ts:563-579` — read the current
  `handleAnswer` implementations on both transports and confirmed the
  `selections`/`cancel` forwarding now matches, with `relay-adapter.ts`'s own
  comment naming the bug that was fixed.
- `packages/web/src/hooks/useConnectionManager.ts:213` — confirmed
  `createAuthResponse` is called with exactly 3 arguments (the 4th,
  `relayKex`, is never passed by the shipping web client).
- `packages/daemon/tests/remote/relay-encryption.test.ts:114-171` — read
  `completeHandshake` and confirmed it builds and passes the `relayKex`
  argument no shipping client passes.
- `packages/daemon/tests/relay-client-to-daemon-conformance.test.ts:138` —
  confirmed the `describe` title literally says `NOT end-to-end`.
- `.github/workflows/macos-app.yml` — read the path filter and confirmed
  `packages/shared/src/protocol.ts` is not in it, and the file's own header
  comment says "NOT a required gate."
- Ran `bun test packages/daemon/tests/relay-adapter-auth.test.ts` directly:
  **8 pass, 0 fail** — not the 29 tests both ADR 0011 and this epic's own
  issue text (#883, #902) claim for that file.

## Something the epic got wrong, corrected rather than repeated

Two things, both fixed in this PR instead of being carried into a new ADR:

1. **The acceptance criterion in #883 was wrong, and the epic's own halfway
   checkpoint says so.** #883 set "the file count drops" (measured via
   `grep -rln "question_resolved" ... | wc -l`, 13) as a criterion. It never
   moved — still 13 after C1-C5/C8 — because exhaustive dispatch makes every
   consumer mention a type *more* explicitly, not less. ADR 0013 records this
   as a wrong criterion, quotes the epic's own correction, and cites the
   metric that actually held up: C7 (#900, PR #922) measured edit sites
   directly by adding a scratch message type twice (10 files on pristine
   `develop` → 8 files after C7). Repeating the file-count number as if it
   were a real finding would have been exactly the kind of stale claim
   `AGENTS.md` warns about.
2. **A stale "29 tests" count for `relay-adapter-auth.test.ts`**, present in
   both ADR 0011 (already-accepted) and in this epic's own issue text
   (#883, #902). Running the file shows 8 tests; `git log -p --follow` shows
   the file has only ever had 8 `test(` calls added across its history — it
   did not shrink during this epic, the original "29" was simply wrong. The
   file's core claim — it's named for `RelayAdapter` and never constructs
   one — holds regardless of count, so ADR 0014 uses the verified number (8)
   and fixes ADR 0011's table entry in the same change, per `AGENTS.md` rule
   3 ("when code and comment disagree, fix the comment in the same change,
   even when the behavior fix belongs to someone else"). This is included in
   `AGENTS.md`'s own table too, so the correction is visible where the
   original wrong claim lives.

## Gates (foreground)

- `bun run typecheck` — clean
- `bun run typecheck:web` — clean
- `bunx biome check .` — 0 errors, 48 warnings (documented baseline, unchanged)
- `typos <changed files>` — clean
- `bun test` — full suite, foreground: 4349 pass, 0 fail, 20861 expect() calls,
  220 files, 314.81s
