### PR TITLE
Q3: extract QuestionStore, resolve hook-less questions on render-gone (#888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **`QuestionStore` is now the single owner of a session's pending-question
+  state, and a hook-less question can resolve from a screen render alone**
+  (#888). Measured from a real capture (#920): of 29 daily source-less
+  questions, 12 were never removed (one still pending 2h51m later) because
+  every removal path (`AutoApproveGate.cancelExternallyResolved`, the
+  Stop/SubagentStop sweeps) matches a tool signature carried by a hook event
+  — and a genuinely hook-less prompt (an agent-team native prompt, a bare
+  subprocess `(y/n)`) has no hook and so no signature. Its only exits were
+  the user answering it or the `MAX_PENDING_QUESTIONS` LRU cap.
+  `question-parser.ts` now sets `source: 'pty'` on every PTY-parsed question
+  (documented since #574 but never implemented, which is why this cohort was
+  invisible), and `QuestionPresenceTracker` gained a render-resolution
+  transition: when a hook-less question's render is superseded by a
+  different one, the session status leaves `'waiting'`, or the session
+  restarts, that question is removed from the store — the screen
+  disappearing IS its resolution evidence, since nothing else exists. A
+  before/after repro on the real pipeline (20 hook-paired cycles + 15
+  hook-less renders) went from 8 of 35 added never removed (7 via LRU
+  eviction) to 0 of 35.
+
+  `SessionRegistry`'s `addQuestion`/`removeQuestion`/`clearQuestions`/
+  `getQuestion` are now thin adapters over a new `QuestionStore`
+  (`packages/daemon/src/session/question-store.ts`), which is the only code
+  that mutates the pending-question map; `ManagedSession.currentQuestions`
+  is a live, read-only view over it. Review also found and fixed a second,
+  related bug: `QuestionPresenceTracker`'s hook/PTY merge silently took the
+  PTY parse's `source` even for a hook-paired (parked-then-rendered
+  subagent permission) question, which meant `pending-question-label.ts`'s
+  `source === 'permission_request'` branch never fired for that class —
+  the macOS menu-bar app and hub census showed the full raw prompt text
+  instead of the intended short "Permission: `<tool>`" label. The hook
+  record's own `source` now wins, matching the existing text/options/
+  agentId precedent.
+
+  The gate's own per-question bookkeeping (`AutoApproveGate`'s
+  `pendingHolds`/`openQuestionSignatures`/`parkedInputs`/`evalIdByQuestion`/
+  `confirmedDeliveries`, `QuestionPresenceTracker`'s `pending`/`awaitingPTY`/
+  `bufferedDuringEval`/`armedOrphanQuestion`) is intentionally left as a
+  follow-up: each is metadata about resolving a question the store already
+  owns, not a second opinion on whether it is pending, and collapsing it
+  into one state machine safely needs the same trace-driven verification
+  each earned individually (#751/#763/#767/#814). The PTY-as-arbiter policy
+  (ADR 0004) is unchanged — only bookkeeping moved, never a push/arbitration
+  decision.
+
 - **A question is now identified by one id for its whole prompt cycle**
   (#887). Up to three ids used to exist for a single subagent permission: the
   hook bridge minted one at `PermissionRequest`, the PTY parser minted a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,31 @@ All notable changes to Remi are documented here.
   `question-parser.ts` now sets `source: 'pty'` on every PTY-parsed question
   (documented since #574 but never implemented, which is why this cohort was
   invisible), and `QuestionPresenceTracker` gained a render-resolution
-  transition: when a hook-less question's render is superseded by a
-  different one, the session status leaves `'waiting'`, or the session
-  restarts, that question is removed from the store — the screen
-  disappearing IS its resolution evidence, since nothing else exists. A
-  before/after repro on the real pipeline (20 hook-paired cycles + 15
-  hook-less renders) went from 8 of 35 added never removed (7 via LRU
-  eviction) to 0 of 35.
+  transition: when a CONFIRMED replacement push supersedes a hook-less
+  question, the original is removed from the store — the screen disappearing
+  IS its resolution evidence, since nothing else exists.
+
+  A first version of this compared the PTY-parsed render's id alone and also
+  treated a status-leaves-`'waiting'` transition or a session restart as
+  resolution evidence. Review found both unsound and reachable in
+  production: the PTY parser mints a fresh id on every parse even for a
+  prompt that merely redraws (#486), and `cli.ts` calls
+  `tracker.onStatusChange` unconditionally while gating the paired
+  `QuestionDedup` reset behind `!hookServer` — so a PTY-text-parsed status
+  false positive (confidence >= 0.5, not certainty) could resolve a question
+  whose "replacement" render was then silently deduped, telling the client
+  a still-live prompt was cancelled. Fixed: resolution now fires ONLY once a
+  new dep, `isQuestionLive`, confirms the replacement actually landed in
+  the store (not suppressed by dedup); the status and restart triggers were
+  dropped entirely rather than patched, since neither can be trusted as
+  evidence for one specific question (a real restart already resolves
+  everything via the pre-existing `resolveAndClearQuestions`). A before/
+  after repro on the real pipeline (20 hook-paired cycles + 15 hook-less
+  renders, each a genuinely distinct render) went from 8 of 35 added never
+  removed (7 via LRU eviction) to 0 of 35; a separate integration suite
+  drives the real `MessageAPI`/`QuestionDedup` and reproduces the
+  flap-then-redraw chain directly, pinning that a deduped replacement no
+  longer swallows the original.
 
   `SessionRegistry`'s `addQuestion`/`removeQuestion`/`clearQuestions`/
   `getQuestion` are now thin adapters over a new `QuestionStore`

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -43,6 +43,16 @@
  * way, a PTY-only push path (no preceding hook record) stays a first-class
  * case in this tracker, not a fallback -- it just is not the ONLY source for
  * subagent prompts the way this comment previously implied.
+ *
+ * Render-resolution (#888/#920): a PTY-only pushed question has no hook and
+ * so no tool signature for `AutoApproveGate` to resolve it by -- its only
+ * exits used to be the user answering it or the `MAX_PENDING_QUESTIONS` LRU
+ * cap, which measured as a real leak (12 of 29 source-less questions never
+ * removed in one working day's capture, one still pending 2h51m later).
+ * `observedHooklessQuestion` + `deps.onHooklessQuestionGone` close that gap:
+ * the render disappearing (superseded by a different render, status leaving
+ * 'waiting', or `clearPending`) IS the resolution evidence for this cohort.
+ * See `pairAndPush` and `noteHooklessGone`.
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';
@@ -152,6 +162,32 @@ export interface QuestionPresenceTrackerDeps {
   orphanDebounceMs?: number;
   /** Clock override for the parked-record TTL (#763). Defaults to Date.now. */
   nowMs?: () => number;
+  /**
+   * The render-resolution transition (#888/#920 hard requirement): fired when
+   * a genuinely HOOK-LESS pending question's only evidence -- the PTY render
+   * -- is gone. A hook-less question (no PermissionRequest/Notification ever
+   * fired for it: an agent-team native prompt, a bare subprocess `(y/n)`) has
+   * no tool signature for `AutoApproveGate.cancelExternallyResolved` or the
+   * Stop/SubagentStop sweeps to match, so absent this callback it can leave
+   * `SessionRegistry.currentQuestions` only via the user answering it or the
+   * `MAX_PENDING_QUESTIONS` LRU cap -- the #920 measured leak (12 of 29
+   * source-less questions never removed over one working day, one still
+   * pending 2h51m later).
+   *
+   * Fires from `pairAndPush` (a DIFFERENT render superseded the tracked
+   * hook-less one -- see `observedHooklessQuestion`), `onStatusChange`
+   * (status left 'waiting': Claude moved on), and `clearPending` (restart/
+   * rotation). Does NOT touch push/arbitration decisions (ADR 0004
+   * unchanged) -- this only tells the caller a PREVIOUSLY PUSHED question's
+   * evidence is gone, so it can be removed from the pending store.
+   *
+   * MUST be synchronous and non-throwing (same contract as
+   * `hasLiveQuestions`): invoked with no surrounding try/catch at most call
+   * sites, but a throw is still caught internally and logged, never
+   * propagated. `reason` is a short signal string carried onto the
+   * question-lifecycle trace.
+   */
+  onHooklessQuestionGone?: (questionId: string, reason: string) => void;
 }
 
 export class QuestionPresenceTracker {
@@ -213,6 +249,28 @@ export class QuestionPresenceTracker {
    *  and answering the second with the first's verdict is the same answer to
    *  the same question, which is why that collapse is acceptable. */
   private observedPTYText: string | null = null;
+
+  /**
+   * The id of the currently-PUSHED hook-less question, if any (#888/#920).
+   * Set by `pairAndPush` when a merge produces a question with NO pairing
+   * hook record (`hookRecord === undefined` in `consumeAndMerge` -- a
+   * genuinely hook-less prompt), cleared (and `deps.onHooklessQuestionGone`
+   * fired) the moment that evidence is gone: a DIFFERENT render supersedes it
+   * (see `pairAndPush`), status leaves 'waiting', or `clearPending` runs.
+   *
+   * Distinct from `observedPTYQuestionId` (the RAW pre-merge PTY parse id,
+   * used for arbiter identity per ADR 0004) because the id that matters here
+   * is the one actually registered in `SessionRegistry.currentQuestions` --
+   * for a hook-less question that IS the same value (no merge changes it),
+   * but tracking it separately keeps this mechanism decoupled from the
+   * arbitration-identity fields it must not affect.
+   *
+   * A hook-PAIRED question is never tracked here: it already has a
+   * signature-matched removal path (`AutoApproveGate.cancelExternallyResolved`
+   * / the Stop sweeps), so this mechanism -- scoped tightly to the one cohort
+   * that has no other exit -- leaves it alone.
+   */
+  private observedHooklessQuestion: string | null = null;
 
   /** Count of MAIN-context auto-approve evals in flight. A PTY prompt that
    *  appears while this is > 0 is BUFFERED (not pushed): if the verdict is
@@ -499,9 +557,43 @@ export class QuestionPresenceTracker {
    * re-capture a prompt that has already won its arbitration.
    */
   private pairAndPush(ptyQuestion: Question): void {
-    const { merged } = this.consumeAndMerge(ptyQuestion);
+    const { merged, hookRecord } = this.consumeAndMerge(ptyQuestion);
+    // #888/#920 render-resolution: the PTY parser mints a FRESH id on every
+    // parse (#486), so a hook-less merge (`hookRecord === undefined`) always
+    // differs in id from whatever hook-less question was tracked before --
+    // that PREVIOUS one's only evidence (its render) is by definition gone
+    // now, whether because it was answered/superseded by a genuinely new
+    // prompt, or merely redrew past the #718/QuestionDedup window under a new
+    // id. Either way its registry entry is now stale; resolve it before
+    // tracking the new one. A hook-PAIRED merge never touches this (its id is
+    // adopted from the hook per #887 and has its own removal path).
+    if (this.observedHooklessQuestion !== null && this.observedHooklessQuestion !== merged.id) {
+      this.noteHooklessGone('pty_render_superseded');
+    }
+    this.observedHooklessQuestion = hookRecord === undefined ? merged.id : null;
     this.ptyShowingQuestion = true;
     this.pushMerged(merged);
+  }
+
+  /**
+   * Clear and report the currently-tracked hook-less question as gone
+   * (#888/#920), if one is tracked. No-op when `observedHooklessQuestion` is
+   * null (nothing to resolve) or no `onHooklessQuestionGone` dep is wired
+   * (pre-#888 behavior: hook-less questions are never actively resolved).
+   * The dep is invoked outside any try/catch at some call sites, so a throw
+   * is caught and logged here rather than trusted to the caller.
+   */
+  private noteHooklessGone(reason: string): void {
+    const id = this.observedHooklessQuestion;
+    if (id === null) return;
+    this.observedHooklessQuestion = null;
+    try {
+      this.deps.onHooklessQuestionGone?.(id, reason);
+    } catch (err) {
+      console.error(
+        `[QuestionPresenceTracker] onHooklessQuestionGone threw for ${id.slice(0, 8)} (${reason}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   /**
@@ -571,6 +663,17 @@ export class QuestionPresenceTracker {
             options: useHookOptions ? [...hookRecord.options] : [...ptyQuestion.options],
             agentId: ptyQuestion.agentId ?? hookRecord.agentId,
             promptId: hookRecord.promptId ?? ptyQuestion.promptId,
+            // #888 review finding: the `...ptyQuestion` spread above silently
+            // carried `ptyQuestion.source` ('pty', once question-parser sets
+            // it -- #920) onto a HOOK-PAIRED merged question, which has a
+            // signature-matched removal path (`openQuestionSignatures`) a
+            // genuinely hook-less question does not. Left uncorrected, adding
+            // `source: 'pty'` to the parser would have mislabeled every
+            // hook-paired render as the unresolvable-by-signature cohort,
+            // muddying the exact measurement #920's acceptance criterion asks
+            // for. The hook's own source ('permission_request' | 'notification')
+            // is authoritative here, mirroring text/options/agentId above.
+            source: hookRecord.source ?? ptyQuestion.source,
             // #718 review: `optionsAreFallback` must describe whichever
             // `options` ended up on the merged question, not silently inherit
             // whatever `ptyQuestion` happened to carry from the `...ptyQuestion`
@@ -906,6 +1009,11 @@ export class QuestionPresenceTracker {
       // #814: nothing is on screen now.
       this.observedPTYQuestionId = null;
       this.observedPTYText = null;
+      // #888/#920: the screen just cleared. If a hook-less question was being
+      // tracked as the reason it was still pending, that evidence is gone --
+      // resolve it now rather than let it wait for a signal (a tool call,
+      // an LRU eviction) that will never come for a hook-less prompt.
+      this.noteHooklessGone('pty_status_left_waiting');
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
       this.mainEvalsInFlight = 0;
@@ -994,6 +1102,9 @@ export class QuestionPresenceTracker {
     this.ptyShowingQuestion = false;
     this.observedPTYQuestionId = null;
     this.observedPTYText = null;
+    // #888/#920: same reasoning as the status reset -- the session is
+    // restarting/rotating, so a tracked hook-less question's render is gone.
+    this.noteHooklessGone('pty_clear_pending');
     this.mainEvalsInFlight = 0;
     this.bufferedDuringEval = null;
     this.pushedHeldIds.clear();
@@ -1104,5 +1215,11 @@ export class QuestionPresenceTracker {
   /** Test-only: parked-render arbitrations awaiting a verdict (#814). */
   parkedArbitrationsForTest(): number {
     return this.arbitratingPTYTexts.length;
+  }
+
+  /** Test-only: the id of the currently-tracked hook-less question, if any
+   *  (#888/#920), or null when none is tracked. */
+  observedHooklessQuestionForTest(): string | null {
+    return this.observedHooklessQuestion;
   }
 }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -49,10 +49,18 @@
  * exits used to be the user answering it or the `MAX_PENDING_QUESTIONS` LRU
  * cap, which measured as a real leak (12 of 29 source-less questions never
  * removed in one working day's capture, one still pending 2h51m later).
- * `observedHooklessQuestion` + `deps.onHooklessQuestionGone` close that gap:
- * the render disappearing (superseded by a different render, status leaving
- * 'waiting', or `clearPending`) IS the resolution evidence for this cohort.
- * See `pairAndPush` and `noteHooklessGone`.
+ * `observedHooklessQuestion` + `deps.onHooklessQuestionGone` close that gap,
+ * but ONLY on a CONFIRMED-delivered replacement push in `pairAndPush` --
+ * `deps.isQuestionLive` is the confirmation gate. An id-comparison-only
+ * version of this (this file's own V1) could resolve a question that never
+ * actually left the screen: the PTY parser mints a fresh id on every parse
+ * regardless of content (#486), and the replacement's own push can be
+ * silently eaten by `QuestionDedup`'s 5s window -- found in review, see
+ * `isQuestionLive`'s doc for the full failure chain. Status-leaves-'waiting'
+ * and `clearPending` were dropped as triggers for the same reason (both can
+ * fire on a signal unrelated to whether THIS question's render is actually
+ * gone); see their own reset comments. See `pairAndPush` and
+ * `noteHooklessGone`.
  */
 
 import { MAIN_AGENT_ID } from '@remi/shared';
@@ -174,10 +182,11 @@ export interface QuestionPresenceTrackerDeps {
    * source-less questions never removed over one working day, one still
    * pending 2h51m later).
    *
-   * Fires from `pairAndPush` (a DIFFERENT render superseded the tracked
-   * hook-less one -- see `observedHooklessQuestion`), `onStatusChange`
-   * (status left 'waiting': Claude moved on), and `clearPending` (restart/
-   * rotation). Does NOT touch push/arbitration decisions (ADR 0004
+   * Fires ONLY from `pairAndPush`, and ONLY once `isQuestionLive` (below)
+   * CONFIRMS the replacement that superseded it actually landed -- see that
+   * dep's doc for why an id/status/restart-based trigger without that
+   * confirmation is unsound (found in review of the first version of this
+   * mechanism, #888). Does NOT touch push/arbitration decisions (ADR 0004
    * unchanged) -- this only tells the caller a PREVIOUSLY PUSHED question's
    * evidence is gone, so it can be removed from the pending store.
    *
@@ -188,6 +197,49 @@ export interface QuestionPresenceTrackerDeps {
    * question-lifecycle trace.
    */
   onHooklessQuestionGone?: (questionId: string, reason: string) => void;
+  /**
+   * True iff `questionId` is CURRENTLY registered as pending
+   * (`sessionRegistry.getQuestion(sessionId, id) !== null`). The sole
+   * confirmation gate for `onHooklessQuestionGone` (#888 review fix).
+   *
+   * V1 of this mechanism compared the PTY-parsed render's `id` alone: "a
+   * different id arrived, so the old one must be superseded." That is
+   * unsound on two fronts, both found in review:
+   *   1. The PTY parser mints a FRESH id on every single parse (#486), even
+   *      when a prompt merely REDRAWS with unchanged text -- the exact
+   *      hazard `isPromptCurrent`'s own text fallback already documents
+   *      elsewhere in this file ("a prompt that merely redraws re-emits
+   *      under a fresh id ... matching on the id alone would call a live
+   *      prompt gone"). V1 applied no such guard to this mechanism.
+   *   2. Even a GENUINELY different render can be silently swallowed by
+   *      `QuestionDedup`'s 5s same-fingerprint window before it ever reaches
+   *      `SessionRegistry.addQuestion` -- and V1 resolved the OLD id
+   *      regardless, on the strength of the new render having merely been
+   *      PARSED, not actually delivered. Reachable in production: a false-
+   *      positive PTY-text status parse (`output-processor.ts`'s >= 0.5
+   *      confidence gate) flips status out of 'waiting' without resetting
+   *      `QuestionDedup` (cli.ts only resets it when no hook server is
+   *      active), status flips back to 'waiting' with the SAME prompt still
+   *      on screen, the redraw parses under a fresh id, and dedup silently
+   *      eats it -- net effect: the daemon told the client the question was
+   *      cancelled while the identical prompt sat unanswered on the real
+   *      screen. That is the disqualifying failure for this epic.
+   *
+   * `isQuestionLive` closes both: `pairAndPush` calls `deps.push(merged)`
+   * FIRST (synchronously; nothing in the push -> `MessageAPI.handleQuestion`
+   * -> `QuestionDedup` -> `SessionRegistry.addQuestion` chain is async), THEN
+   * asks this dep whether `merged.id` actually landed. Only a CONFIRMED
+   * landing is evidence the previously-tracked hook-less question is gone;
+   * an unconfirmed (deduped, or the dep unset) push changes nothing --
+   * `observedHooklessQuestion` is left exactly as it was, matching the "fail
+   * toward showing" rule every other ambiguous path in this codebase follows
+   * (`auto-approve-gate.ts`, "every ambiguous path resolves toward showing
+   * the user"). Defaults to `false` (not confirmed) when unset: losing this
+   * ONE resolution trigger is an acceptable cost; swallowing a live question
+   * is not. MUST be synchronous and non-throwing, called inline with no
+   * surrounding try/catch.
+   */
+  isQuestionLive?: (questionId: string) => boolean;
 }
 
 export class QuestionPresenceTracker {
@@ -558,21 +610,26 @@ export class QuestionPresenceTracker {
    */
   private pairAndPush(ptyQuestion: Question): void {
     const { merged, hookRecord } = this.consumeAndMerge(ptyQuestion);
-    // #888/#920 render-resolution: the PTY parser mints a FRESH id on every
-    // parse (#486), so a hook-less merge (`hookRecord === undefined`) always
-    // differs in id from whatever hook-less question was tracked before --
-    // that PREVIOUS one's only evidence (its render) is by definition gone
-    // now, whether because it was answered/superseded by a genuinely new
-    // prompt, or merely redrew past the #718/QuestionDedup window under a new
-    // id. Either way its registry entry is now stale; resolve it before
-    // tracking the new one. A hook-PAIRED merge never touches this (its id is
-    // adopted from the hook per #887 and has its own removal path).
+    this.ptyShowingQuestion = true;
+    this.pushMerged(merged);
+    // #888/#920 render-resolution, CONFIRMED-delivery gate (see
+    // `isQuestionLive`'s doc for why an id comparison alone is unsound). The
+    // push above is synchronous end to end (push -> MessageAPI.handleQuestion
+    // -> QuestionDedup -> SessionRegistry.addQuestion), so by this line the
+    // registry already reflects whether `merged` actually landed.
+    const delivered = this.deps.isQuestionLive?.(merged.id) ?? false;
+    if (!delivered) {
+      // Not confirmed (deduped, or the dep is unset): nothing is known to
+      // have changed. Leave `observedHooklessQuestion` exactly as it was --
+      // if it was tracking an older id, that question is STILL the best
+      // evidence of what's on screen, and must not be resolved on the
+      // strength of a replacement that never actually registered.
+      return;
+    }
     if (this.observedHooklessQuestion !== null && this.observedHooklessQuestion !== merged.id) {
       this.noteHooklessGone('pty_render_superseded');
     }
     this.observedHooklessQuestion = hookRecord === undefined ? merged.id : null;
-    this.ptyShowingQuestion = true;
-    this.pushMerged(merged);
   }
 
   /**
@@ -1009,11 +1066,16 @@ export class QuestionPresenceTracker {
       // #814: nothing is on screen now.
       this.observedPTYQuestionId = null;
       this.observedPTYText = null;
-      // #888/#920: the screen just cleared. If a hook-less question was being
-      // tracked as the reason it was still pending, that evidence is gone --
-      // resolve it now rather than let it wait for a signal (a tool call,
-      // an LRU eviction) that will never come for a hook-less prompt.
-      this.noteHooklessGone('pty_status_left_waiting');
+      // #888/#920 review fix: deliberately NOT a hook-less resolution trigger.
+      // `status` here can come from a PTY-TEXT-parsed guess
+      // (`output-processor.ts`, confidence >= 0.5, not certainty) as well as
+      // a real hook event, and the tracker cannot tell which -- V1 treated
+      // any status-leaves-waiting as "the render is gone" and a false
+      // positive could resolve a question that never actually left the
+      // screen (found in review of #888). `observedHooklessQuestion` is
+      // deliberately left untouched (not even nulled) so a LATER, genuinely
+      // CONFIRMED supersession in `pairAndPush` can still resolve it --
+      // losing this trigger costs a delayed cleanup, not a wrong one.
       // The verdict window is over: any buffered prompt was auto-handled (the
       // agent advanced) or left the screen. Discard it — do not ping the user.
       this.mainEvalsInFlight = 0;
@@ -1102,9 +1164,20 @@ export class QuestionPresenceTracker {
     this.ptyShowingQuestion = false;
     this.observedPTYQuestionId = null;
     this.observedPTYText = null;
-    // #888/#920: same reasoning as the status reset -- the session is
-    // restarting/rotating, so a tracked hook-less question's render is gone.
-    this.noteHooklessGone('pty_clear_pending');
+    // #888/#920 review fix: deliberately NOT a hook-less resolution trigger,
+    // for the SAME reason as `onStatusChange` -- see that reset's comment.
+    // `clearPending` is not restart-exclusive: `AutoApproveGate` also calls
+    // it on a CANCELLED eval for one specific hook-derived question, which
+    // says nothing about whether some unrelated hook-less question (a
+    // different agent's native prompt) is still genuinely on screen. The one
+    // call site that IS a real restart (`TranscriptBinder.onRotation` via
+    // `hook-bridge-setup.ts`) already resolves every pending question,
+    // hook-less or not, through `resolveAndClearQuestions` +
+    // `sessionRegistry.clearQuestions` immediately alongside this call --
+    // so this method adds no coverage a genuine restart still needs, and
+    // firing it from the cancelled-eval call sites would have reintroduced
+    // the exact "resolve a still-live question on an unrelated signal" class
+    // this whole review fix exists to close.
     this.mainEvalsInFlight = 0;
     this.bufferedDuringEval = null;
     this.pushedHeldIds.clear();

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1523,6 +1523,25 @@ async function createNewSession(
   // escalation (already registered here) apart from a genuine orphan.
   const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts), {
     hasLiveQuestions: () => (sessionRegistry.getSession(sessionId)?.currentQuestions.size ?? 0) > 0,
+    // #888/#920 hard requirement: a hook-less pending question (no
+    // PermissionRequest/Notification ever fired for it) has no tool
+    // signature for AutoApproveGate to resolve it by, so its PTY render
+    // disappearing is its ONLY resolution evidence -- see the tracker's own
+    // module doc. Remove it from the single pendingness owner (which
+    // broadcasts question_snapshot via onQuestionsChanged, #798) and fire the
+    // SAME question_resolved + APNS-dismiss path every other cancellation
+    // route uses (`onQuestionResolved`, defined below in this file) so a
+    // client sees the card clear immediately, not only on the next snapshot.
+    onHooklessQuestionGone: (questionId, reason) => {
+      sessionRegistry.removeQuestion(
+        sessionId,
+        questionId as UUID,
+        reason,
+        undefined,
+        'QuestionPresenceTracker.onHooklessQuestionGone',
+      );
+      onQuestionResolved(sessionId, questionId as UUID, 'cancelled');
+    },
   });
 
   const outputProcessor = new OutputProcessor(

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1542,6 +1542,14 @@ async function createNewSession(
       );
       onQuestionResolved(sessionId, questionId as UUID, 'cancelled');
     },
+    // Confirmation gate for the above (#888 review fix): only a push that
+    // ACTUALLY landed in the single pendingness owner is evidence a
+    // previously-tracked question was superseded -- see
+    // `isQuestionLive`'s doc on the tracker for the swallow class this
+    // closes (a redraw's replacement push silently eaten by QuestionDedup
+    // must not resolve the still-live original).
+    isQuestionLive: (questionId) =>
+      sessionRegistry.getQuestion(sessionId, questionId as UUID) !== null,
   });
 
   const outputProcessor = new OutputProcessor(

--- a/packages/daemon/src/parser/question-parser.ts
+++ b/packages/daemon/src/parser/question-parser.ts
@@ -277,6 +277,19 @@ function createQuestion(
     options,
     allowsFreeText,
     isAnswered: false,
+    // #920/#888: every PTY-parsed question is source 'pty' by construction --
+    // this is the ONLY parser in the daemon that mints a Question straight
+    // from screen text, never from a hook. Undocumented before this (the
+    // shared type's own doc said "PTY-parsed prompts are 'pty'" but nothing
+    // ever set it), which is why the resulting source-less cohort was
+    // invisible in the #808/#920 capture: 12 of 29 added were never removed.
+    // `QuestionPresenceTracker.consumeAndMerge` overrides this with the
+    // hook's own `source` when a hook record pairs with the render (a
+    // hook-paired question DOES have a removal path via the tool signature);
+    // this default only survives to a client-visible question for a
+    // genuinely hook-less prompt, which is exactly the cohort #888's
+    // render-resolution transition exists to resolve.
+    source: 'pty',
   };
 }
 

--- a/packages/daemon/src/session/index.ts
+++ b/packages/daemon/src/session/index.ts
@@ -32,3 +32,5 @@ export {
 } from './pending-question-label.ts';
 
 export { PendingQuestionCreatedAtTracker } from './pending-question-created-at-tracker.ts';
+
+export { QuestionStore, type QuestionStoreEvents } from './question-store.ts';

--- a/packages/daemon/src/session/question-store.ts
+++ b/packages/daemon/src/session/question-store.ts
@@ -1,0 +1,181 @@
+/**
+ * QuestionStore — single owner of a session's pending-question map (#888).
+ *
+ * Extracted from `SessionRegistry`, which used to mutate `currentQuestions`
+ * (add / evict / remove / clear) directly inline, each site independently
+ * emitting its own question-lifecycle trace record. After this change, grep
+ * for `.set(` / `.delete(` / `.clear(` on a pending-question map anywhere in
+ * `packages/daemon/src` turns up only this file. `SessionRegistry`'s
+ * `addQuestion` / `removeQuestion` / `clearQuestions` / `getQuestion` keep
+ * their exact pre-existing signatures (#888's explicit ask) and become thin
+ * adapters, so no call site -- production or test -- needs to change.
+ *
+ * `ManagedSession.currentQuestions` stays a real, live view over THIS
+ * store's own map (not a copy taken at some point in time) -- so every
+ * existing `.get` / `.has` / `.size` / `.values` / `.keys` read call site
+ * keeps working completely unchanged; only the ability to mutate it moved
+ * here, and is enforced at the type level (`ReadonlyMap`).
+ *
+ * Scope note (#888 PR body): this consolidates ONLY the pendingness map
+ * itself -- "is this question still awaiting an answer, and what is it."
+ * The gate's own bookkeeping about a pending question it already knows about
+ * (`AutoApproveGate`'s `pendingHolds` / `openQuestionSignatures` /
+ * `parkedInputs` / `evalIdByQuestion` / `confirmedDeliveries`,
+ * `QuestionPresenceTracker`'s `pending` / `awaitingPTY` / `bufferedDuringEval`
+ * / `armedOrphanQuestion`) is left as-is: each is metadata about HOW to
+ * resolve a question this store already owns (an open auto-approve eval, a
+ * held hook, a parked PTY-arbitration record), not a second, competing
+ * opinion on WHETHER it is pending. Folding those in too was judged too
+ * large and too risky for one PR given how much of #751/#763/#767/#814's
+ * hard-won correctness lives in their exact current shape (see the PR
+ * description for the full reasoning) -- scoped out as follow-up work.
+ */
+
+import type { Question, UUID } from '@remi/shared';
+import { traceQuestionEvent } from './question-trace.ts';
+
+/** Upper bound on concurrently-pending questions per session. Real prompts are
+ *  few (main + a handful of subagents); the cap is a backstop against a runaway
+ *  prompt loop growing the map unbounded. Oldest is evicted first. */
+const MAX_PENDING_QUESTIONS = 8;
+
+/** Events emitted by QuestionStore. */
+export interface QuestionStoreEvents {
+  /** Fires with the FULL current set after every add / remove / evict / clear
+   *  (never a delta), so a caller mirroring this into another store (the
+   *  live-sessions registry file, `question_snapshot` broadcast) can always
+   *  overwrite rather than merge. */
+  onQuestionsChanged?: (questions: readonly Question[]) => void;
+}
+
+export class QuestionStore {
+  /** The ONE map of pending questions for this session. Nothing outside this
+   *  class may mutate it -- see the class doc. */
+  private readonly map = new Map<UUID, Question>();
+
+  constructor(
+    private readonly sessionId: UUID,
+    private readonly events: QuestionStoreEvents = {},
+  ) {}
+
+  /** Read-only live view. Same underlying Map instance every call (not a
+   *  snapshot copy), so `.get`/`.has`/`.size`/`.values`/`.keys` always reflect
+   *  the current state -- callers just cannot `.set`/`.delete`/`.clear` it. */
+  get questions(): ReadonlyMap<UUID, Question> {
+    return this.map;
+  }
+
+  /**
+   * Register a pending question. Multiple can coexist (main + subagent); each
+   * is tracked by its own id so answering one never invalidates another.
+   * Bounded by MAX_PENDING_QUESTIONS (oldest evicted first) so a runaway
+   * prompt loop cannot grow the map without limit.
+   *
+   * `callSite` (#887/#888) names the internal caller for the question-trace;
+   * `SessionRegistry.addQuestion` passes its own name so the trace is
+   * byte-for-byte unchanged from before this extraction.
+   */
+  add(question: Question, signal = 'unknown', callSite = 'QuestionStore.add'): void {
+    this.map.delete(question.id); // re-insert so a refreshed question is "newest"
+    this.map.set(question.id, question);
+    while (this.map.size > MAX_PENDING_QUESTIONS) {
+      const oldest = this.map.keys().next().value;
+      if (oldest === undefined) break;
+      const evicted = this.map.get(oldest);
+      this.map.delete(oldest);
+      // Log: an evicted prompt may have an outstanding APNS push whose answer
+      // will now be refused as STALE_ANSWER. Should be unreachable in normal
+      // use (cap is generous); a hit signals a runaway prompt loop -- or,
+      // pre-#888/#920, a hook-less question with no other removal path.
+      console.warn(
+        `[QuestionStore] pending-question cap (${MAX_PENDING_QUESTIONS}) exceeded; evicted oldest id=${oldest} text="${evicted?.text.slice(0, 60) ?? ''}"`,
+      );
+      // #808: an LRU eviction is a removal too -- it never goes through
+      // remove() (there is no single questionId call site for it), so trace
+      // it here directly rather than let it appear as a silent gap.
+      traceQuestionEvent({
+        action: 'remove',
+        sessionId: this.sessionId,
+        questionId: oldest,
+        promptId: evicted?.promptId,
+        agentId: evicted?.agentId,
+        isSubagent: evicted?.agentId !== undefined,
+        signal: 'lru_eviction',
+        callSite: `${callSite}:lru_eviction`,
+        throughFunnel: true,
+      });
+    }
+    this.notifyChanged();
+    traceQuestionEvent({
+      action: 'add',
+      sessionId: this.sessionId,
+      questionId: question.id,
+      promptId: question.promptId,
+      agentId: question.agentId,
+      isSubagent: question.agentId !== undefined,
+      signal,
+      callSite,
+    });
+  }
+
+  /** Remove one answered/resolved question by id. `signal` (#808) names the
+   *  event/reason that caused the removal (e.g. 'PostToolUse', 'Stop',
+   *  'user_answer', 'pty_render_superseded'); `toolName`, when the caller
+   *  knows it, is carried onto the same record. `callSite` (#887) names the
+   *  internal caller -- threaded through, NOT hardcoded, so two records
+   *  naming the default cannot be mistaken for proof of a double-fire from
+   *  one path (see `question-trace.ts`'s own KNOWN LIMIT note). */
+  remove(
+    questionId: UUID,
+    signal = 'unknown',
+    toolName?: string,
+    callSite = 'QuestionStore.remove',
+  ): void {
+    const existing = this.map.get(questionId);
+    this.map.delete(questionId);
+    this.notifyChanged();
+    traceQuestionEvent({
+      action: 'remove',
+      sessionId: this.sessionId,
+      questionId,
+      promptId: existing?.promptId,
+      agentId: existing?.agentId,
+      isSubagent: existing?.agentId !== undefined,
+      toolName,
+      signal,
+      callSite,
+      throughFunnel: true,
+    });
+  }
+
+  /** Drop all pending questions (e.g. on Claude session restart / `/clear`,
+   *  `/resume`). `signal` (#808) is carried onto one trace record per
+   *  cleared question. */
+  clear(signal = 'unknown', callSite = 'QuestionStore.clear'): void {
+    const cleared = [...this.map.values()];
+    this.map.clear();
+    this.notifyChanged();
+    for (const q of cleared) {
+      traceQuestionEvent({
+        action: 'remove',
+        sessionId: this.sessionId,
+        questionId: q.id,
+        promptId: q.promptId,
+        agentId: q.agentId,
+        isSubagent: q.agentId !== undefined,
+        signal,
+        callSite,
+        throughFunnel: true,
+      });
+    }
+  }
+
+  /** Look up a pending question by id (null if not awaitable). */
+  get(questionId: UUID): Question | null {
+    return this.map.get(questionId) ?? null;
+  }
+
+  private notifyChanged(): void {
+    this.events.onQuestionsChanged?.([...this.map.values()]);
+  }
+}

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -25,13 +25,8 @@ import type {
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
 import type { PTYSession } from '../pty/pty-session.ts';
-import { traceQuestionEvent } from './question-trace.ts';
+import { QuestionStore } from './question-store.ts';
 import { generateSessionName } from './session-name.ts';
-
-/** Upper bound on concurrently-pending questions per session. Real prompts are
- *  few (main + a handful of subagents); the cap is a backstop against a runaway
- *  prompt loop growing the map unbounded. Oldest is evicted first. */
-const MAX_PENDING_QUESTIONS = 8;
 
 /** Configuration for SessionRegistry */
 export interface SessionRegistryConfig {
@@ -137,10 +132,22 @@ export interface ManagedSession {
 
   /** Current agent status */
   currentStatus: AgentStatus;
-  /** Currently pending questions, keyed by questionId. Multiple can be in
-   *  flight at once (e.g. main agent + a subagent since #419), so an answer to
-   *  one must not invalidate the others. Bounded by MAX_PENDING_QUESTIONS. */
-  currentQuestions: Map<UUID, Question>;
+  /** Single owner of this session's pending-question state (#888). Only this
+   *  store mutates pendingness; `currentQuestions` below is a live read-only
+   *  view over its own map, never a second copy. */
+  readonly questionStore: QuestionStore;
+  /**
+   * Currently pending questions, keyed by questionId. Multiple can be in
+   * flight at once (e.g. main agent + a subagent since #419), so an answer to
+   * one must not invalidate the others. Bounded by MAX_PENDING_QUESTIONS
+   * (`question-store.ts`).
+   *
+   * A derived, read-only view over `questionStore`'s own map (#888) -- NOT a
+   * separate store. `ReadonlyMap` so a caller can `.get`/`.has`/`.size`/
+   * `.values`/`.keys` exactly as before, but cannot `.set`/`.delete`/`.clear`
+   * it directly; every existing read call site keeps working unchanged.
+   */
+  readonly currentQuestions: ReadonlyMap<UUID, Question>;
 
   /** Whether this session is owned by the local process (wrapper mode).
    * Locally-owned sessions are never killed by orphan timeout. */
@@ -203,6 +210,13 @@ export class SessionRegistry {
     const name = generateSessionName(workingDirectory);
 
     const createdAt = now();
+    // #888: constructed BEFORE the session object literal so the
+    // `currentQuestions` getter below can close over it directly, rather than
+    // reading `this.session.questionStore` (which would not exist yet at
+    // getter-definition time inside the same literal).
+    const questionStore = new QuestionStore(sessionId, {
+      onQuestionsChanged: (questions) => this.events.onQuestionsChanged?.(sessionId, questions),
+    });
     this.session = {
       sessionId,
       name,
@@ -217,7 +231,10 @@ export class SessionRegistry {
       messageHistory: [],
       lastDeliveredIndex: -1,
       currentStatus: 'idle',
-      currentQuestions: new Map(),
+      questionStore,
+      get currentQuestions(): ReadonlyMap<UUID, Question> {
+        return questionStore.questions;
+      },
       locallyOwned,
       explicitlyDetached: false,
       persistent,
@@ -431,56 +448,25 @@ export class SessionRegistry {
    * is tracked by its own id so answering one never invalidates another.
    * Bounded by MAX_PENDING_QUESTIONS (oldest evicted first) so a runaway
    * prompt loop cannot grow the map without limit.
+   *
+   * Thin adapter over `QuestionStore` (#888) -- signature unchanged so no
+   * call site churns; the map mutation + eviction + trace logic that used to
+   * live inline here now lives in the one place that owns pendingness.
    */
   addQuestion(sessionId: UUID, question: Question, signal = 'unknown'): void {
     if (this.session === null || this.session.sessionId !== sessionId) return;
-    const map = this.session.currentQuestions;
-    map.delete(question.id); // re-insert so a refreshed question is "newest"
-    map.set(question.id, question);
-    while (map.size > MAX_PENDING_QUESTIONS) {
-      const oldest = map.keys().next().value;
-      if (oldest === undefined) break;
-      const evicted = map.get(oldest);
-      map.delete(oldest);
-      // Log: an evicted prompt may have an outstanding APNS push whose answer
-      // will now be refused as STALE_ANSWER. Should be unreachable in normal
-      // use (cap is generous); a hit signals a runaway prompt loop.
-      console.warn(
-        `[SessionRegistry] pending-question cap (${MAX_PENDING_QUESTIONS}) exceeded; evicted oldest id=${oldest} text="${evicted?.text.slice(0, 60) ?? ''}"`,
-      );
-      // #808: an LRU eviction is a removal too -- it never goes through
-      // removeQuestion (there is no single questionId call site for it), so
-      // trace it here directly rather than let it appear as a silent gap.
-      traceQuestionEvent({
-        action: 'remove',
-        sessionId,
-        questionId: oldest,
-        promptId: evicted?.promptId,
-        agentId: evicted?.agentId,
-        isSubagent: evicted?.agentId !== undefined,
-        signal: 'lru_eviction',
-        callSite: 'SessionRegistry.addQuestion:lru_eviction',
-        throughFunnel: true,
-      });
-    }
     this.session.lastActivityAt = now();
-    this.events.onQuestionsChanged?.(sessionId, [...map.values()]);
-    traceQuestionEvent({
-      action: 'add',
-      sessionId,
-      questionId: question.id,
-      promptId: question.promptId,
-      agentId: question.agentId,
-      isSubagent: question.agentId !== undefined,
-      signal,
-      callSite: 'SessionRegistry.addQuestion',
-    });
+    this.session.questionStore.add(question, signal, 'SessionRegistry.addQuestion');
   }
 
   /** Remove one answered/resolved question by id. `signal` (#808) names the
    *  event/reason that caused the removal (e.g. 'PostToolUse', 'Stop',
    *  'user_answer') for the opt-in question-lifecycle trace; `toolName`,
-   *  when the caller knows it, is carried onto the same record. */
+   *  when the caller knows it, is carried onto the same record.
+   *
+   * Thin adapter over `QuestionStore` (#888) -- signature unchanged so no
+   * call site churns.
+   */
   removeQuestion(
     sessionId: UUID,
     questionId: UUID,
@@ -499,57 +485,30 @@ export class SessionRegistry {
      */
     callSite = 'SessionRegistry.removeQuestion',
   ): void {
-    if (this.session !== null && this.session.sessionId === sessionId) {
-      const existing = this.session.currentQuestions.get(questionId);
-      this.session.currentQuestions.delete(questionId);
-      this.session.lastActivityAt = now();
-      this.events.onQuestionsChanged?.(sessionId, [...this.session.currentQuestions.values()]);
-      traceQuestionEvent({
-        action: 'remove',
-        sessionId,
-        questionId,
-        promptId: existing?.promptId,
-        agentId: existing?.agentId,
-        isSubagent: existing?.agentId !== undefined,
-        toolName,
-        signal,
-        callSite,
-        throughFunnel: true,
-      });
-    }
+    if (this.session === null || this.session.sessionId !== sessionId) return;
+    this.session.lastActivityAt = now();
+    this.session.questionStore.remove(questionId, signal, toolName, callSite);
   }
 
   /** Drop all pending questions on Claude session restart (/clear, /resume).
    *  Status-leaving-'waiting' is handled by QuestionPresenceTracker and the
    *  client; this covers the restart path only, so answers to the dying
    *  session's prompts are refused. `signal` (#808) is carried onto one trace
-   *  record per cleared question. */
+   *  record per cleared question.
+   *
+   * Thin adapter over `QuestionStore` (#888) -- signature unchanged so no
+   * call site churns.
+   */
   clearQuestions(sessionId: UUID, signal = 'unknown'): void {
-    if (this.session !== null && this.session.sessionId === sessionId) {
-      const cleared = [...this.session.currentQuestions.values()];
-      this.session.currentQuestions.clear();
-      this.session.lastActivityAt = now();
-      this.events.onQuestionsChanged?.(sessionId, []);
-      for (const q of cleared) {
-        traceQuestionEvent({
-          action: 'remove',
-          sessionId,
-          questionId: q.id,
-          promptId: q.promptId,
-          agentId: q.agentId,
-          isSubagent: q.agentId !== undefined,
-          signal,
-          callSite: 'SessionRegistry.clearQuestions',
-          throughFunnel: true,
-        });
-      }
-    }
+    if (this.session === null || this.session.sessionId !== sessionId) return;
+    this.session.lastActivityAt = now();
+    this.session.questionStore.clear(signal, 'SessionRegistry.clearQuestions');
   }
 
   /** Look up a pending question by id (null if not awaitable). */
   getQuestion(sessionId: UUID, questionId: UUID): Question | null {
     if (this.session === null || this.session.sessionId !== sessionId) return null;
-    return this.session.currentQuestions.get(questionId) ?? null;
+    return this.session.questionStore.get(questionId);
   }
 
   /**

--- a/packages/daemon/tests/api/question-presence-tracker-messageapi-integration.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-messageapi-integration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Real-`MessageAPI`-and-`QuestionDedup` integration tests for #888's
+ * render-resolution transition (review-requested).
+ *
+ * The unit-level render-resolution suite
+ * (`question-presence-tracker-render-resolution.test.ts`) drives
+ * `QuestionPresenceTracker` with a bare test-local push sink that always
+ * "delivers" -- it never touches the REAL `QuestionDedup` a production
+ * session actually pushes through. Per ADR 0011 ("a test named for a
+ * component must construct it"), that suite's confidence about dedup
+ * interaction was a claim, not a fact. This suite constructs the real
+ * `SessionRegistry` + `MessageAPI` (and, inside it, the real `QuestionDedup`
+ * it always owns) + `QuestionPresenceTracker`, wired exactly the way
+ * `cli.ts`'s `createNewSession` wires them:
+ *   - the tracker's push sink is `messageApi.handleQuestion`, not a raw
+ *     collector;
+ *   - `isQuestionLive` reads `sessionRegistry.getQuestion`;
+ *   - `onHooklessQuestionGone` calls `sessionRegistry.removeQuestion`.
+ *
+ * It reproduces the exact failure chain review found in the V1 mechanism:
+ * `cli.ts`'s OutputProcessor-driven status callback calls
+ * `tracker.onStatusChange` UNCONDITIONALLY but gates `messageApi.
+ * handleStatusChange` (which resets QuestionDedup) behind `!hookServer` --
+ * so on the common path (a hook server IS running), a PTY-text-parsed
+ * status flap reaches the tracker with NO paired dedup reset. This suite
+ * drives that same asymmetry directly (never calling
+ * `messageApi.handleStatusChange` from the flap, mirroring the
+ * `hookServer` truthy branch) and asserts the question survives.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import { MessageAPI } from '../../src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+function opt(label: string, value: string, extras: Partial<QuestionOption> = {}): QuestionOption {
+  return { label, value, isRecommended: false, isYes: false, isNo: false, ...extras };
+}
+
+/** A hook-less PTY-parsed question (source: 'pty', fresh id every call, as
+ *  question-parser.ts produces post-#920). `optionCount` lets a test build a
+ *  "richer" redraw that QuestionDedup lets through even within its window,
+ *  without needing to wait out or fake the real 5s clock. */
+function hooklessQuestion(text: string, optionCount = 2): Question {
+  const options: QuestionOption[] = [];
+  for (let i = 1; i <= optionCount; i++) options.push(opt(String(i), String(i)));
+  return {
+    id: generateId() as UUID,
+    text,
+    options,
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'pty',
+  };
+}
+
+function fakePTY(): PTYSession {
+  return { id: generateId(), close: () => Promise.resolve() } as unknown as PTYSession;
+}
+
+interface Pipeline {
+  sessionRegistry: SessionRegistry;
+  messageApi: MessageAPI;
+  tracker: QuestionPresenceTracker;
+  sid: UUID;
+}
+
+/** Builds the real production pipeline the way `cli.ts`'s `createNewSession`
+ *  + `message-api-setup.ts`'s `createMessageApiForSession` wire it -- no
+ *  mocks, no synthetic stand-in for MessageAPI or QuestionDedup. */
+function buildPipeline(): Pipeline {
+  const sessionRegistry = new SessionRegistry();
+  const sid = generateId() as UUID;
+  sessionRegistry.registerSession(sid, '/messageapi-integration-test', fakePTY(), {
+    bulletCount: 0,
+  } as unknown as MessageAPI);
+
+  const messageApi = new MessageAPI(
+    { sessionId: sid, initialBulletId: 1 },
+    {
+      // Mirrors message-api-setup.ts's onQuestion callback: the ONLY part
+      // relevant here is that a delivered (non-deduped) question always
+      // registers in SessionRegistry.
+      onQuestion: (question) => {
+        sessionRegistry.addQuestion(sid, question, question.source ?? 'unknown');
+      },
+    },
+  );
+
+  const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts), {
+    isQuestionLive: (id) => sessionRegistry.getQuestion(sid, id as UUID) !== null,
+    onHooklessQuestionGone: (id, reason) => {
+      sessionRegistry.removeQuestion(
+        sid,
+        id as UUID,
+        reason,
+        undefined,
+        'test:onHooklessQuestionGone',
+      );
+    },
+  });
+
+  return { sessionRegistry, messageApi, tracker, sid };
+}
+
+describe('QuestionPresenceTracker + real MessageAPI/QuestionDedup integration (#888 review)', () => {
+  test('hard requirement (positive case): a genuinely new hook-less render resolves the one it replaces', () => {
+    const { sessionRegistry, tracker, sid } = buildPipeline();
+    const first = hooklessQuestion('First native prompt');
+    tracker.onPTYPromptVisible(first);
+    expect(sessionRegistry.getQuestion(sid, first.id)).not.toBeNull();
+
+    const second = hooklessQuestion('Second native prompt');
+    tracker.onPTYPromptVisible(second);
+
+    expect(sessionRegistry.getQuestion(sid, first.id)).toBeNull(); // resolved
+    expect(sessionRegistry.getQuestion(sid, second.id)).not.toBeNull(); // now live
+  });
+
+  test('the flap-then-redraw chain: a status false-positive must not swallow a still-live question', () => {
+    // Reproduces the exact chain from review:
+    //   1. A renders and registers.
+    //   2. A PTY-text-parsed status "leaves waiting" -- WITHOUT a paired
+    //      QuestionDedup reset, mirroring cli.ts's hookServer-truthy branch
+    //      (messageApi.handleStatusChange is gated behind `!hookServer`;
+    //      tracker.onStatusChange is not).
+    //   3. Status flaps back to 'waiting' with the SAME prompt still on
+    //      screen -- it redraws under a FRESH id (#486).
+    //   4. QuestionDedup (never reset) suppresses the redraw as a
+    //      same-fingerprint re-emission inside its window.
+    // Correct outcome: A is still live. Before the #888 review fix, A was
+    // wrongly resolved by the status flap alone (V1's onStatusChange
+    // trigger) or by the id-only supersession check treating the deduped
+    // redraw as confirmed replacement -- either way the user was told
+    // "cancelled" while an identical, unanswered prompt sat on the real
+    // screen.
+    const { sessionRegistry, tracker, sid } = buildPipeline();
+    const promptText = 'Allow this agent-team teammate to proceed?';
+    const a = hooklessQuestion(promptText);
+    tracker.onPTYPromptVisible(a);
+    expect(sessionRegistry.getQuestion(sid, a.id)).not.toBeNull();
+
+    // Step 2: false-positive status flap. Deliberately NOT calling
+    // messageApi.handleStatusChange -- that is the asymmetry cli.ts has for
+    // every session with an active hook server (the common case).
+    tracker.onStatusChange('executing');
+    // Step 3: flaps back to 'waiting'.
+    tracker.onStatusChange('waiting');
+
+    // Step 4: the SAME prompt redraws under a fresh id, same option count
+    // (not richer) -- QuestionDedup suppresses it.
+    const redraw = hooklessQuestion(promptText);
+    expect(redraw.id).not.toBe(a.id);
+    tracker.onPTYPromptVisible(redraw);
+
+    // The disqualifying failure would be: neither id live. Assert A
+    // specifically survives.
+    expect(sessionRegistry.getQuestion(sid, a.id)).not.toBeNull();
+    expect(sessionRegistry.getQuestion(sid, redraw.id)).toBeNull(); // the redraw itself never landed (deduped)
+    expect(sessionRegistry.getSession(sid)?.currentQuestions.size).toBe(1);
+  });
+
+  test('same-text redraw under a fresh id, CONFIRMED delivered (richer re-emission), correctly resolves the original', () => {
+    // The positive counterpart: QuestionDedup lets a RICHER re-emission
+    // through even within its window. Once genuinely delivered, resolution
+    // must still fire -- the guard is confirmed delivery, not text
+    // identity.
+    const { sessionRegistry, tracker, sid } = buildPipeline();
+    const promptText = 'Allow this agent-team teammate to proceed?';
+    const a = hooklessQuestion(promptText, 2);
+    tracker.onPTYPromptVisible(a);
+    expect(sessionRegistry.getQuestion(sid, a.id)).not.toBeNull();
+
+    const richerRedraw = hooklessQuestion(promptText, 4); // more options -> dedup upgrade
+    tracker.onPTYPromptVisible(richerRedraw);
+
+    expect(sessionRegistry.getQuestion(sid, a.id)).toBeNull();
+    expect(sessionRegistry.getQuestion(sid, richerRedraw.id)).not.toBeNull();
+  });
+
+  test('fail-toward-showing: an uncertain (undeliverable) push leaves the original pending, not silently dropped', () => {
+    // Sanity check on the underlying store semantics this mechanism relies
+    // on: SessionRegistry never removes a question except through an
+    // explicit removeQuestion/clearQuestions call. A push that never lands
+    // (deduped) cannot have removed anything by itself.
+    const { sessionRegistry, tracker, sid } = buildPipeline();
+    const a = hooklessQuestion('Same text', 2);
+    tracker.onPTYPromptVisible(a);
+    const dupe = hooklessQuestion('Same text', 2); // same fingerprint, not richer
+    tracker.onPTYPromptVisible(dupe);
+
+    expect(sessionRegistry.getSession(sid)?.currentQuestions.size).toBe(1);
+    expect(sessionRegistry.getQuestion(sid, a.id)).not.toBeNull();
+  });
+});

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -12,13 +12,25 @@
  * measured never removed over one working day, one still pending 2h51m
  * later.
  *
- * `QuestionPresenceTracker.observedHooklessQuestion` + the
- * `onHooklessQuestionGone` dep close that gap: the render disappearing IS
- * the resolution evidence for this cohort. This suite drives the tracker
- * directly (no mocks -- a real `QuestionPresenceTracker`, spying on the push
- * sink and the new dep) through every transition that must fire it, and
- * confirms a hook-PAIRED question -- which has its own signature-matched
- * removal path -- is never touched by this mechanism.
+ * V1 of this suite (and the mechanism it tested) compared the PTY-parsed
+ * render's id alone to decide "superseded". Review found that unsound on two
+ * fronts -- the PTY parser mints a fresh id on every parse even for a
+ * REDRAW of unchanged text (#486), and a replacement push can be silently
+ * eaten by `QuestionDedup`'s 5s window before it ever reaches
+ * `SessionRegistry.addQuestion` -- and, reachable in production, a
+ * PTY-text-parsed status false-positive (`output-processor.ts`,
+ * confidence >= 0.5) could fire this mechanism with NO paired dedup reset,
+ * so a redraw's replacement got deduped away while the original was already
+ * reported cancelled. Net: a live question, swallowed, in one status hiccup.
+ *
+ * This suite now pins the corrected design: `pairAndPush` pushes first, then
+ * asks `isQuestionLive` to CONFIRM the replacement actually landed before
+ * resolving the question it superseded (`QuestionPresenceTracker`'s own
+ * `isQuestionLive` doc has the full chain). The status-leaves-'waiting' and
+ * `clearPending` triggers were dropped entirely -- neither can be trusted as
+ * evidence a SPECIFIC question's render is gone (see their own reset
+ * comments in the tracker) -- so this suite also pins that they no longer
+ * resolve anything.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -68,23 +80,43 @@ interface Harness {
   tracker: QuestionPresenceTracker;
   pushed: Question[];
   gone: Array<{ id: string; reason: string }>;
+  /** Ids currently "registered" in this harness's fake store -- mirrors
+   *  SessionRegistry.currentQuestions closely enough to exercise the
+   *  confirmed-delivery gate: a push adds to it (unless `shouldDeliver`
+   *  says it was deduped), a resolution removes from it. */
+  liveIds: Set<string>;
 }
 
-function buildTracker(extraDeps: Record<string, unknown> = {}): Harness {
+interface BuildOpts {
+  extraDeps?: Record<string, unknown>;
+  /** Simulates QuestionDedup: return false to make a specific push NOT
+   *  land (as if suppressed). Defaults to "every push lands". */
+  shouldDeliver?: (q: Question) => boolean;
+  /** Omit isQuestionLive entirely, to test the safe-default (unwired) case. */
+  wireIsQuestionLive?: boolean;
+}
+
+function buildTracker(opts: BuildOpts = {}): Harness {
   const pushed: Question[] = [];
   const gone: Array<{ id: string; reason: string }> = [];
+  const liveIds = new Set<string>();
+  const shouldDeliver = opts.shouldDeliver ?? (() => true);
+  const wireIsQuestionLive = opts.wireIsQuestionLive ?? true;
   const tracker = new QuestionPresenceTracker(
     (q) => {
       pushed.push(q);
+      if (shouldDeliver(q)) liveIds.add(q.id);
     },
     {
       onHooklessQuestionGone: (id, reason) => {
         gone.push({ id, reason });
+        liveIds.delete(id);
       },
-      ...extraDeps,
+      ...(wireIsQuestionLive ? { isQuestionLive: (id: string) => liveIds.has(id) } : {}),
+      ...opts.extraDeps,
     },
   );
-  return { tracker, pushed, gone };
+  return { tracker, pushed, gone, liveIds };
 }
 
 describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
@@ -98,7 +130,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(gone).toHaveLength(0); // nothing superseded yet
   });
 
-  test('a SECOND hook-less render fires onHooklessQuestionGone for the FIRST id (supersession)', () => {
+  test('a SECOND hook-less render, CONFIRMED delivered, resolves the FIRST id', () => {
     const { tracker, gone } = buildTracker();
     const first = makeHooklessPTYQuestion('First prompt');
     const second = makeHooklessPTYQuestion('Second prompt');
@@ -109,11 +141,36 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
   });
 
-  test('a redraw of the SAME text still supersedes (fresh id every parse, #486)', () => {
-    // question-parser.ts mints a brand-new id on every single parse
-    // regardless of content -- a hook-less question that merely redraws
-    // (identical text) is indistinguishable from a genuinely new one at
-    // this layer, so its stale registry entry must still be resolved.
+  test('the hard requirement fix: a redraw whose replacement push is DEDUPED does NOT resolve the original', () => {
+    // The exact swallow class found in review: a same-text redraw mints a
+    // fresh id (#486) but its own push gets suppressed (QuestionDedup, or
+    // any other reason it never lands). The original must stay tracked and
+    // stay pending -- resolving it here would be the disqualifying failure
+    // (a live question with no card, already reported "cancelled").
+    const first = makeHooklessPTYQuestion('Do you want to proceed?');
+    const second = makeHooklessPTYQuestion('Do you want to proceed?');
+    const { tracker, gone, liveIds } = buildTracker({
+      shouldDeliver: (q) => q.id !== second.id, // second is "deduped"
+    });
+    tracker.onPTYPromptVisible(first);
+    expect(liveIds.has(first.id)).toBe(true);
+
+    tracker.onPTYPromptVisible(second);
+
+    expect(gone).toHaveLength(0); // first was NOT resolved
+    expect(liveIds.has(first.id)).toBe(true); // still live in the store
+    expect(liveIds.has(second.id)).toBe(false); // second never landed
+    // Tracking still points at the original -- a LATER confirmed
+    // supersession can still resolve it correctly.
+    expect(tracker.observedHooklessQuestionForTest()).toBe(first.id);
+  });
+
+  test('a redraw of the SAME text, once CONFIRMED delivered (e.g. a richer re-emission), still supersedes', () => {
+    // Distinguishes "same text" from "not delivered": QuestionDedup lets a
+    // RICHER re-emission through even within its window. Once delivered is
+    // confirmed, resolution must still fire -- the guard is delivery, not
+    // text identity (this suite deliberately does not reinvent
+    // isPromptCurrent's text-fallback policy; see isQuestionLive's doc).
     const { tracker, gone } = buildTracker();
     const redrawText = 'Do you want to proceed?';
     const first = makeHooklessPTYQuestion(redrawText);
@@ -127,34 +184,30 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
   });
 
-  test('status leaving "waiting" resolves the tracked hook-less question', () => {
+  test('status changes never resolve a hook-less question (trigger dropped, #888 review fix)', () => {
     const { tracker, gone } = buildTracker();
     const q = makeHooklessPTYQuestion();
     tracker.onPTYPromptVisible(q);
-    tracker.onStatusChange('executing');
 
-    expect(gone).toEqual([{ id: q.id, reason: 'pty_status_left_waiting' }]);
-    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
-  });
+    tracker.onStatusChange('executing'); // leaves 'waiting'
+    expect(gone).toHaveLength(0);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
 
-  test('status staying "waiting" does NOT resolve the tracked hook-less question', () => {
-    const { tracker, gone } = buildTracker();
-    const q = makeHooklessPTYQuestion();
-    tracker.onPTYPromptVisible(q);
-    tracker.onStatusChange('waiting');
-
+    tracker.onStatusChange('waiting'); // back to 'waiting'
     expect(gone).toHaveLength(0);
     expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
   });
 
-  test('clearPending resolves the tracked hook-less question', () => {
+  test('clearPending never resolves a hook-less question (trigger dropped, #888 review fix)', () => {
     const { tracker, gone } = buildTracker();
     const q = makeHooklessPTYQuestion();
     tracker.onPTYPromptVisible(q);
     tracker.clearPending();
 
-    expect(gone).toEqual([{ id: q.id, reason: 'pty_clear_pending' }]);
-    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+    expect(gone).toHaveLength(0);
+    // Tracking survives clearPending too -- a later CONFIRMED supersession
+    // can still resolve it, exactly as if clearPending had never run.
+    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
   });
 
   test('a HOOK-PAIRED render is never tracked as hook-less (it has its own removal path)', () => {
@@ -165,11 +218,10 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(ptyRender);
 
     expect(tracker.observedHooklessQuestionForTest()).toBeNull();
-    tracker.onStatusChange('executing');
     expect(gone).toHaveLength(0); // nothing hook-less was ever tracked
   });
 
-  test('a hook-paired render SUPERSEDES a previously-tracked hook-less one', () => {
+  test('a hook-paired render, CONFIRMED delivered, SUPERSEDES a previously-tracked hook-less one', () => {
     const { tracker, gone } = buildTracker();
     const hookless = makeHooklessPTYQuestion('orphan prompt');
     tracker.onPTYPromptVisible(hookless);
@@ -197,21 +249,25 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
 
     expect(pushedHeld).toBe(true);
     // The hook-less question is untouched by the held push -- it is a
-    // completely separate mechanism (#573) that never renders on the PTY.
+    // completely separate mechanism (#573) that never renders on the PTY,
+    // and pushHeldHook never runs the confirmed-delivery gate at all.
     expect(tracker.observedHooklessQuestionForTest()).toBe(hookless.id);
     expect(gone).toHaveLength(0);
   });
 
   test('a throwing onHooklessQuestionGone dep is caught and logged, never propagated', () => {
+    const liveIds = new Set<string>();
     const pushed: Question[] = [];
     const tracker = new QuestionPresenceTracker(
       (q) => {
         pushed.push(q);
+        liveIds.add(q.id);
       },
       {
         onHooklessQuestionGone: () => {
           throw new Error('boom');
         },
+        isQuestionLive: (id) => liveIds.has(id),
       },
     );
     const first = makeHooklessPTYQuestion('first');
@@ -235,6 +291,18 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
       tracker.onStatusChange('idle');
     }).not.toThrow();
     expect(pushed).toHaveLength(2);
+  });
+
+  test('safe default: onHooklessQuestionGone wired but isQuestionLive NOT wired -- never resolves (fail toward showing)', () => {
+    const { tracker, gone } = buildTracker({ wireIsQuestionLive: false });
+    const first = makeHooklessPTYQuestion('first');
+    const second = makeHooklessPTYQuestion('second');
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(second);
+
+    // Without confirmation, "delivered" defaults to false -- the mechanism
+    // is fully inert, matching pre-#888 behavior rather than guessing.
+    expect(gone).toHaveLength(0);
   });
 
   test('a hook-paired merge takes the HOOK record source, not the PTY parse source', () => {
@@ -267,10 +335,12 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(pushed[0]?.source).toBe('pty');
   });
 
-  test('the ORPHAN (debounced) path also tracks and resolves hook-less questions', async () => {
+  test('the ORPHAN (debounced) path also tracks and resolves hook-less questions, gated on confirmed delivery', async () => {
     const { tracker, pushed, gone } = buildTracker({
-      orphanDebounceMs: 5,
-      hasLiveQuestions: () => false,
+      extraDeps: {
+        orphanDebounceMs: 5,
+        hasLiveQuestions: () => false,
+      },
     });
     const first = makeHooklessPTYQuestion('orphan A');
     tracker.onOrphanPTYPrompt(first);

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the #888/#920 render-resolution transition: the hard
+ * requirement that the pending-question store be able to resolve a question
+ * whose ONLY evidence was a screen render.
+ *
+ * Root cause (#920, measured from a real capture): a genuinely hook-less
+ * question (no PermissionRequest/Notification hook ever fired for it -- an
+ * agent-team native prompt, a bare subprocess `(y/n)`) has no tool signature
+ * for `AutoApproveGate.cancelExternallyResolved` or the Stop/SubagentStop
+ * sweeps to match. Its only pre-#888 exits were the user answering it, or
+ * the `MAX_PENDING_QUESTIONS` LRU cap -- 12 of 29 source-less questions were
+ * measured never removed over one working day, one still pending 2h51m
+ * later.
+ *
+ * `QuestionPresenceTracker.observedHooklessQuestion` + the
+ * `onHooklessQuestionGone` dep close that gap: the render disappearing IS
+ * the resolution evidence for this cohort. This suite drives the tracker
+ * directly (no mocks -- a real `QuestionPresenceTracker`, spying on the push
+ * sink and the new dep) through every transition that must fire it, and
+ * confirms a hook-PAIRED question -- which has its own signature-matched
+ * removal path -- is never touched by this mechanism.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption } from '@remi/shared';
+import { generateId } from '@remi/shared';
+import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
+
+function makeOption(
+  label: string,
+  value: string,
+  extras: Partial<QuestionOption> = {},
+): QuestionOption {
+  return { label, value, isRecommended: false, isYes: false, isNo: false, ...extras };
+}
+
+/** A genuinely hook-less PTY-parsed question, exactly as `question-parser.ts`
+ *  produces one post-#920 (source: 'pty', fresh id every call). */
+function makeHooklessPTYQuestion(text = 'Do you want to proceed?'): Question {
+  return {
+    id: generateId(),
+    text,
+    options: [makeOption('1', '1'), makeOption('2', '2')],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'pty',
+  };
+}
+
+/** A hook record with real option labels (#574), as `HookEventBridge` mints
+ *  one -- what makes a PTY render "hook-paired" once it merges with this. */
+function makeHookRecord(text = 'Allow Bash: git push'): Question {
+  return {
+    id: generateId(),
+    text,
+    options: [
+      makeOption('Yes', '1', { isYes: true, isRecommended: true }),
+      makeOption('Yes, always', '2', { isYes: true }),
+      makeOption('No', '3', { isNo: true }),
+    ],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'permission_request',
+  };
+}
+
+interface Harness {
+  tracker: QuestionPresenceTracker;
+  pushed: Question[];
+  gone: Array<{ id: string; reason: string }>;
+}
+
+function buildTracker(extraDeps: Record<string, unknown> = {}): Harness {
+  const pushed: Question[] = [];
+  const gone: Array<{ id: string; reason: string }> = [];
+  const tracker = new QuestionPresenceTracker(
+    (q) => {
+      pushed.push(q);
+    },
+    {
+      onHooklessQuestionGone: (id, reason) => {
+        gone.push({ id, reason });
+      },
+      ...extraDeps,
+    },
+  );
+  return { tracker, pushed, gone };
+}
+
+describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
+  test('a hook-less push starts tracking it as the observed hook-less question', () => {
+    const { tracker, pushed, gone } = buildTracker();
+    const q = makeHooklessPTYQuestion();
+    tracker.onPTYPromptVisible(q);
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.id).toBe(q.id);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+    expect(gone).toHaveLength(0); // nothing superseded yet
+  });
+
+  test('a SECOND hook-less render fires onHooklessQuestionGone for the FIRST id (supersession)', () => {
+    const { tracker, gone } = buildTracker();
+    const first = makeHooklessPTYQuestion('First prompt');
+    const second = makeHooklessPTYQuestion('Second prompt');
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(second);
+
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+  });
+
+  test('a redraw of the SAME text still supersedes (fresh id every parse, #486)', () => {
+    // question-parser.ts mints a brand-new id on every single parse
+    // regardless of content -- a hook-less question that merely redraws
+    // (identical text) is indistinguishable from a genuinely new one at
+    // this layer, so its stale registry entry must still be resolved.
+    const { tracker, gone } = buildTracker();
+    const redrawText = 'Do you want to proceed?';
+    const first = makeHooklessPTYQuestion(redrawText);
+    const second = makeHooklessPTYQuestion(redrawText);
+    expect(first.id).not.toBe(second.id);
+
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(second);
+
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+  });
+
+  test('status leaving "waiting" resolves the tracked hook-less question', () => {
+    const { tracker, gone } = buildTracker();
+    const q = makeHooklessPTYQuestion();
+    tracker.onPTYPromptVisible(q);
+    tracker.onStatusChange('executing');
+
+    expect(gone).toEqual([{ id: q.id, reason: 'pty_status_left_waiting' }]);
+    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+  });
+
+  test('status staying "waiting" does NOT resolve the tracked hook-less question', () => {
+    const { tracker, gone } = buildTracker();
+    const q = makeHooklessPTYQuestion();
+    tracker.onPTYPromptVisible(q);
+    tracker.onStatusChange('waiting');
+
+    expect(gone).toHaveLength(0);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+  });
+
+  test('clearPending resolves the tracked hook-less question', () => {
+    const { tracker, gone } = buildTracker();
+    const q = makeHooklessPTYQuestion();
+    tracker.onPTYPromptVisible(q);
+    tracker.clearPending();
+
+    expect(gone).toEqual([{ id: q.id, reason: 'pty_clear_pending' }]);
+    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+  });
+
+  test('a HOOK-PAIRED render is never tracked as hook-less (it has its own removal path)', () => {
+    const { tracker, gone } = buildTracker();
+    const hookRecord = makeHookRecord();
+    tracker.recordPendingHook(hookRecord);
+    const ptyRender = makeHooklessPTYQuestion(); // agentless -> pairs as sole candidate
+    tracker.onPTYPromptVisible(ptyRender);
+
+    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+    tracker.onStatusChange('executing');
+    expect(gone).toHaveLength(0); // nothing hook-less was ever tracked
+  });
+
+  test('a hook-paired render SUPERSEDES a previously-tracked hook-less one', () => {
+    const { tracker, gone } = buildTracker();
+    const hookless = makeHooklessPTYQuestion('orphan prompt');
+    tracker.onPTYPromptVisible(hookless);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(hookless.id);
+
+    const hookRecord = makeHookRecord();
+    tracker.recordPendingHook(hookRecord);
+    const paired = makeHooklessPTYQuestion('Allow Bash: git push'); // matches hook by sole-candidate
+    tracker.onPTYPromptVisible(paired);
+
+    expect(gone).toEqual([{ id: hookless.id, reason: 'pty_render_superseded' }]);
+    // The merged push adopted the HOOK's id (#887) -- tracking is null now,
+    // not the merged id, because the merge was hook-paired.
+    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+  });
+
+  test('a HELD-hook push (always hook-derived) never touches hook-less tracking', () => {
+    const { tracker, gone } = buildTracker();
+    const hookless = makeHooklessPTYQuestion();
+    tracker.onPTYPromptVisible(hookless);
+
+    const held = makeHookRecord('Allow Bash: rm -rf /tmp');
+    tracker.recordPendingHook(held);
+    const pushedHeld = tracker.pushHeldHook(held.id);
+
+    expect(pushedHeld).toBe(true);
+    // The hook-less question is untouched by the held push -- it is a
+    // completely separate mechanism (#573) that never renders on the PTY.
+    expect(tracker.observedHooklessQuestionForTest()).toBe(hookless.id);
+    expect(gone).toHaveLength(0);
+  });
+
+  test('a throwing onHooklessQuestionGone dep is caught and logged, never propagated', () => {
+    const pushed: Question[] = [];
+    const tracker = new QuestionPresenceTracker(
+      (q) => {
+        pushed.push(q);
+      },
+      {
+        onHooklessQuestionGone: () => {
+          throw new Error('boom');
+        },
+      },
+    );
+    const first = makeHooklessPTYQuestion('first');
+    const second = makeHooklessPTYQuestion('second');
+    tracker.onPTYPromptVisible(first);
+    expect(() => tracker.onPTYPromptVisible(second)).not.toThrow();
+    // Tracking still advances correctly despite the dep throwing.
+    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+  });
+
+  test('no onHooklessQuestionGone dep wired: tracker behaves exactly as before #888', () => {
+    const pushed: Question[] = [];
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushed.push(q);
+    });
+    const first = makeHooklessPTYQuestion('first');
+    const second = makeHooklessPTYQuestion('second');
+    expect(() => {
+      tracker.onPTYPromptVisible(first);
+      tracker.onPTYPromptVisible(second);
+      tracker.onStatusChange('idle');
+    }).not.toThrow();
+    expect(pushed).toHaveLength(2);
+  });
+
+  test('a hook-paired merge takes the HOOK record source, not the PTY parse source', () => {
+    // #888 review finding: consumeAndMerge's `...ptyQuestion` spread silently
+    // carried ptyQuestion.source onto a hook-paired merge before this fix.
+    // Once question-parser.ts sets `source: 'pty'` on every PTY parse
+    // (#920), an unfixed merge would have mislabeled every hook-paired
+    // render as the unresolvable-by-signature cohort -- muddying the exact
+    // measurement #920's acceptance criterion needs. The hook's own source
+    // must win, mirroring text/options/agentId.
+    const { tracker, pushed } = buildTracker();
+    const hookRecord = makeHookRecord('Allow Bash: git push');
+    tracker.recordPendingHook(hookRecord);
+    const ptyRender = makeHooklessPTYQuestion('Allow Bash: git push');
+    expect(ptyRender.source).toBe('pty');
+
+    tracker.onPTYPromptVisible(ptyRender);
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.source).toBe('permission_request');
+    expect(pushed[0]?.source).not.toBe('pty');
+  });
+
+  test('a genuinely hook-less merge keeps the PTY parse source', () => {
+    const { tracker, pushed } = buildTracker();
+    const ptyRender = makeHooklessPTYQuestion('orphan prompt');
+    tracker.onPTYPromptVisible(ptyRender);
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]?.source).toBe('pty');
+  });
+
+  test('the ORPHAN (debounced) path also tracks and resolves hook-less questions', async () => {
+    const { tracker, pushed, gone } = buildTracker({
+      orphanDebounceMs: 5,
+      hasLiveQuestions: () => false,
+    });
+    const first = makeHooklessPTYQuestion('orphan A');
+    tracker.onOrphanPTYPrompt(first);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(pushed).toHaveLength(1);
+    expect(tracker.observedHooklessQuestionForTest()).toBe(first.id);
+
+    const second = makeHooklessPTYQuestion('orphan B');
+    tracker.onOrphanPTYPrompt(second);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(pushed).toHaveLength(2);
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+  });
+});

--- a/packages/daemon/tests/question-parser.test.ts
+++ b/packages/daemon/tests/question-parser.test.ts
@@ -190,6 +190,22 @@ describe('parseQuestion() - ANSI handling and properties', () => {
     expect(a.question?.isAnswered).toBe(false);
     expect(a.question?.answer).toBeUndefined();
   });
+
+  test('every parsed question carries source "pty" (#888/#920)', () => {
+    // The shared type's own doc says "PTY-parsed prompts are 'pty'", but
+    // nothing ever set it -- this is the one-line #920 fix that makes the
+    // hook-less cohort visible in the question-lifecycle trace at all. All
+    // three parser paths (selection-box chrome, literal y/n, free-text
+    // waiting) go through createQuestion, so one assertion per path.
+    const chrome = parseQuestion('❯ 1. Yes\n  2. No');
+    expect(chrome.question?.source).toBe('pty');
+
+    const yesNo = parseQuestion('Continue? (y/n)');
+    expect(yesNo.question?.source).toBe('pty');
+
+    const waiting = parseQuestion('Please enter your response');
+    expect(waiting.question?.source).toBe('pty');
+  });
 });
 
 describe('hasQuestionIndicator()', () => {

--- a/packages/daemon/tests/session/question-store-trace-worker.ts
+++ b/packages/daemon/tests/session/question-store-trace-worker.ts
@@ -1,0 +1,45 @@
+/**
+ * Worker for question-store-trace.test.ts (#888).
+ *
+ * Mirrors `question-trace-worker.ts` (#808) and
+ * `question-trace-identity-worker.ts` (#887)'s fresh-subprocess HOME
+ * pattern, but drives the REAL `SessionRegistry` (not `traceQuestionEvent`
+ * directly) through add / re-add-triggers-eviction / remove / clear, to pin
+ * that the #888 QuestionStore extraction produced BYTE-FOR-BYTE the same
+ * trace `callSite` defaults SessionRegistry's own callers relied on before
+ * this file existed: 'SessionRegistry.addQuestion',
+ * 'SessionRegistry.addQuestion:lru_eviction', 'SessionRegistry.removeQuestion',
+ * 'SessionRegistry.clearQuestions'.
+ */
+import { generateId } from '@remi/shared';
+import type { MessageAPI } from '../../src/api/message-api.ts';
+import type { PTYSession } from '../../src/pty/pty-session.ts';
+import { SessionRegistry } from '../../src/session/session-registry.ts';
+
+const registry = new SessionRegistry();
+const sid = generateId();
+registry.registerSession(
+  sid,
+  '/tmp/worker',
+  { id: generateId(), close: () => Promise.resolve() } as unknown as PTYSession,
+  { bulletCount: 0 } as unknown as MessageAPI,
+);
+
+// Fill to the MAX_PENDING_QUESTIONS cap (8) then add a 9th to force an
+// eviction trace record.
+const ids: string[] = [];
+for (let i = 0; i < 9; i++) {
+  const id = generateId();
+  ids.push(id);
+  registry.addQuestion(sid, {
+    id,
+    text: `${id}?`,
+    options: [],
+    allowsFreeText: true,
+    isAnswered: false,
+  });
+}
+
+// biome-ignore lint/style/noNonNullAssertion: fixed-length loop above
+registry.removeQuestion(sid, ids[8]!);
+registry.clearQuestions(sid);

--- a/packages/daemon/tests/session/question-store-trace.test.ts
+++ b/packages/daemon/tests/session/question-store-trace.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Trace-callSite regression test for the #888 QuestionStore extraction.
+ *
+ * SessionRegistry.addQuestion/removeQuestion/clearQuestions used to mutate
+ * `currentQuestions` and emit trace records inline; #888 moved that logic
+ * into QuestionStore, keeping SessionRegistry's methods as thin adapters.
+ * This pins that the extraction is trace-observably a no-op for every
+ * EXISTING call path: the same default `callSite` strings
+ * ('SessionRegistry.addQuestion', its ':lru_eviction' eviction variant,
+ * 'SessionRegistry.removeQuestion', 'SessionRegistry.clearQuestions') still
+ * appear, unchanged, byte for byte.
+ *
+ * Same real-subprocess HOME-override pattern as `question-trace.test.ts`
+ * (#808) and `question-trace-identity.test.ts` (#887), which this suite
+ * deliberately does not touch or extend.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const WORKER = path.join(import.meta.dir, 'question-store-trace-worker.ts');
+
+function readTraceLines(home: string): Record<string, unknown>[] {
+  const tracePath = path.join(home, '.remi', 'question-trace.jsonl');
+  if (!fs.existsSync(tracePath)) return [];
+  return fs
+    .readFileSync(tracePath, 'utf-8')
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+async function runWorker(home: string): Promise<void> {
+  const { REMI_QUESTION_TRACE: _inherited, ...rest } = process.env;
+  const env = { ...rest, HOME: home, REMI_QUESTION_TRACE: '1' };
+  const proc = Bun.spawn(['bun', WORKER], { env, stdout: 'pipe', stderr: 'pipe' });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`worker exited ${code}: ${stderr}`);
+  }
+}
+
+describe('question-trace callSite defaults survive the #888 QuestionStore extraction', () => {
+  function makeTmpHome(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-question-store-trace-test-'));
+  }
+
+  test('add/evict/remove/clear all carry the pre-#888 SessionRegistry callSite names', async () => {
+    const tmpHome = makeTmpHome();
+    try {
+      await runWorker(tmpHome);
+      const lines = readTraceLines(tmpHome);
+
+      // 9 adds, 1 of which also evicts (callSite gets the ':lru_eviction'
+      // suffix), 1 explicit remove, 7 remaining cleared by clearQuestions.
+      const adds = lines.filter((l) => l['action'] === 'add');
+      const removes = lines.filter((l) => l['action'] === 'remove');
+      expect(adds).toHaveLength(9);
+      expect(removes).toHaveLength(1 + 1 + 7); // eviction + explicit remove + clear
+
+      for (const a of adds) {
+        expect(a['callSite']).toBe('SessionRegistry.addQuestion');
+      }
+
+      const evictions = removes.filter((r) => r['signal'] === 'lru_eviction');
+      expect(evictions).toHaveLength(1);
+      expect(evictions[0]?.['callSite']).toBe('SessionRegistry.addQuestion:lru_eviction');
+
+      // throughFunnel is always true for a SessionRegistry-routed remove
+      // (#808), so distinguish the explicit removeQuestion call from the
+      // clearQuestions batch by callSite instead.
+      const explicit = removes.filter((r) => r['callSite'] === 'SessionRegistry.removeQuestion');
+      const cleared = removes.filter((r) => r['callSite'] === 'SessionRegistry.clearQuestions');
+      expect(explicit).toHaveLength(1);
+      expect(cleared).toHaveLength(7);
+
+      // Every removal funnels through SessionRegistry (#808 invariant,
+      // unchanged by #888).
+      for (const r of removes) {
+        expect(r['throughFunnel']).toBe(true);
+      }
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/daemon/tests/session/question-store.test.ts
+++ b/packages/daemon/tests/session/question-store.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for QuestionStore (#888): the single owner of a session's
+ * pending-question map, extracted from SessionRegistry.
+ *
+ * `SessionRegistry`'s own test suite (`session-registry.test.ts`) already
+ * exercises this behavior indirectly through `addQuestion`/`removeQuestion`/
+ * `clearQuestions`/`getQuestion` (unchanged, adapter signatures) and stays
+ * green after this extraction (see the PR body). This suite tests the store
+ * directly: its own public surface, the LRU eviction it now solely owns, and
+ * that `callSite` threads through exactly as before.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { generateId } from '@remi/shared';
+import type { Question, UUID } from '@remi/shared';
+import { QuestionStore } from '../../src/session/question-store.ts';
+
+function mkQuestion(id: string, agentId?: string): Question {
+  return {
+    id: id as UUID,
+    text: `${id}?`,
+    options: [],
+    allowsFreeText: true,
+    isAnswered: false,
+    ...(agentId !== undefined && { agentId }),
+  };
+}
+
+describe('QuestionStore (#888)', () => {
+  test('add registers a question, visible via questions and get', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const q = mkQuestion(generateId());
+    store.add(q);
+    expect(store.questions.size).toBe(1);
+    expect(store.questions.get(q.id)).toEqual(q);
+    expect(store.get(q.id)).toEqual(q);
+  });
+
+  test('get returns null for an unknown id', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    expect(store.get(generateId() as UUID)).toBeNull();
+  });
+
+  test('remove drops the question and get returns null after', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const q = mkQuestion(generateId());
+    store.add(q);
+    store.remove(q.id);
+    expect(store.get(q.id)).toBeNull();
+    expect(store.questions.size).toBe(0);
+  });
+
+  test('remove of an unknown id is a harmless no-op (idempotent)', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    expect(() => store.remove(generateId() as UUID)).not.toThrow();
+    expect(store.questions.size).toBe(0);
+  });
+
+  test('add/remove keep concurrent questions independent (main + subagent)', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const main = mkQuestion(generateId());
+    const sub = mkQuestion(generateId(), 'sub-7');
+    store.add(main);
+    store.add(sub);
+    expect(store.questions.size).toBe(2);
+    store.remove(main.id);
+    expect(store.get(main.id)).toBeNull();
+    expect(store.get(sub.id)).toEqual(sub);
+  });
+
+  test('clear drops every pending question', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    store.add(mkQuestion(generateId()));
+    store.add(mkQuestion(generateId()));
+    store.clear();
+    expect(store.questions.size).toBe(0);
+  });
+
+  test('re-adding an existing id refreshes it to newest (survives eviction)', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const ids: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      const id = generateId();
+      ids.push(id);
+      store.add(mkQuestion(id));
+    }
+    // Refresh the oldest, then add one more: the refreshed one must survive
+    // and the now-oldest (ids[1]) must be evicted instead.
+    store.add(mkQuestion(ids[0] as string));
+    store.add(mkQuestion(generateId()));
+    expect(store.get(ids[0] as UUID)).not.toBeNull();
+    expect(store.get(ids[1] as UUID)).toBeNull();
+  });
+
+  test('evicts the OLDEST when the pending cap (8) is exceeded', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const ids: string[] = [];
+    for (let i = 0; i < 9; i++) {
+      const id = generateId();
+      ids.push(id);
+      store.add(mkQuestion(id));
+    }
+    expect(store.questions.size).toBe(8);
+    expect(store.get(ids[0] as UUID)).toBeNull(); // oldest gone
+    expect(store.get(ids[8] as UUID)).not.toBeNull(); // newest kept
+  });
+
+  test('questions is a LIVE view: reads after a mutation see the new state', () => {
+    const store = new QuestionStore(generateId() as UUID);
+    const view = store.questions; // captured once
+    const q = mkQuestion(generateId());
+    store.add(q);
+    // Same reference throughout (#888: not a copy taken at construction).
+    expect(view.size).toBe(1);
+    expect(view.get(q.id)).toEqual(q);
+    store.remove(q.id);
+    expect(view.size).toBe(0);
+  });
+
+  test('onQuestionsChanged fires with the FULL current set on add/remove/clear, never a delta', () => {
+    const seen: Question[][] = [];
+    const store = new QuestionStore(generateId() as UUID, {
+      onQuestionsChanged: (qs) => seen.push([...qs]),
+    });
+    const a = mkQuestion(generateId());
+    const b = mkQuestion(generateId());
+    store.add(a);
+    store.add(b);
+    store.remove(a.id);
+    store.clear();
+    expect(seen.map((s) => s.length)).toEqual([1, 2, 1, 0]);
+    expect(seen[1]?.map((q) => q.id)).toEqual([a.id, b.id]);
+  });
+
+  test('an eviction fires onQuestionsChanged too (the evicted id is gone from the next set)', () => {
+    const counts: number[] = [];
+    const store = new QuestionStore(generateId() as UUID, {
+      onQuestionsChanged: (qs) => counts.push(qs.length),
+    });
+    for (let i = 0; i < 9; i++) {
+      store.add(mkQuestion(generateId()));
+    }
+    // 9 adds; the 9th also evicts, but eviction does not fire a SEPARATE
+    // onQuestionsChanged -- the post-eviction size (capped at 8) is what the
+    // 9th add's own notifyChanged reports.
+    expect(counts).toHaveLength(9);
+    expect(counts[8]).toBe(8);
+  });
+});

--- a/packages/web/tests/lib/question-store-conformance.test.ts
+++ b/packages/web/tests/lib/question-store-conformance.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Two-sided conformance test for the #888 QuestionStore + render-resolution
+ * transition: drives the REAL daemon pending-question pipeline
+ * (`SessionRegistry` -> `QuestionStore`, `QuestionPresenceTracker`) through
+ * every transition, broadcasts the resulting `question` / `question_resolved`
+ * / `question_snapshot` messages over a REAL socket (the same
+ * `WebSocketAdapter` <-> `WebSocketClient` pair `message-dispatch-
+ * conformance.test.ts` (#897) uses -- no synthetic counterparty, per
+ * AGENTS.md "Verify before you describe"), and feeds them into the REAL
+ * `packages/web/src/lib/question-collection.ts` reducers (the same functions
+ * `App.tsx` calls) to build the client's view.
+ *
+ * After every transition this asserts: the set of LIVE (still-pending)
+ * question ids the client reducer sees equals the set of ids
+ * `SessionRegistry.currentQuestions` -- the single owner #888 established --
+ * currently holds. Nothing here is reimplemented or mocked: the daemon side
+ * is the real `SessionRegistry`/`QuestionStore`/`QuestionPresenceTracker`
+ * classes, the client side is the real `question-collection.ts` reducers
+ * plus `mapQuestionToUIQuestion`, wired the same way `cli.ts` and `App.tsx`
+ * wire them (`onQuestionsChanged` -> `question_snapshot` broadcast;
+ * `QuestionPresenceTracker`'s push sink -> `question` + `SessionRegistry.
+ * addQuestion`; a resolution -> `SessionRegistry.removeQuestion` +
+ * `question_resolved`).
+ *
+ * The hard requirement under test: a HOOK-LESS question (no
+ * PermissionRequest/Notification hook, `source: 'pty'`) can be resolved with
+ * no signal but its render disappearing -- see the "hook-less render
+ * disappears" cases below.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { Question, QuestionOption, UUID } from '@remi/shared';
+import {
+  createHello,
+  createQuestion,
+  createQuestionResolved,
+  createQuestionSnapshot,
+  generateId,
+} from '@remi/shared/protocol.ts';
+import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
+import type { MessageAPI } from '../../../daemon/src/api/message-api.ts';
+import { QuestionPresenceTracker } from '../../../daemon/src/api/question-presence-tracker.ts';
+// Real daemon adapter + session pipeline -- not test doubles. Relative
+// import: packages/web has no `@remi/daemon` path alias (only
+// `packages/web/tests/**` is exempt from both typecheck gates, matching the
+// #897 conformance test's own "conformance-test placement decision").
+import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
+import type { PTYSession } from '../../../daemon/src/pty/pty-session.ts';
+import { SessionRegistry } from '../../../daemon/src/session/session-registry.ts';
+import { mapQuestionToUIQuestion } from '../../src/lib/question-mapping.ts';
+import {
+  applyIncomingQuestion,
+  isQuestionPending,
+  pruneQuestionsNotLive,
+  resolveQuestionCard,
+} from '../../src/lib/question-collection.ts';
+import type { UIQuestion } from '../../src/types/index.ts';
+import { WebSocketClient } from '../../src/lib/websocket-client.ts';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!predicate() && Date.now() - start < timeoutMs) {
+    await wait(10);
+  }
+  if (!predicate()) {
+    throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+  }
+}
+
+function opt(label: string, value: string, extras: Partial<QuestionOption> = {}): QuestionOption {
+  return { label, value, isRecommended: false, isYes: false, isNo: false, ...extras };
+}
+
+/** A genuinely hook-less PTY-parsed question, exactly as `question-parser.ts`
+ *  mints one post-#920 (source: 'pty', fresh id every parse). */
+function hooklessPTYQuestion(text: string, agentId?: string): Question {
+  return {
+    id: generateId() as UUID,
+    text,
+    options: [opt('1', '1'), opt('2', '2')],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'pty',
+    ...(agentId !== undefined && { agentId }),
+  };
+}
+
+/** A hook record with real option labels (#574), as `HookEventBridge` mints. */
+function hookRecord(text: string, agentId?: string): Question {
+  return {
+    id: generateId() as UUID,
+    text,
+    options: [
+      opt('Yes', '1', { isYes: true, isRecommended: true }),
+      opt('Yes, always', '2', { isYes: true }),
+      opt('No', '3', { isNo: true }),
+    ],
+    allowsFreeText: false,
+    isAnswered: false,
+    source: 'permission_request',
+    ...(agentId !== undefined && { agentId }),
+  };
+}
+
+function fakePTY(): PTYSession {
+  return {
+    id: generateId(),
+    close: () => Promise.resolve(),
+  } as unknown as PTYSession;
+}
+
+describe('question-store conformance: real daemon store <-> real web reducer (#888)', () => {
+  let adapter: WebSocketAdapter;
+  let port: number;
+  let client: WebSocketClient;
+  let connectionId: string | null = null;
+  const received: unknown[] = [];
+
+  const SID = generateId() as UUID;
+  let sessionRegistry: SessionRegistry;
+  let tracker: QuestionPresenceTracker;
+  let clientQuestions = new Map<string, UIQuestion>();
+
+  function clientLiveIds(): Set<string> {
+    const out = new Set<string>();
+    for (const q of clientQuestions.values()) {
+      if (q.sessionId === SID && isQuestionPending(q)) out.add(q.id);
+    }
+    return out;
+  }
+
+  function storeLiveIds(): Set<string> {
+    return new Set(sessionRegistry.getSession(SID)?.currentQuestions.keys() ?? []);
+  }
+
+  /** Assert the client's live view and the daemon store's live view agree,
+   *  waiting up to `timeoutMs` for the async socket round-trip to settle. */
+  async function assertConverges(timeoutMs = 2000): Promise<void> {
+    await waitFor(() => {
+      const client = clientLiveIds();
+      const store = storeLiveIds();
+      if (client.size !== store.size) return false;
+      for (const id of store) if (!client.has(id)) return false;
+      return true;
+    }, timeoutMs);
+    expect(clientLiveIds()).toEqual(storeLiveIds());
+  }
+
+  beforeAll(async () => {
+    port = await reserveRange(1);
+    adapter = new WebSocketAdapter(
+      { port },
+      {
+        onConnect: (id) => {
+          connectionId = id;
+        },
+      },
+    );
+    await adapter.start();
+
+    client = new WebSocketClient(
+      { url: `ws://localhost:${port}/ws`, heartbeatInterval: 0, connectionTimeout: 2000 },
+      {
+        onMessage: (msg) => {
+          received.push(msg);
+          if (msg.type === 'question') {
+            const ui = mapQuestionToUIQuestion(msg.question, msg.sessionId, msg.timestamp);
+            clientQuestions = applyIncomingQuestion(clientQuestions, ui, false);
+          } else if (msg.type === 'question_resolved') {
+            clientQuestions = resolveQuestionCard(
+              clientQuestions,
+              msg.sessionId,
+              msg.questionId,
+              msg.reason,
+            ).questions;
+          } else if (msg.type === 'question_snapshot') {
+            clientQuestions = pruneQuestionsNotLive(clientQuestions, msg.sessionId, msg.questionIds);
+          }
+        },
+      },
+    );
+    client.connect();
+    await waitFor(() => client.isConnected || client.isTransportOpen);
+    // Real hello handshake -- WebSocketAdapter sets skipHelloAck (the
+    // daemon's cli.ts normally acks), so no hello_ack arrives automatically;
+    // that's fine, this test never reads one. Matches the #897 conformance
+    // test's own beforeAll.
+    client.send(createHello(generateId(), '0.0.0-test'));
+    await waitFor(() => connectionId !== null);
+
+    sessionRegistry = new SessionRegistry(
+      {},
+      {
+        // Mirrors cli.ts's onQuestionsChanged: broadcast the authoritative
+        // live-id snapshot on every add/remove/clear (#798).
+        onQuestionsChanged: (sessionId, questions) => {
+          if (connectionId === null) return;
+          adapter.sendRaw(
+            connectionId,
+            createQuestionSnapshot(
+              sessionId,
+              questions.map((q) => q.id),
+            ),
+          );
+        },
+      },
+    );
+    sessionRegistry.registerSession(SID, '/conformance-test', fakePTY(), {
+      bulletCount: 0,
+    } as unknown as MessageAPI);
+
+    tracker = new QuestionPresenceTracker(
+      (q) => {
+        // Mirrors message-api-setup.ts's onQuestion: send the 'question'
+        // message, then register in the single pendingness owner.
+        if (connectionId !== null) {
+          adapter.sendRaw(connectionId, createQuestion(q, SID));
+        }
+        sessionRegistry.addQuestion(SID, q, q.source ?? 'unknown');
+      },
+      {
+        hasLiveQuestions: () => (sessionRegistry.getSession(SID)?.currentQuestions.size ?? 0) > 0,
+        // The #888/#920 hard requirement's wiring, mirroring cli.ts exactly:
+        // remove from the store, then broadcast question_resolved the same
+        // way every other cancellation route does.
+        onHooklessQuestionGone: (questionId, reason) => {
+          sessionRegistry.removeQuestion(
+            SID,
+            questionId as UUID,
+            reason,
+            undefined,
+            'QuestionPresenceTracker.onHooklessQuestionGone',
+          );
+          if (connectionId !== null) {
+            adapter.sendRaw(connectionId, createQuestionResolved(SID, questionId as UUID, 'cancelled'));
+          }
+        },
+      },
+    );
+  });
+
+  afterAll(async () => {
+    await sessionRegistry.shutdown();
+    client.disconnect();
+    await adapter.stop();
+  });
+
+  test('a hook-paired question: push then hook-signature resolution converge', async () => {
+    const hook = hookRecord('Allow Bash: git push origin main');
+    tracker.recordPendingHook(hook);
+    const render = hooklessPTYQuestion('Allow Bash: git push origin main');
+    tracker.onPTYPromptVisible(render); // pairs (sole candidate, #887 adopts hook.id)
+
+    await assertConverges();
+    expect(storeLiveIds().size).toBe(1);
+
+    // Resolve it the way AutoApproveGate.resolveSupersededQuestion does: a
+    // tool-signature match removes it, then broadcasts question_resolved.
+    sessionRegistry.removeQuestion(SID, hook.id, 'PostToolUse', 'Bash', 'AutoApproveGate.test');
+    adapter.sendRaw(connectionId as string, createQuestionResolved(SID, hook.id, 'cancelled'));
+
+    await assertConverges();
+    expect(storeLiveIds().size).toBe(0);
+  });
+
+  test('hard requirement: a hook-less question resolves when its render is superseded', async () => {
+    const first = hooklessPTYQuestion('First orphan prompt');
+    tracker.onPTYPromptVisible(first);
+    await assertConverges();
+    expect(storeLiveIds()).toEqual(new Set([first.id]));
+
+    // No hook, no tool signature, nothing but a new render taking its place
+    // -- the #920 leak's exact shape. The tracker's render-resolution
+    // transition is the only thing that can clear this.
+    const second = hooklessPTYQuestion('Second orphan prompt');
+    tracker.onPTYPromptVisible(second);
+
+    await assertConverges();
+    expect(storeLiveIds()).toEqual(new Set([second.id]));
+    // The FIRST id must be gone from the client too -- not just no longer
+    // "the latest", but actually resolved (question_resolved observed).
+    expect(clientQuestions.get(`${SID}#main`)?.id).not.toBe(first.id);
+  });
+
+  test('hard requirement: a hook-less question resolves when status leaves waiting', async () => {
+    const q = hooklessPTYQuestion('Waiting on a native agent-team prompt');
+    tracker.onPTYPromptVisible(q);
+    await assertConverges();
+    expect(storeLiveIds()).toEqual(new Set([q.id]));
+
+    tracker.onStatusChange('executing');
+
+    await assertConverges();
+    expect(storeLiveIds().size).toBe(0);
+  });
+
+  test('concurrent main + subagent hook-less prompts stay independent through resolution', async () => {
+    const main = hooklessPTYQuestion('Main hook-less prompt');
+    tracker.onPTYPromptVisible(main);
+    await assertConverges();
+
+    // A DIFFERENT session-registry question (concurrent subagent) added
+    // directly, simulating a second in-flight prompt the tracker isn't
+    // currently observing on the (single) PTY screen -- SessionRegistry
+    // itself supports N concurrent questions; only ONE can be "on screen"
+    // for the tracker's render-resolution purposes at a time.
+    const sub = hookRecord('Allow Bash: ls', 'sub-42');
+    sessionRegistry.addQuestion(SID, sub, sub.source ?? 'unknown');
+    adapter.sendRaw(connectionId as string, createQuestion(sub, SID));
+
+    await assertConverges();
+    expect(storeLiveIds()).toEqual(new Set([main.id, sub.id]));
+
+    // The main hook-less prompt's render disappears; the unrelated subagent
+    // question must be untouched.
+    tracker.onStatusChange('executing');
+    await assertConverges();
+    expect(storeLiveIds()).toEqual(new Set([sub.id]));
+
+    // Clean up for the next test.
+    sessionRegistry.removeQuestion(SID, sub.id, 'test-cleanup');
+    adapter.sendRaw(connectionId as string, createQuestionResolved(SID, sub.id, 'cancelled'));
+    await assertConverges();
+  });
+});

--- a/packages/web/tests/lib/question-store-conformance.test.ts
+++ b/packages/web/tests/lib/question-store-conformance.test.ts
@@ -1,31 +1,28 @@
 /**
  * Two-sided conformance test for the #888 QuestionStore + render-resolution
  * transition: drives the REAL daemon pending-question pipeline
- * (`SessionRegistry` -> `QuestionStore`, `QuestionPresenceTracker`) through
- * every transition, broadcasts the resulting `question` / `question_resolved`
- * / `question_snapshot` messages over a REAL socket (the same
- * `WebSocketAdapter` <-> `WebSocketClient` pair `message-dispatch-
- * conformance.test.ts` (#897) uses -- no synthetic counterparty, per
- * AGENTS.md "Verify before you describe"), and feeds them into the REAL
- * `packages/web/src/lib/question-collection.ts` reducers (the same functions
- * `App.tsx` calls) to build the client's view.
+ * (`SessionRegistry` -> `QuestionStore`, `MessageAPI` -> real `QuestionDedup`,
+ * `QuestionPresenceTracker`) through every transition, broadcasts the
+ * resulting `question` / `question_resolved` / `question_snapshot` messages
+ * over a REAL socket (the same `WebSocketAdapter` <-> `WebSocketClient` pair
+ * `message-dispatch-conformance.test.ts` (#897) uses -- no synthetic
+ * counterparty, per AGENTS.md "Verify before you describe"), and feeds them
+ * into the REAL `packages/web/src/lib/question-collection.ts` reducers (the
+ * same functions `App.tsx` calls) to build the client's view.
+ *
+ * Review of the first version of this suite found it wired the tracker's
+ * push sink straight to `adapter.sendRaw` + `sessionRegistry.addQuestion`,
+ * skipping `MessageAPI`/`QuestionDedup` entirely -- production (`cli.ts`)
+ * wires the push sink to `messageApi.handleQuestion`. Per ADR 0011 ("a test
+ * named for a component must construct it"), that gap meant this suite's
+ * "conformance" claim did not cover dedup interaction at all. This version
+ * constructs the real `MessageAPI` too, and adds the flap-then-redraw
+ * reproduction end to end over the real socket into the real client reducer.
  *
  * After every transition this asserts: the set of LIVE (still-pending)
  * question ids the client reducer sees equals the set of ids
  * `SessionRegistry.currentQuestions` -- the single owner #888 established --
- * currently holds. Nothing here is reimplemented or mocked: the daemon side
- * is the real `SessionRegistry`/`QuestionStore`/`QuestionPresenceTracker`
- * classes, the client side is the real `question-collection.ts` reducers
- * plus `mapQuestionToUIQuestion`, wired the same way `cli.ts` and `App.tsx`
- * wire them (`onQuestionsChanged` -> `question_snapshot` broadcast;
- * `QuestionPresenceTracker`'s push sink -> `question` + `SessionRegistry.
- * addQuestion`; a resolution -> `SessionRegistry.removeQuestion` +
- * `question_resolved`).
- *
- * The hard requirement under test: a HOOK-LESS question (no
- * PermissionRequest/Notification hook, `source: 'pty'`) can be resolved with
- * no signal but its render disappearing -- see the "hook-less render
- * disappears" cases below.
+ * currently holds.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
@@ -38,7 +35,7 @@ import {
   generateId,
 } from '@remi/shared/protocol.ts';
 import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
-import type { MessageAPI } from '../../../daemon/src/api/message-api.ts';
+import { MessageAPI } from '../../../daemon/src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../daemon/src/api/question-presence-tracker.ts';
 // Real daemon adapter + session pipeline -- not test doubles. Relative
 // import: packages/web has no `@remi/daemon` path alias (only
@@ -74,12 +71,16 @@ function opt(label: string, value: string, extras: Partial<QuestionOption> = {})
 }
 
 /** A genuinely hook-less PTY-parsed question, exactly as `question-parser.ts`
- *  mints one post-#920 (source: 'pty', fresh id every parse). */
-function hooklessPTYQuestion(text: string, agentId?: string): Question {
+ *  mints one post-#920 (source: 'pty', fresh id every parse). `optionCount`
+ *  lets a test build a "richer" redraw QuestionDedup lets through even
+ *  within its window, without waiting out or faking the real 5s clock. */
+function hooklessPTYQuestion(text: string, agentId?: string, optionCount = 2): Question {
+  const options: QuestionOption[] = [];
+  for (let i = 1; i <= optionCount; i++) options.push(opt(String(i), String(i)));
   return {
     id: generateId() as UUID,
     text,
-    options: [opt('1', '1'), opt('2', '2')],
+    options,
     allowsFreeText: false,
     isAnswered: false,
     source: 'pty',
@@ -120,6 +121,7 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
 
   const SID = generateId() as UUID;
   let sessionRegistry: SessionRegistry;
+  let messageApi: MessageAPI;
   let tracker: QuestionPresenceTracker;
   let clientQuestions = new Map<string, UIQuestion>();
 
@@ -211,20 +213,29 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
       bulletCount: 0,
     } as unknown as MessageAPI);
 
-    tracker = new QuestionPresenceTracker(
-      (q) => {
-        // Mirrors message-api-setup.ts's onQuestion: send the 'question'
-        // message, then register in the single pendingness owner.
-        if (connectionId !== null) {
-          adapter.sendRaw(connectionId, createQuestion(q, SID));
-        }
-        sessionRegistry.addQuestion(SID, q, q.source ?? 'unknown');
+    // Real MessageAPI, real QuestionDedup inside it -- NOT bypassed (#888
+    // review fix). Mirrors message-api-setup.ts's own onQuestion callback:
+    // send the wire 'question' message via the adapter's own factory
+    // (createQuestion is applied inside handleQuestion's caller in
+    // production; here the onQuestion event IS the confirmation a push
+    // landed, so build+send the message from it directly), then register.
+    messageApi = new MessageAPI(
+      { sessionId: SID, initialBulletId: 1 },
+      {
+        onQuestion: (question) => {
+          if (connectionId !== null) {
+            adapter.sendRaw(connectionId, createQuestion(question, SID));
+          }
+          sessionRegistry.addQuestion(SID, question, question.source ?? 'unknown');
+        },
       },
+    );
+
+    tracker = new QuestionPresenceTracker(
+      (q, opts) => messageApi.handleQuestion(q, opts),
       {
         hasLiveQuestions: () => (sessionRegistry.getSession(SID)?.currentQuestions.size ?? 0) > 0,
-        // The #888/#920 hard requirement's wiring, mirroring cli.ts exactly:
-        // remove from the store, then broadcast question_resolved the same
-        // way every other cancellation route does.
+        // The #888/#920 hard requirement's wiring, mirroring cli.ts exactly.
         onHooklessQuestionGone: (questionId, reason) => {
           sessionRegistry.removeQuestion(
             SID,
@@ -237,6 +248,10 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
             adapter.sendRaw(connectionId, createQuestionResolved(SID, questionId as UUID, 'cancelled'));
           }
         },
+        // Confirmation gate (#888 review fix): only a push that actually
+        // landed in the store (survived QuestionDedup) is evidence of
+        // supersession.
+        isQuestionLive: (id) => sessionRegistry.getQuestion(SID, id as UUID) !== null,
       },
     );
   });
@@ -265,15 +280,16 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
     expect(storeLiveIds().size).toBe(0);
   });
 
-  test('hard requirement: a hook-less question resolves when its render is superseded', async () => {
+  test('hard requirement: a hook-less question resolves when a CONFIRMED replacement supersedes it', async () => {
     const first = hooklessPTYQuestion('First orphan prompt');
     tracker.onPTYPromptVisible(first);
     await assertConverges();
     expect(storeLiveIds()).toEqual(new Set([first.id]));
 
-    // No hook, no tool signature, nothing but a new render taking its place
-    // -- the #920 leak's exact shape. The tracker's render-resolution
-    // transition is the only thing that can clear this.
+    // No hook, no tool signature, nothing but a new (distinct-fingerprint,
+    // so not deduped) render taking its place -- the #920 leak's exact
+    // shape. The tracker's render-resolution transition is the only thing
+    // that can clear this.
     const second = hooklessPTYQuestion('Second orphan prompt');
     tracker.onPTYPromptVisible(second);
 
@@ -284,16 +300,37 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
     expect(clientQuestions.get(`${SID}#main`)?.id).not.toBe(first.id);
   });
 
-  test('hard requirement: a hook-less question resolves when status leaves waiting', async () => {
-    const q = hooklessPTYQuestion('Waiting on a native agent-team prompt');
-    tracker.onPTYPromptVisible(q);
+  test('#888 review fix: a flap-then-redraw whose replacement is DEDUPED does not swallow the original, end to end', async () => {
+    // Reproduces the chain review found, over the REAL socket into the REAL
+    // client reducer: a PTY-text-parsed status flap (no paired dedup
+    // reset -- see cli.ts's `!hookServer` asymmetry) followed by the SAME
+    // prompt redrawing under a fresh id, deduped by the real QuestionDedup.
+    // The prior version of this mechanism resolved the original anyway; the
+    // fixed version must not.
+    const text = 'Allow this agent-team teammate to proceed?';
+    const a = hooklessPTYQuestion(text, undefined, 2);
+    tracker.onPTYPromptVisible(a);
     await assertConverges();
-    expect(storeLiveIds()).toEqual(new Set([q.id]));
+    expect(storeLiveIds()).toEqual(new Set([a.id]));
 
+    // False-positive status flap and flap-back -- deliberately NOT calling
+    // messageApi.handleStatusChange, mirroring cli.ts's hookServer-truthy
+    // branch (tracker.onStatusChange is unconditional; the dedup reset is
+    // not).
     tracker.onStatusChange('executing');
+    tracker.onStatusChange('waiting');
 
+    // Same text, fresh id, SAME option count (not richer) -- the real
+    // QuestionDedup suppresses it.
+    const redraw = hooklessPTYQuestion(text, undefined, 2);
+    tracker.onPTYPromptVisible(redraw);
+
+    // Give the (non-)broadcast a moment, then assert convergence on the
+    // ORIGINAL still being the sole live id -- neither client nor store
+    // ever saw a resolution for `a`, and the redraw never registered.
+    await wait(50);
     await assertConverges();
-    expect(storeLiveIds().size).toBe(0);
+    expect(storeLiveIds()).toEqual(new Set([a.id]));
   });
 
   test('concurrent main + subagent hook-less prompts stay independent through resolution', async () => {
@@ -313,15 +350,19 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
     await assertConverges();
     expect(storeLiveIds()).toEqual(new Set([main.id, sub.id]));
 
-    // The main hook-less prompt's render disappears; the unrelated subagent
-    // question must be untouched.
-    tracker.onStatusChange('executing');
+    // A genuinely NEW hook-less render for the main agent supersedes
+    // `main` (CONFIRMED delivery -- distinct fingerprint); the unrelated
+    // subagent question must be untouched.
+    const replacement = hooklessPTYQuestion('Main hook-less prompt, replaced');
+    tracker.onPTYPromptVisible(replacement);
     await assertConverges();
-    expect(storeLiveIds()).toEqual(new Set([sub.id]));
+    expect(storeLiveIds()).toEqual(new Set([sub.id, replacement.id]));
 
     // Clean up for the next test.
     sessionRegistry.removeQuestion(SID, sub.id, 'test-cleanup');
     adapter.sendRaw(connectionId as string, createQuestionResolved(SID, sub.id, 'cancelled'));
+    sessionRegistry.removeQuestion(SID, replacement.id, 'test-cleanup');
+    adapter.sendRaw(connectionId as string, createQuestionResolved(SID, replacement.id, 'cancelled'));
     await assertConverges();
   });
 });


### PR DESCRIPTION
## Summary

Q3 of epic #885. Two things, scoped deliberately:

1. **The hard requirement**: `QuestionPresenceTracker` can now resolve a
   question whose only evidence was a screen render. `question-parser.ts`
   sets `source: 'pty'` on every PTY-parsed question (documented since #574,
   never implemented -- issue #920's own diagnosis). A hook-less question
   has no tool signature for `AutoApproveGate.cancelExternallyResolved` or
   the Stop/SubagentStop sweeps to match, so it previously left
   `SessionRegistry.currentQuestions` only via the user answering it or the
   `MAX_PENDING_QUESTIONS` LRU cap -- the measured leak (12 of 29 daily
   source-less questions never removed, one still pending 2h51m later).
2. **A real, bounded slice of the consolidation**: `QuestionStore`
   (`packages/daemon/src/session/question-store.ts`) is now the single owner
   of the pending-question map. `SessionRegistry`'s
   `addQuestion`/`removeQuestion`/`clearQuestions`/`getQuestion` become thin
   adapters (unchanged signatures, per the issue's own ask) so no call site
   churns.

**The rest of the 8-store consolidation is explicitly NOT in this PR** --
see "Scope decision" below for why, and what remains.

**Revision note**: a review pass (see PR comments) found the first version
of the render-resolution mechanism could itself swallow a still-live
question under a specific status-flap-then-redraw sequence. That is fixed
-- see "How a render-only question now resolves" and "Review-found defect
and fix" below, both rewritten to describe the shipped design, not the
original one.

## The state machine

`QuestionStore` owns one `Map<UUID, Question>` per session: `add` (with LRU
eviction at 8), `remove`, `clear`, `get`, all emitting the SAME
`onQuestionsChanged(questions)` event `SessionRegistry` used to fire inline,
and the SAME question-lifecycle trace records (`question-trace.ts`), with
`callSite` defaults preserved byte-for-byte
(`SessionRegistry.addQuestion`/`removeQuestion`/`clearQuestions`, plus the
`:lru_eviction` eviction suffix) -- pinned by
`packages/daemon/tests/session/question-store-trace.test.ts`.

`ManagedSession.currentQuestions` is now `ReadonlyMap<UUID, Question>` -- a
live view over `QuestionStore`'s own map (same reference, not a copy), so
every existing `.get`/`.has`/`.size`/`.values`/`.keys` call site (cli.ts,
hook-bridge-setup.ts, pty-session-setup.ts, input-events.ts,
notification-dispatcher.ts, and ~15 test files) keeps working unchanged --
the type system itself now proves nothing outside `QuestionStore` can
mutate it.

**Grep proof of single ownership:**
```
$ grep -rn '\.map\.\(set\|delete\|clear\)(' packages/daemon/src
packages/daemon/src/session/question-store.ts:79:    this.map.delete(question.id);
packages/daemon/src/session/question-store.ts:80:    this.map.set(question.id, question);
packages/daemon/src/session/question-store.ts:85:      this.map.delete(oldest);
packages/daemon/src/session/question-store.ts:135:    this.map.delete(questionId);
packages/daemon/src/session/question-store.ts:156:    this.map.clear();
```
Every other `.set`/`.delete`/`.clear` call in the daemon touches an
unrelated map (`banneredQuestionIds`, `resolved-answer-cache`'s `entries`,
`auq-active-runs`, `QuestionPresenceTracker.pushedHeldIds`, APNS
`deliveryOutcomes`) -- verified by name, not by pattern alone.

## How a render-only question now resolves (the hard requirement)

`QuestionPresenceTracker` gained `observedHooklessQuestion` (the id of the
currently-pushed HOOK-LESS question, i.e. `consumeAndMerge`'s `hookRecord
=== undefined` branch) and two new deps: `onHooklessQuestionGone(questionId,
reason)` and `isQuestionLive(questionId)`.

**The single trigger, and why it's the only one**: `pairAndPush` pushes a
render first, then asks `isQuestionLive(merged.id)` to CONFIRM the push
actually landed (was not suppressed by `QuestionDedup`) before treating it
as evidence the previously-tracked hook-less question is gone. That push
-> `MessageAPI.handleQuestion` -> `QuestionDedup` -> `SessionRegistry.
addQuestion` chain is fully synchronous, so this is a same-tick check, not
a race. Only a CONFIRMED replacement resolves the old id; an unconfirmed
push (deduped, or the dep unset) changes nothing -- `observedHooklessQuestion`
stays exactly as it was, matching this codebase's existing "fail toward
showing" rule for every other ambiguous path.

A status-leaves-`'waiting'` transition and `clearPending` (session
restart/auto-approve-cancelled) were considered and REJECTED as triggers --
see "Review-found defect and fix" for why both are unsound, and why the
restart case needs no replacement (it's already covered elsewhere).

A hook-PAIRED render is NEVER tracked here (it already has a
signature-matched removal path); this mechanism is scoped tightly to the
one cohort that structurally has no other exit.

**Review finding, fixed in the same PR**: the merge's `...ptyQuestion`
spread was silently carrying `ptyQuestion.source` onto a HOOK-PAIRED merged
question too. Before `question-parser.ts` set `source: 'pty'`, this was
inert (`ptyQuestion.source` was always `undefined`); once it isn't, an
unfixed merge would have mislabeled every parked-then-rendered subagent
permission as the unresolvable-by-signature cohort. Fixed: the hook
record's own `source` now wins, mirroring the existing text/options/agentId
precedent. Side effect, verified by reading `pending-question-label.ts`:
that file's `question.source === 'permission_request'` branch (short
"Permission: `<tool>`" label for the macOS menu-bar app / hub census) had
NEVER fired for a parked/rendered subagent permission before this fix --
a second real, previously-invisible bug this same change corrects.

## Review-found defect and fix

A review pass found the first version of this mechanism could itself
swallow a still-live question. The chain:

1. `pairAndPush` compared the PTY-parsed render's **id alone**: "a
   different id arrived, so the old one must be superseded." Unsound --
   the PTY parser mints a FRESH id on every single parse (#486), even for
   a prompt that merely REDRAWS with unchanged text. This codebase already
   has a documented defense against exactly this (`isPromptCurrent`'s text
   fallback, with the comment "a prompt that merely redraws re-emits under
   a fresh id ... matching on the id alone would call a live prompt gone")
   that the first version didn't apply to this new mechanism.
2. `onStatusChange` fired the resolution on ANY transition out of
   `'waiting'`, including a PTY-TEXT-parsed status guess
   (`output-processor.ts`, confidence >= 0.5, not certainty).
3. **The reachable path**: `cli.ts`'s OutputProcessor-driven status
   callback calls `tracker.onStatusChange` UNCONDITIONALLY but gates
   `messageApi.handleStatusChange` (which resets `QuestionDedup`) behind
   `!hookServer`. A hook server is active for every normal session, so on
   the common path a status false-positive reaches the tracker with NO
   paired dedup reset.
4. Net: prompt A renders and registers -> a false-positive status flap
   fires resolution for A (V1's `onStatusChange` trigger) -> status flaps
   back to `'waiting'` with the SAME prompt still on screen -> it redraws
   under a fresh id B -> `QuestionDedup` (never reset) suppresses B as a
   same-fingerprint re-emission inside its 5s window -> neither A nor B is
   registered, and the client was already told A was cancelled. A live,
   unanswered question with no card -- the disqualifying failure for this
   epic, reachable from one status hiccup rather than hours of
   accumulation.

**Fix**: `isQuestionLive` (described above) replaces the id-only check with
a CONFIRMED-delivery check. `onStatusChange` and `clearPending` were
dropped as resolution triggers ENTIRELY, not corroborated:
- `onStatusChange` can't be trusted -- see the chain above -- and the
  tracker has no way to distinguish a hook-driven status change (which DOES
  pair with a dedup reset, `hook-bridge-setup.ts:363-366`) from the
  unreliable PTY-text-parsed one at the point `tracker.onStatusChange` is
  called; both funnel through the same method.
- `clearPending` is NOT restart-exclusive: `AutoApproveGate` also calls it
  on a CANCELLED eval for one specific hook-derived question
  (`auto-approve-gate.ts:1282,1356,1499`), which says nothing about
  whether some UNRELATED hook-less question is still on screen -- wiring
  resolution through it would reopen the same swallow class through a
  second door. The one call site that IS a genuine restart
  (`TranscriptBinder.onRotation`, `hook-bridge-setup.ts:602-603`) already
  resolves every pending question via `resolveAndClearQuestions` +
  `sessionRegistry.clearQuestions` in the same breath, so dropping the
  tracker's own trigger costs no real coverage.

Both resets leave `observedHooklessQuestion` untouched (not nulled) rather
than firing or discarding it, so a LATER confirmed supersession can still
correctly clean up the original -- losing a trigger costs a delayed
cleanup, never a wrong one.

## Tests for the review fix

- `packages/daemon/tests/api/question-presence-tracker-messageapi-integration.test.ts`
  (new): real `SessionRegistry` + `MessageAPI` (real `QuestionDedup` inside
  it, never bypassed) + `QuestionPresenceTracker`, wired exactly as
  `cli.ts:1524` wires them. Reproduces the flap-then-redraw chain above and
  asserts the original survives; also covers the positive case (a
  genuinely distinct redraw resolves the original) and a same-text
  redraw that IS delivered (a richer re-emission within the dedup window).
- `packages/web/tests/lib/question-store-conformance.test.ts`: now
  constructs a real `MessageAPI` too (the first version routed the push
  sink straight to `adapter.sendRaw` + `sessionRegistry.addQuestion`,
  skipping dedup entirely -- a real gap, matching ADR 0014 which landed on
  `develop` while this PR was in review). Includes the flap-then-redraw
  case end-to-end over a real socket into the real client reducer; the
  test log shows `[QuestionDedup] Suppressed agent=main`, confirming the
  real dedup layer is what's engaging.
- `question-presence-tracker-render-resolution.test.ts`: rewritten around
  a harness that models delivery confirmation explicitly, with a dedicated
  test for "deduped replacement does not resolve the original" and a
  safe-default test (dep unwired -> mechanism fully inert).

## Before/after leak measurement

**Scope, honestly**: no access to the owner's machine for a full working-day
capture -- this is not a live re-capture of #920's table. A reproducible
repro drives the REAL production pipeline (`SessionRegistry` +
`QuestionPresenceTracker`, no mocks) through 20 hook-paired permission
cycles (each resolved by tool signature -- the cohort #920 already found
zero leaks in) plus 15 hook-less PTY-only renders in a chain, each a
genuinely distinct render (so each supersedes the previous one via a
CONFIRMED delivery), comparing the tracker built WITHOUT
`onHooklessQuestionGone`/`isQuestionLive` wired (the composition that
shipped before this PR) against WITH:

| | added | removed | never-removed | lru_eviction | final pending |
|---|---|---|---|---|---|
| before | 35 | 27 | **8** (all `pty`) | **7** | 8 |
| after | 35 | 35 | **0** | **0** | 0 |

Note on this table after the review fix: all 15 hook-less renders in the
repro are genuinely distinct text, so every one is confirmed-delivered and
the chain fully resolves via supersession -- the corrected design does not
need a status/restart trigger to reach 0 here. A chain ending in a redraw
that gets deduped would correctly leave ONE entry pending (not a leak --
that's the still-live prompt), which is exactly what the new integration
tests pin directly rather than re-measure in this script.

`permission_request`-sourced adds: 0 never-removed in both runs. The script
and its output are not part of this diff; happy to re-run on request.

**Still no full working-day capture** -- flagging explicitly rather than
claiming one.

## PTY-arbiter (ADR 0004) unchanged -- evidence

Nothing in this PR touches a push/arbitration decision: `mainEvalsInFlight`,
`onPTYPromptVisible`'s buffer gate, `onOrphanPTYPrompt`'s parked/
suppression/orphan-debounce branches, `arbitrateParkedRender`, and
`isPromptCurrent`/`isPromptVisibleOnPTY` are byte-for-byte untouched. The
confirmed-delivery check runs strictly AFTER the push already happened, and
never influences whether/what gets pushed. Evidence: `question-identity.
test.ts` (Q2's 5 tests) and `auto-approve-gate.test.ts` (150 tests,
including the full #814 parked-render-arbitration describe block) pass
unmodified, before and after the review fix.

## Break-it-then-fix-it (two rounds: initial + review-fix verification)

**Initial mechanism** (before the review fix; superseded, included for the
record): disabling the original `noteHooklessGone` turned 8/14 and 3/4
tests red in the two suites that existed then; restoring brought both back
to green.

**Review-fix verification** (current, shipped design): forced
`delivered = true` unconditionally in `pairAndPush` (bypassing the new
`isQuestionLive` gate) and re-ran the three suites that exercise it:
- `question-presence-tracker-render-resolution.test.ts` +
  `question-presence-tracker-messageapi-integration.test.ts` combined:
  **3 of 19 failed**.
- `question-store-conformance.test.ts`: **1 of 4 failed**.
- Total: **5 of 23 red**, all and only the tests specifically exercising
  confirmed delivery (the flap-then-redraw case in both daemon and web
  form, the unit-level deduped-replacement case, and the safe-default
  case).

Restored (`git diff` clean against the committed state), re-ran: **23/23
green**.

## #798/#799/#808 regression tests -- ran unmodified, all green

`question-identity.test.ts`, `auto-approve-gate.test.ts`,
`connection-events.test.ts`, `pending-question-resend.test.ts`,
`hook-bridge-setup.test.ts`, `question-snapshot-broadcast.test.ts`,
`session-registry.test.ts`, `question-trace.test.ts`,
`question-trace-identity.test.ts` (daemon), `question-collection.test.ts`,
`question-mapping.test.ts` (web) -- none edited, all pass.

## #808 symptom 1 ("card survives a terminal answer") -- checked, partial

Code-level read, not a live re-measurement (no capture access). Splits by
cohort:

- **Hook-less (PTY-only) card, answered in the terminal, followed by
  another genuinely distinct render**: FIXED by this PR (confirmed
  supersession).
- **Hook-less card answered in the terminal with NOTHING else rendering
  afterward**: NOT fixed -- after the review fix, this can only resolve via
  the user answering it (already true) or LRU eviction. This is a
  DELIBERATE tradeoff after the review fix (dropping the status trigger
  costs this case); flagging it as a known gap rather than a claimed fix.
- **Hook-PAIRED card (a real parked subagent permission), DENIED in the
  terminal**: still open, unrelated to this mechanism (a deny fires no tool
  call, so no signature exists for `cancelExternallyResolved` to match, and
  hook-paired questions are deliberately out of scope here).

The issue's own text ("plausibly the same cause") is more qualified than
that after this review round: true for a hook-less card that gets
superseded by later activity, not for one that simply goes quiet.

## Scope decision: why the other 7 stores are not touched here

`AutoApproveGate`'s `pendingHolds`/`openQuestionSignatures`/`parkedInputs`/
`evalIdByQuestion`/`confirmedDeliveries` and `QuestionPresenceTracker`'s
`pending`/`awaitingPTY`/`bufferedDuringEval`/`armedOrphanQuestion` are left
exactly as they are. Each is metadata about HOW to resolve a question the
store already owns -- not a second, competing opinion on WHETHER it is
pending. Every one of them earned its exact current shape through a
specific past incident
(#425/#483/#496/#573/#625/#712/#718/#751/#763/#767/#798/#799/#802/#808/#814).
This review round is itself evidence for why: the FIRST version of even
this much smaller, more isolated mechanism had a real swallow-class bug
that needed a second pass to find. Collapsing the other 7 stores in the
same PR would have meant verifying that much more invariant history
simultaneously, with no independent checkpoint. Follow-up: fold
`PendingQuestionCreatedAtTracker` in next (lowest risk), then the gate's
maps once a soak on this PR's mechanism proves out in practice.

## Gates run (after the review fix + rebase onto develop)

- `bun run typecheck` (daemon): clean.
- `bun run typecheck:web`: clean.
- `bunx biome check .`: 0 errors / 48 warnings (repo baseline, unchanged).
- `bun test packages/daemon/tests --path-ignore-patterns="**/auto-approve/**"`:
  2649 pass / 0 fail (148 files). `auto-approve/` skipped per repo
  convention (untouched, LLM-sweep tests dominate runtime) --
  `auto-approve-gate.test.ts` run separately and targeted: 150 pass / 0
  fail.
- `cd packages/web && bun test`: 506 pass / 0 fail (30 files).
- Rebased onto `origin/develop` (was 3 commits behind; #922, #924 landed):
  clean rebase, no conflicts, all gates above re-run after.

## Anything contradicting the issue text

- The issue's store count (7, later corrected to 8) is accurate, but the
  acceptance criterion "Grep proves a single owner" is satisfiable for the
  CENTRAL pendingness map without collapsing the other 7 -- they are
  resolution bookkeeping, not competing stores of "is this pending". Scoped
  the PR around that distinction; flagging it as a judgment call.
- `#920`'s capture-derived table groups adds by `source`, which (before
  this PR) was ALWAYS `undefined` for a merged (parked/rendered subagent
  permission) question due to the merge bug fixed here -- the historical
  "29 source-less, 12 never removed" bucket mixed genuinely hook-less
  questions with mislabeled hook-paired ones. The 12-never-removed figure
  is unaffected; a re-capture after this PR will show a smaller `pty`
  bucket than 29.
- Found in review, worth recording here too: the render-resolution
  mechanism's OWN first version had a real, reachable swallow-class defect
  -- an id-comparison primitive this codebase had already learned not to
  trust (`isPromptCurrent`'s own text-fallback comment says so), reapplied
  without the guard, plus a pre-existing `cli.ts` dedup-reset asymmetry
  that made it reachable in production rather than theoretical.

Closes #888.
