### PR TITLE
Q4: PermissionDenied + Elicitation; Q5: drop notification synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,35 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`PermissionDenied` and `Elicitation`/`ElicitationResult` are now
+  registered hooks, observe-only** (#889, Q4). A classifier-denied permission
+  fires no tool call, so nothing previously proved a still-open escalation
+  was resolved; `PermissionDenied` now routes into the same
+  `AutoApproveGate.cancelExternallyResolved` funnel PreToolUse/PostToolUse
+  use, taking advantage of its exact `tool_use_id` (the one permission edge
+  where Claude Code sends one). An MCP `Elicitation` dialog previously
+  arrived only as a PTY orphan (the dedicated hook was never registered, and
+  the `Notification(elicitation_dialog)` variant that did fire was logged
+  and ignored); it now builds an answerable, free-text `Question` card
+  instead of fabricating Accept/Decline options nobody has verified against
+  a real dialog, and `ElicitationResult` resolves that exact card by
+  `elicitation_id`. Neither hook response encodes a decision —
+  `REMI_REGISTERED_HOOK_EVENTS` grows from 11 to 14, each new registration
+  measured at well under 1ms of added roundtrip latency locally.
+
 ### Fixed
+- **The redundant `Notification(permission_prompt)` question synthesis is
+  deleted** (#890, Q5). It fed a `QuestionPresenceTracker` stash that only
+  ever mattered if it arrived with no paired `PermissionRequest` — a richer
+  paired `PermissionRequest` (the common case) always superseded it, and the
+  stash itself is never pushed on its own. A capture corpus (4244 events / 5
+  sessions / one working day) found 68/68 `permission_prompt` notifications
+  paired by `prompt_id`, 0 unpaired. The event still flips status to
+  `'waiting'`; in the theoretical unpaired case, a still-rendering prompt
+  falls to the same orphan-PTY fallback every other hook-less prompt already
+  uses, not to silence.
+
 - **`QuestionStore` is now the single owner of a session's pending-question
   state, and a hook-less question can resolve from a screen render alone**
   (#888). Measured from a real capture (#920): of 29 daily source-less

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,12 @@ All notable changes to Remi are documented here.
   registered and the card the user could actually see was left with no
   automated way to clear. The map now refuses to displace a still-live card
   and never tracks an id that did not reach `sessionRegistry`, the same
-  confirmed-delivery gate #888 landed.
+  confirmed-delivery gate #888 landed. Review also added the two missing
+  guards' tests plus one proving `PermissionDenied` resolves only its own
+  agent when two escalations share a signature, and one proving Q5's residual
+  unpaired-notification path still surfaces a card; and corrected
+  `docs/claude-code-hook-contract.md`, which still listed all three
+  newly-registered events as unregistered.
 
 ### Fixed
 - **The redundant `Notification(permission_prompt)` question synthesis is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to Remi are documented here.
   `elicitation_id`. Neither hook response encodes a decision —
   `REMI_REGISTERED_HOOK_EVENTS` grows from 11 to 14, each new registration
   measured at well under 1ms of added roundtrip latency locally.
+  Review fix before merge: an `Elicitation` re-fired for an `elicitation_id`
+  whose card was still open used to repoint the correlation map at the repeat,
+  which `QuestionDedup` had already suppressed (same text, same zero options,
+  so never "richer") — so `ElicitationResult` resolved an id that was never
+  registered and the card the user could actually see was left with no
+  automated way to clear. The map now refuses to displace a still-live card
+  and never tracks an id that did not reach `sessionRegistry`, the same
+  confirmed-delivery gate #888 landed.
 
 ### Fixed
 - **The redundant `Notification(permission_prompt)` question synthesis is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ All notable changes to Remi are documented here.
   fires no tool call, so nothing previously proved a still-open escalation
   was resolved; `PermissionDenied` now routes into the same
   `AutoApproveGate.cancelExternallyResolved` funnel PreToolUse/PostToolUse
-  use, taking advantage of its exact `tool_use_id` (the one permission edge
-  where Claude Code sends one). An MCP `Elicitation` dialog previously
+  use, matching on `tool_name` + `tool_input` + `agentId`. (It does carry a
+  `tool_use_id`, unlike `PermissionRequest` — but the escalation it would match
+  was registered from a `PermissionRequest`, which never sends one, so the
+  exact-id branch is unreachable from this path today and the id is
+  forward-compatible only.) An MCP `Elicitation` dialog previously
   arrived only as a PTY orphan (the dedicated hook was never registered, and
   the `Notification(elicitation_dialog)` variant that did fire was logged
   and ignored); it now builds an answerable, free-text `Question` card

--- a/docs/claude-code-hook-contract.md
+++ b/docs/claude-code-hook-contract.md
@@ -125,8 +125,9 @@ it can proceed with that action — a stale or slow daemon can make Claude Code
 unable to submit a prompt, create a worktree, or finish a session, purely
 because a hook nobody needed a decision from is still gating the action
 (#203). This is why `HOOK_EVENT_NAMES` (31, type-complete as of this PR) and
-`REMI_REGISTERED_HOOK_EVENTS` (11, unchanged by this PR) are and must stay
-two different lists.
+`REMI_REGISTERED_HOOK_EVENTS` (11 when this document landed; **14 since #889**
+added `PermissionDenied`, `Elicitation` and `ElicitationResult`) are and must
+stay two different lists.
 
 ### Axis 2: semantic power — varies from zero to full override, per event
 
@@ -178,7 +179,10 @@ case than an event whose response can only leave a comment.
 tracked 22 before this PR; the 9 missing (`Setup`, `UserPromptExpansion`,
 `PermissionDenied`, `PostToolBatch`, `MessageDisplay`, `CwdChanged`,
 `FileChanged`, `DirectoryAdded`, `TaskCreated`) are added by this PR at the
-type level only (not registered — see the blocking-semantics section).
+type level only (not registered — see the blocking-semantics section). Of
+those, `PermissionDenied` has since been registered too (#889), along with
+`Elicitation`/`ElicitationResult`, which were already typed; the **Reg.**
+column below is the current list, not this PR's.
 
 Legend: **Reg.** = in `REMI_REGISTERED_HOOK_EVENTS` today. **Resp.** = has a
 dedicated `hookSpecificOutput` response schema (see the semantic-power table
@@ -190,15 +194,15 @@ above for what it does).
 | `PostToolUse` | Y | `tool_name, tool_input, tool_response, tool_use_id?, duration_ms` | Y | [B] `duration_ms` was missing (named in #886) |
 | `PostToolUseFailure` | Y | `tool_name, tool_input, error, tool_use_id?, is_interrupt?, duration_ms?` | Y (context only) | [B] 3 input fields were missing (named in #886) |
 | `PostToolBatch` | — | `tool_calls: unknown[]` | Y | [B] new type this PR; per-item shape not traced |
-| `PermissionDenied` | — | `tool_name, tool_input, tool_use_id?, reason?` | Y (`retry`) | [B] new type this PR; unlike `PermissionRequest`, DOES carry `tool_use_id` |
+| `PermissionDenied` | Y (#889) | `tool_name, tool_input, tool_use_id?, reason?` | Y (`retry`) | [B] new type this PR; unlike `PermissionRequest`, DOES carry `tool_use_id` |
 | `PermissionRequest` | Y | `tool_name, tool_input, permission_suggestions?` — **no `tool_use_id`** | Y (full decision) | [B] confirms the "no tool_use_id" conclusion in `hook-types.ts` was correct; only its citation (cc-ref) was wrong |
 | `UserPromptExpansion` | — | `expansion_type, command_name, command_args?, command_source?, prompt` | Y (context only) | [B] new type this PR |
 | `PreCompact` | — | `trigger, custom_instructions?` | — | [B] was typed `source`; binary sends `trigger`. Named in #886 |
 | `PostCompact` | — | `trigger, compact_summary?` | — | [B] same `source`→`trigger` correction; `compact_summary` named in #886 |
 | `ConfigChange` | — | `source, file_path` | — | [B] was typed `config_type: string`, which **does not exist** in the binary at all — see "Renames, not additions" below |
 | `DirectoryAdded` | — | `directory, source?` | — | [B] new type this PR. **Not documented on code.claude.com/docs/en/hooks** — confirmed by direct page search, see "Version sensitivity" |
-| `Elicitation` | — | `mcp_server_name, message?, mode?, url?, elicitation_id?, requested_schema?` | Y | [B] only `mcp_server_name` was typed before this PR |
-| `ElicitationResult` | — | `mcp_server_name, elicitation_id?, mode?, action?, content?` | Y | [B] same |
+| `Elicitation` | Y (#889) | `mcp_server_name, message?, mode?, url?, elicitation_id?, requested_schema?` | Y | [B] only `mcp_server_name` was typed before this PR |
+| `ElicitationResult` | Y (#889) | `mcp_server_name, elicitation_id?, mode?, action?, content?` | Y | [B] same |
 | `CwdChanged` | — | `old_cwd, new_cwd` | Y (`watchPaths`) | [B] new type this PR |
 | `FileChanged` | — | `file_path, event` | Y (`watchPaths`) | [B] new type this PR |
 | `InstructionsLoaded` | — | `file_path, memory_type, load_reason, globs?, trigger_file_path?, parent_file_path?` | — | [B] was typed `source: string`, which **does not exist** in the binary at all |

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -433,6 +433,15 @@ export class QuestionPresenceTracker {
       // A pending rich permission request stays put unless the incoming is a
       // newer permission request: a generic Notification or a source-less
       // StopFailure-shaped question for the same agent must NOT evict it.
+      //
+      // Currently UNREACHABLE, deliberately kept (#890/Q5): both entry points
+      // -- `hook-bridge-setup.ts`'s `onQuestion` (gated to
+      // `source === 'permission_request'`) and `parkAwaitingPTY` below (always
+      // a permission question) -- now pass only 'permission_request', because
+      // Q5 deleted the 'notification' synthesis that was the other caller.
+      // Not deleted: this is the invariant that makes adding a future stashed
+      // source safe, and re-deriving it after a regression is how #574 was
+      // found in the first place.
       if (existing.source === 'permission_request' && question.source !== 'permission_request') {
         console.debug(
           `[QuestionPresenceTracker] Keeping richer pending permission_request for agent "${key}"; not evicting with source="${question.source ?? 'undefined'}" (kept="${existing.text.slice(0, 50)}", dropped="${question.text.slice(0, 50)}")`,
@@ -728,8 +737,10 @@ export class QuestionPresenceTracker {
             // `source: 'pty'` to the parser would have mislabeled every
             // hook-paired render as the unresolvable-by-signature cohort,
             // muddying the exact measurement #920's acceptance criterion asks
-            // for. The hook's own source ('permission_request' | 'notification')
-            // is authoritative here, mirroring text/options/agentId above.
+            // for. The hook's own source is authoritative here, mirroring
+            // text/options/agentId above. That source is always
+            // 'permission_request' since #890/Q5 deleted the 'notification'
+            // synthesis -- the only other value that ever reached this stash.
             source: hookRecord.source ?? ptyQuestion.source,
             // #718 review: `optionsAreFallback` must describe whichever
             // `options` ended up on the merged question, not silently inherit
@@ -801,9 +812,12 @@ export class QuestionPresenceTracker {
    * returns — and re-pushing those is the #625 phantom flood. But some
    * prompts reach ONLY the PTY (#712): Claude's native agent-team permission
    * prompts (no PermissionRequest hook fires for these at all, see
-   * anthropics/claude-code #23983), a prompt re-rendered as passthrough after
-   * a held hook was released (its card already dismissed, registry entry
-   * removed), and MCP elicitation dialogs. Those must still reach the phone.
+   * anthropics/claude-code #23983), and a prompt re-rendered as passthrough
+   * after a held hook was released (its card already dismissed, registry entry
+   * removed). Those must still reach the phone. (MCP elicitation dialogs USED
+   * to belong on this list; since #889 the `Elicitation` hook is registered
+   * and pushes the card itself, so its PTY render is a gate-owned echo like
+   * any other -- suppressed below via the live-question check, not orphaned.)
    *
    * Disambiguation is structural, not content-based: if the gate already owns
    * this prompt cycle, EITHER it has already registered a live question

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1568,8 +1568,9 @@ async function createNewSession(
         // phantom-notification source (>1,100 confirmed pushes fired right after a
         // 0 ms approve). But #624/#712 review found real prompts that reach ONLY
         // the PTY (Claude's native Agent-Teams permissions, a passthrough
-        // re-render after a held hook's card was already dismissed, MCP
-        // elicitation dialogs) — those were silently swallowed by the old
+        // re-render after a held hook's card was already dismissed; MCP
+        // elicitation dialogs were a third until #889 registered the
+        // `Elicitation` hook) — those were silently swallowed by the old
         // unconditional suppression. `onOrphanPTYPrompt` tells the two apart
         // structurally (pending hook record / live registered question means the
         // gate owns this cycle) and debounces the genuine orphans before pushing.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -387,7 +387,55 @@ export function setupHookBridge(
   // session's lifetime, mirroring `AutoApproveGate`'s `MAX_PARKED_INPUTS`.
   const MAX_PENDING_ELICITATIONS = 32;
   const elicitationQuestions = new Map<string, UUID>();
+  /**
+   * Record `elicitation_id -> questionId`, but NEVER let an id that is not a
+   * live registered card displace one that is (review finding on #889).
+   *
+   * `handleElicitation` mints an id and returns it unconditionally, but the
+   * emission behind it is fire-and-forget and can be dropped: `MessageAPI.
+   * handleQuestion` returns void and silently skips `addQuestion` when
+   * `QuestionDedup.shouldEmit` is false (`message-api.ts`). A re-fired
+   * `Elicitation` for the SAME `elicitation_id` is exactly that case — same
+   * `mcp_server_name`/`message` text, same `options: []` + `allowsFreeText:
+   * true`, so never "richer" — and the dedup baseline is still live because
+   * `handleElicitation` emits the question BEFORE its `onStatusChange
+   * ('waiting')`, so status never leaves 'waiting' to reset it. Overwriting
+   * blindly therefore pointed the map at a card that was never registered,
+   * leaving the FIRST card (the one the user can actually see) unreachable:
+   * `ElicitationResult` resolved the phantom, and the live card could only
+   * clear by the user answering it or LRU eviction. Same defect class as #925
+   * — a resolution path that cannot reach the question it is for — so the same
+   * guard: confirm the target is really registered.
+   *
+   * Note the rule is the OPPOSITE of `cancelExternallyResolved`-before-
+   * register (`auto-approve-gate.ts`), which resolves the earlier entry so the
+   * newer one wins. There, a re-requested permission genuinely re-renders, so
+   * newest is the live prompt. Here a re-fired `Elicitation` is the SAME MCP
+   * dialog, and the newer card is the one that does not exist; keeping the
+   * older, still-live card is what makes `ElicitationResult` able to close it.
+   */
   const rememberElicitation = (elicitationId: string, questionId: UUID): void => {
+    const previous = elicitationQuestions.get(elicitationId);
+    if (previous !== undefined && previous !== questionId) {
+      const previousIsLive = sessionRegistry.getQuestion(sessionId, previous) !== null;
+      if (previousIsLive) {
+        logError(
+          `[Hooks] Elicitation re-fired for ${elicitationId} while its card ${previous} is still live; keeping it (not tracking ${questionId}) so ElicitationResult resolves the card the user can see`,
+        );
+        return;
+      }
+    }
+    // Confirmed delivery, the #925 gate: `addQuestion` runs synchronously
+    // inside the `onQuestion` chain, so by now the card is either registered
+    // or was dropped. Tracking an id that never registered would make
+    // `ElicitationResult` broadcast a dismiss for a card no client ever saw
+    // and consume a slot under `MAX_PENDING_ELICITATIONS` for nothing.
+    if (sessionRegistry.getQuestion(sessionId, questionId) === null) {
+      logError(
+        `[Hooks] Elicitation card ${questionId} for ${elicitationId} was not registered (deduped as a repeat of a still-open prompt); not tracking it`,
+      );
+      return;
+    }
     if (elicitationQuestions.size >= MAX_PENDING_ELICITATIONS) {
       const oldest = elicitationQuestions.keys().next();
       if (!oldest.done) {

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -384,7 +384,10 @@ export function setupHookBridge(
   // Scoped to this session's closure (dropped with the bridge on teardown, so
   // it cannot outlive the session); capped defensively so a pathological
   // stream of never-resolved elicitations cannot grow it unbounded within one
-  // session's lifetime, mirroring `AutoApproveGate`'s `MAX_PARKED_INPUTS`.
+  // session's lifetime. Same motivation as `AutoApproveGate`'s
+  // `MAX_PARKED_INPUTS` but deliberately a smaller number, not a mirror of it
+  // (that one is 64, `auto-approve-gate.ts`): an MCP dialog per session is far
+  // rarer than a parked permission input.
   const MAX_PENDING_ELICITATIONS = 32;
   const elicitationQuestions = new Map<string, UUID>();
   /**
@@ -1078,8 +1081,10 @@ export function setupHookBridge(
     // A classifier denial fires no tool call, so PreToolUse/PostToolUse never
     // observe it -- this is the ONLY external-resolution signal for it. Same
     // funnel, same signature-then-tool_use_id matching as PreToolUse/
-    // PostToolUse above; a no-op when nothing open matches (#889: "every
-    // ambiguous path resolves toward showing the user" -- this never guesses,
+    // PostToolUse above; a no-op when nothing open matches (the codebase-wide
+    // rule from `auto-approve-gate.ts`, "every ambiguous path resolves toward
+    // showing the user" -- see `question-presence-tracker.ts`'s own citation of
+    // it; NOT something #889 introduced -- this never guesses,
     // it only clears an escalation THIS gate is still tracking under the
     // exact same tool_name+tool_input+agentId, and tool_use_id when both
     // sides carry one).

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -34,13 +34,28 @@
  * still open for THAT agent (the terminal-rejection case a matching tool
  * call can never signal, since a deny produces no tool call at all).
  *
+ * #889 (Q4) adds two more observe-only resolution/surfacing paths, both
+ * registered in `REMI_REGISTERED_HOOK_EVENTS` for the first time here:
+ *   - `PermissionDenied` routes into the SAME external-resolution funnel as
+ *     PreToolUse/PostToolUse (`gate.cancelExternallyResolved`) — a classifier
+ *     denial fires no tool call, so without this a still-open escalation for
+ *     it would linger with no other resolution signal.
+ *   - `Elicitation` builds an answerable card (`hookBridge.handleElicitation`,
+ *     source `'elicitation'`, direct-emitted like a source-less StopFailure
+ *     card) instead of leaving an MCP dialog as a PTY orphan; `elicitationQuestions`
+ *     (below) remembers its `elicitation_id` so a later `ElicitationResult`
+ *     can resolve the SAME card by exact id, mirroring PermissionDenied's
+ *     "close the lingering-card gap" shape.
+ *
  * This listener block IS the per-session hook router (admit-then-fan-out); a
  * formal HookRouter class is deferred to a later refactor (#470). The function
- * registers 11 hookServer listeners — the original 7 (SessionStart, PreToolUse,
- * PostToolUse, Notification, PermissionRequest, Stop, SessionEnd) plus the 4
+ * registers 13 hookServer `.on()` listeners — the original 6 (SessionStart,
+ * PreToolUse, PostToolUse, Notification, Stop, SessionEnd; PermissionRequest
+ * is installed separately via `setPermissionResolver`, not `.on()`) plus the 4
  * wired in phase 4 (StopFailure, PostToolUseFailure, SubagentStart, SubagentStop)
- * — and returns void. It runs once per session at createNewSession time, only
- * when a hookServer is configured.
+ * plus the 3 wired for Q4 (#889: PermissionDenied, Elicitation,
+ * ElicitationResult) — and returns void. It runs once per session at
+ * createNewSession time, only when a hookServer is configured.
  *
  * The inline session-binding path this file used to also carry (pre-#453) and
  * the shadow-mode differential wiring (#453 phase 3, commit 3) were deleted in
@@ -357,6 +372,63 @@ export function setupHookBridge(
     sessionRegistry.clearQuestions(sessionId, 'session_restart');
   };
 
+  // ---- Elicitation correlation (#889, Q4) ----------------------------------
+  //
+  // `Elicitation` builds a card via `hookBridge.handleElicitation`, direct-
+  // emitted (source 'elicitation', not stashed by the tracker -- see the
+  // module doc above). `ElicitationResult` is the resolution signal: both
+  // events carry `elicitation_id` (optional -- absent on either side means no
+  // correlation is possible, same graceful-degradation as PermissionRequest's
+  // missing tool_use_id), an EXACT key, so this map is a simple id->id lookup
+  // rather than the tool-signature matching `openQuestionSignatures` needs.
+  // Scoped to this session's closure (dropped with the bridge on teardown, so
+  // it cannot outlive the session); capped defensively so a pathological
+  // stream of never-resolved elicitations cannot grow it unbounded within one
+  // session's lifetime, mirroring `AutoApproveGate`'s `MAX_PARKED_INPUTS`.
+  const MAX_PENDING_ELICITATIONS = 32;
+  const elicitationQuestions = new Map<string, UUID>();
+  const rememberElicitation = (elicitationId: string, questionId: UUID): void => {
+    if (elicitationQuestions.size >= MAX_PENDING_ELICITATIONS) {
+      const oldest = elicitationQuestions.keys().next();
+      if (!oldest.done) {
+        elicitationQuestions.delete(oldest.value);
+        logError(
+          `[Hooks] elicitationQuestions at cap (${MAX_PENDING_ELICITATIONS}) for ${sessionId}; evicted the oldest tracked elicitation -- its ElicitationResult (if any) will no longer resolve its card`,
+        );
+      }
+    }
+    elicitationQuestions.set(elicitationId, questionId);
+  };
+  /** Resolve + clear a previously-pushed elicitation card by its exact
+   *  `elicitation_id`. A no-op when nothing is tracked under that id (no
+   *  correlation was possible, already resolved, or evicted at the cap) --
+   *  mirrors `cancelExternallyResolved`'s own no-op-on-no-match safety. */
+  const resolveElicitation = (elicitationId: string): void => {
+    const questionId = elicitationQuestions.get(elicitationId);
+    if (!questionId) return;
+    elicitationQuestions.delete(elicitationId);
+    try {
+      deps.broadcastQuestionResolved?.(sessionId, questionId, 'cancelled');
+    } catch (err) {
+      logError(
+        `[Hooks] question_resolved broadcast (ElicitationResult) failed for ${questionId}: ${errorToString(err)}`,
+      );
+    }
+    try {
+      sessionRegistry.removeQuestion(
+        sessionId,
+        questionId,
+        'ElicitationResult',
+        undefined,
+        'setupHookBridge.resolveElicitation',
+      );
+    } catch (err) {
+      logError(
+        `[Hooks] removeQuestion (ElicitationResult) failed for ${questionId}: ${errorToString(err)}`,
+      );
+    }
+  };
+
   // ---- Bridge + hook handler registration ---------------------------------
 
   const hookBridge = new HookEventBridge(sessionId, {
@@ -370,17 +442,19 @@ export function setupHookBridge(
       // via onHeldEscalate, passthrough via escalatePassthrough). recordPendingHook
       // only stashes; it never emits on its own.
       //   - 'permission_request' (rich: tool + command + options) is the one the gate
-      //     escalates and pushes by id.
-      //   - 'notification' is Claude's redundant generic "needs your permission"
-      //     prompt; it is INTENTIONALLY stashed-and-suppressed (NOT routed to the
-      //     direct-emit path), because direct-emitting it would push for EVERY
-      //     permission — including auto-approved ones — which is exactly the phantom
-      //     #625 removes. It is bounded (one per agent) and cleared on status-leaves-
-      //     waiting. (Assumes Claude pairs it with a PermissionRequest, true today.)
+      //     escalates and pushes by id. This is the ONLY source stashed here now:
+      //     `HookEventBridge` used to also synthesize a redundant generic
+      //     'notification' question from Claude's Notification(permission_prompt)
+      //     (Claude still fires it — it just pairs with the PermissionRequest above
+      //     rather than producing a second Question); #890/Q5 deleted that
+      //     synthesis after a capture corpus found 0 unpaired occurrences across
+      //     4244 events / 5 sessions / one day (see `handleNotification`'s own
+      //     comment for the full argument + residual failure mode).
       // A STANDALONE hook question that no gate pushes (e.g. a Stop-failure "Retry?",
-      // source-less) is emitted directly to the client + lock screen, since the
-      // PTY-render push that used to deliver it is suppressed for hooked sessions.
-      if (question.source === 'permission_request' || question.source === 'notification') {
+      // source-less, or an 'elicitation' card, #889) is emitted directly to the
+      // client + lock screen, since the PTY-render push that used to deliver it
+      // is suppressed for hooked sessions.
+      if (question.source === 'permission_request') {
         tracker.recordPendingHook(question);
       } else {
         messageApi.handleQuestion(question);
@@ -601,6 +675,11 @@ export function setupHookBridge(
         // stale answers are refused.
         tracker.clearPending();
         resolveAndClearQuestions();
+        // #889: drop any elicitation_id correlations too -- their target
+        // questions were just cleared above, and a stale entry surviving into
+        // the new session could (in principle, if Claude Code ever reused an
+        // elicitation_id) resolve an unrelated future card.
+        elicitationQuestions.clear();
         // The new session starts with no subagents (#499 phase 3).
         if (subagentViews) {
           subagentViews.clear();
@@ -936,6 +1015,55 @@ export function setupHookBridge(
       tracker.noteAgentAdvanced(input.agent_id);
       autoApproveGate.cancelStaleForAgent(input.agent_id, 'SubagentStop');
     }
+  });
+
+  // ---- Q4 (#889): PermissionDenied + Elicitation/ElicitationResult --------
+  // Newly registered in REMI_REGISTERED_HOOK_EVENTS by this change (see
+  // hook-types.ts for why). Both stay observe-only: neither hook response
+  // encodes a decision -- `handleRequest` (hook-server.ts) never installs a
+  // resolver for these event names, so they always fall through to the plain
+  // `{}` 200 response, exactly like Stop/SessionEnd/StopFailure today.
+
+  hookServer.on('PermissionDenied', (input) => {
+    binder.onHookEvent(input);
+    if (!binder.admits(input)) return;
+    // A classifier denial fires no tool call, so PreToolUse/PostToolUse never
+    // observe it -- this is the ONLY external-resolution signal for it. Same
+    // funnel, same signature-then-tool_use_id matching as PreToolUse/
+    // PostToolUse above; a no-op when nothing open matches (#889: "every
+    // ambiguous path resolves toward showing the user" -- this never guesses,
+    // it only clears an escalation THIS gate is still tracking under the
+    // exact same tool_name+tool_input+agentId, and tool_use_id when both
+    // sides carry one).
+    autoApproveGate.cancelExternallyResolved(
+      {
+        toolName: input.tool_name,
+        toolInput: input.tool_input,
+        toolUseId: input.tool_use_id,
+        agentId: input.agent_id,
+      },
+      'PermissionDenied',
+    );
+  });
+
+  hookServer.on('Elicitation', (input) => {
+    binder.onHookEvent(input);
+    if (!binder.admits(input)) return;
+    try {
+      const questionId = hookBridge.handleElicitation(input);
+      if (input.elicitation_id) {
+        rememberElicitation(input.elicitation_id, questionId);
+      }
+    } catch (err) {
+      logError(`[Hooks] Elicitation handling failed for ${sessionId}: ${errorToString(err)}`);
+    }
+  });
+
+  hookServer.on('ElicitationResult', (input) => {
+    binder.onHookEvent(input);
+    if (!binder.admits(input)) return;
+    if (!input.elicitation_id) return;
+    resolveElicitation(input.elicitation_id);
   });
 
   log(`[Hooks] Event bridge active for session ${sessionId}`);

--- a/packages/daemon/src/cli/session-phases/message-api-setup.ts
+++ b/packages/daemon/src/cli/session-phases/message-api-setup.ts
@@ -151,9 +151,10 @@ export function createMessageApiForSession(
         ...(claudeSessionId !== undefined && claudeSessionId !== null && { claudeSessionId }),
       };
       sendAndRecord(msg);
-      // #808: `source` ('permission_request' | 'notification' | 'pty') is the
-      // richest "why did this appear" signal already on the Question, and
-      // free to pass through -- no extra threading needed.
+      // #808: `source` (QuestionSource: 'permission_request' | 'notification' |
+      // 'pty' | 'elicitation', #889) is the richest "why did this appear"
+      // signal already on the Question, and free to pass through -- no extra
+      // threading needed.
       sessionRegistry.addQuestion(questionSessionId, stamped, stamped.source ?? 'unknown');
 
       // Push: a non-held question only pushes when no client is attached (the

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -6,29 +6,33 @@
  * This is the hook-based replacement for terminal output parsing.
  *
  * Permission question flow (verified from real hook logs 2026-04-12, updated
- * #718 for structured suggestions observed 2026-07-06):
+ * #718 for structured suggestions observed 2026-07-06; #890/Q5 2026-07-29):
  *   - PermissionRequest fires with tool_name, tool_input, and optionally
  *     permission_suggestions. This is either a legacy plain-string label set
  *     (e.g. ["Yes","Always","No"] for Edit) OR, since ~Claude Code 2.0.54, a
  *     STRUCTURED array of typed entries (`addRules`, `addDirectories`,
  *     `setMode`, ...) — see `optionsFromSuggestions` for how each shape maps
  *     to a variable-count option set (never a fixed 3). With NO usable
- *     suggestions of either shape, the honest Yes/No 2-set substitutes.
+ *     suggestions of either shape, the honest Yes/No 2-set substitutes. This
+ *     is the ONLY event that forwards a Question to `onQuestion` for a
+ *     permission prompt (see `handlePermissionRequest`).
  *   - Notification(permission_prompt) fires shortly after with a plain-text
  *     message like "Claude needs your permission to use Bash" (no numbered
- *     options; those appear only in the terminal UI) — always the Yes/No
- *     fallback, since this event never carries permission_suggestions.
- *   - Both events forward their question to onQuestion. The push gate is
- *     QuestionPresenceTracker (cli.ts wiring): hook events stash the
- *     metadata; PTY confirms presence and fires the push. If both events
- *     arrive before PTY (typical), the second simply replaces the first
- *     in the tracker — Claude only renders one prompt at a time.
+ *     options; those appear only in the terminal UI). It no longer
+ *     synthesizes a second `Question` (#890, Q5: the
+ *     `tracker.recordPendingHook` stash it fed was a stash-only safety net,
+ *     immediately superseded whenever paired with the richer
+ *     PermissionRequest above, and a capture corpus — 4244 events / 5
+ *     sessions / one day — found 68/68 pairs, 0 unpaired; see
+ *     `handleNotification` for the full argument and the residual-failure-
+ *     mode analysis). It still flips status to `'waiting'`.
  */
 
 import { DEFAULT_PERMISSION_LABELS, generateId } from '@remi/shared';
 import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
 import type { HookServerEvents } from './hook-server.ts';
 import type {
+  ElicitationHookInput,
   NotificationHookInput,
   PermissionRequestHookInput,
   PostToolUseFailureHookInput,
@@ -330,35 +334,46 @@ export class HookEventBridge {
 
   handleNotification(input: NotificationHookInput): void {
     if (input.notification_type === 'permission_prompt') {
-      // Phase 4 (#419): the subagentContext drop previously sat here.
-      // It was redundant defense: cli.ts hook-bridge-setup already
-      // forwards subagent events (phase 4 removed the agent_id gate)
-      // and the tracker handles presence by PTY confirmation. Keep
-      // SubagentContextTracker for the auto-approve default-deny path
-      // (still consumed via hookBridge.isInSubagentContext()).
+      // #925/#890 (Q5): the `source: 'notification'` Question synthesis that
+      // used to live here was DELETED after the capture gate closed it out.
+      // `hook-bridge-setup.ts`'s `onQuestion` callback routed BOTH
+      // 'permission_request' and 'notification' sources to
+      // `tracker.recordPendingHook`, which only STASHES (no push of its own —
+      // verified by reading the method body: it touches only `this.pending`,
+      // never the push sink). The stash existed purely as a safety net for
+      // the case where this Notification arrives with NO paired
+      // PermissionRequest for the same prompt; a paired PermissionRequest's
+      // OWN richer stash is never evicted by a later Notification
+      // (`recordPendingHook`'s "richer wins" rule), so in the paired case
+      // this stash was always dead weight, immediately superseded.
       //
-      // Forward the question — push semantics live in the tracker
-      // (cli.ts wiring). A trailing Notification arriving after
-      // PermissionRequest replaces the pending record, which is fine
-      // (Claude renders one prompt at a time).
-      const question: Question = {
-        id: generateId(),
-        text: input.message || 'Allow this action?',
-        options: [...DEFAULT_PERMISSION_OPTIONS],
-        allowsFreeText: false,
-        isAnswered: false,
-        agentId: input.agent_id,
-        // #887: same-turn correlation key, see `Question.promptId`.
-        promptId: input.prompt_id,
-        // Generic fallback: the tracker must let a richer PermissionRequest
-        // for the same agent win over this text/options (#574).
-        source: 'notification',
-        // #718: this generic Notification never carries permission_suggestions
-        // at all, so it is always the honest Yes/No fallback — never let it
-        // overwrite a PTY-parsed question's own options in the tracker merge.
-        optionsAreFallback: true,
-      };
-      this.events.onQuestion(question);
+      // Capture data (`~/.remi/hook-diag.jsonl`, re-verified for this PR):
+      // 4244 events / 5 sessions / one working day (2026-07-29, ~11h span) —
+      // 68 permission_prompt Notifications, 68 paired with a PermissionRequest
+      // by `prompt_id`, 0 UNPAIRED. 171 PermissionRequests (73 subagent-
+      // tagged) across Bash/Monitor/AskUserQuestion/Skill/WebFetch/three
+      // mcp__claude-in-chrome__* tools — the workflow coverage the capture
+      // gate needed. Still only one day on one machine; stated here as a
+      // caveat, not resolved by this change.
+      //
+      // Residual failure mode (argued, not assumed): if a permission_prompt
+      // Notification ever DOES arrive unpaired, two sub-cases:
+      //   - the prompt never renders on the PTY either -> no observable
+      //     effect before OR after this change (the pre-existing stash was
+      //     never pushed on its own regardless).
+      //   - the prompt DOES render -> `QuestionPresenceTracker.consumeAndMerge`
+      //     finds no stashed hookRecord for it and falls through to the bare
+      //     PTY-parsed question (`source: 'pty'`) via the SAME orphan-PTY
+      //     fallback every other genuinely hook-less prompt already uses
+      //     (subagent native prompts, #712) — not "nothing", and arguably
+      //     RICHER than the deleted synthesis's generic "Claude needs your
+      //     permission to use Bash" text would have contributed pre-#887's
+      //     "hook text wins" merge rule.
+      // `onStatusChange('waiting')` below is deliberately KEPT (not deleted
+      // with the Question): idempotent in the paired case (PermissionRequest
+      // already set 'waiting' moments earlier, per this file's own module
+      // doc), and it remains the only wait-signal at all for the theoretical
+      // unpaired case above.
       this.events.onStatusChange('waiting');
     } else if (input.notification_type === 'idle_prompt') {
       this.events.onStatusChange('idle');
@@ -523,6 +538,59 @@ export class HookEventBridge {
     };
     this.events.onQuestion(question);
     this.events.onStatusChange('waiting');
+  }
+
+  /**
+   * Build + emit the answerable card for an MCP `Elicitation` dialog (#889,
+   * Q4). Previously this arrived only as a PTY orphan: the dedicated
+   * `Elicitation` hook was never registered (so it never fired at all), and
+   * the generic `Notification(elicitation_dialog)` variant that DID fire was
+   * logged and ignored (see `handleNotification` above).
+   *
+   * Deliberately observe-only: no fixed Accept/Decline/Cancel options are
+   * fabricated. Claude Code's own TUI is already rendering SOME interactive
+   * prompt for the dialog (that is what makes it a "PTY orphan" today, not a
+   * silent hang), and this codebase has no live capture of what that prompt's
+   * own on-screen convention is (numbered choice? y/n? something else? — see
+   * `docs/claude-code-hook-contract.md` "What's pending"). Fabricating
+   * Accept/Decline options here would type a GUESSED literal string onto the
+   * PTY via the generic answer path (`input-events.ts`'s
+   * `resolveOption(...)?.value ?? answer`), which is worse than the orphan
+   * this is fixing if the guess is wrong. Instead: `options: []` +
+   * `allowsFreeText: true` — already a supported, tested shape
+   * (`question-parser.ts` uses it for PTY-detected free-text prompts, and
+   * `QuestionCard.tsx` already renders a free-text row for zero options) — so
+   * the card surfaces the dialog's own text and lets the user type whatever
+   * they would have typed sitting at the terminal, submitted verbatim
+   * (`ptyInput = resolveOption(...)?.value ?? answer` falls through to the
+   * raw answer when no option matches).
+   *
+   * Returns the created Question's id so `hook-bridge-setup.ts` can correlate
+   * a later `ElicitationResult` (matched by `elicitation_id`, an exact key
+   * both events carry) to resolve this exact card — the same "don't leave a
+   * pending card with no resolution signal" shape as `PermissionDenied`.
+   */
+  handleElicitation(input: ElicitationHookInput): UUID {
+    const question: Question = {
+      id: generateId(),
+      text: input.message
+        ? `${input.mcp_server_name}: ${input.message}`
+        : `${input.mcp_server_name} is requesting input`,
+      options: [],
+      allowsFreeText: true,
+      isAnswered: false,
+      agentId: input.agent_id,
+      // #887: same-turn correlation key, see `Question.promptId`.
+      promptId: input.prompt_id,
+      // #889: NOT 'permission_request'/'notification' -- the onQuestion
+      // callback in hook-bridge-setup.ts only stashes those two sources via
+      // the PTY-arbiter tracker; every other source (this one included)
+      // direct-emits, same as a source-less StopFailure card.
+      source: 'elicitation',
+    };
+    this.events.onQuestion(question);
+    this.events.onStatusChange('waiting');
+    return question.id;
   }
 
   handleSessionEnd(_input: SessionEndHookInput): void {

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -646,6 +646,19 @@ export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
  * none of these three needs a longer budget (no eval, no hold; #889's own
  * text said "~1s", which does not match this codebase's actual default —
  * see the PR for the measured per-event latency instead).
+ *
+ * **A listener's own work is on Claude's critical path.** `HookServer.
+ * handleRequest` (`hook-server.ts`) calls `this.dispatch(body)` and only THEN
+ * returns the `{}` response, and `dispatch` invokes listeners synchronously —
+ * so every millisecond an `.on()` handler spends is a millisecond Claude Code
+ * sits blocked on the hook. There is no answer-first escape hatch to fall back
+ * on. #889's own text asserted the opposite ("HookServer answers `{}` BEFORE
+ * doing work"), which is why this is written down here rather than left as
+ * folklore: the three registrations above are safe because each handler is a
+ * map lookup or a signature compare, not because responding is free. Anything
+ * heavier (an LLM call, a file read, a network hop) must move off the listener
+ * — the way `PermissionRequest` does with its hold/park design — before its
+ * event is added to this list.
  */
 export const REMI_REGISTERED_HOOK_EVENTS = [
   'PreToolUse',

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -614,12 +614,38 @@ export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
  * in setupHookBridge, also add the event name here so the registration
  * actually fires.
  *
- * Deliberately UNCHANGED by #886: that issue added 9 names to
- * HOOK_EVENT_NAMES for type completeness (so HookServer/isValidHookEvent
- * recognize them if Claude Code sends one unprompted), which is not the same
- * decision as opting remi into paying for them on every turn. Registering
- * PermissionDenied/Elicitation is Q4's call to make, deliberately, not a side
- * effect of a documentation pass.
+ * Was UNCHANGED by #886: that issue added 9 names to HOOK_EVENT_NAMES for
+ * type completeness (so HookServer/isValidHookEvent recognize them if Claude
+ * Code sends one unprompted), which is not the same decision as opting remi
+ * into paying for them on every turn. Registering PermissionDenied/
+ * Elicitation was left as Q4's call to make, deliberately, not a side effect
+ * of a documentation pass.
+ *
+ * Q4 (#889) makes that call for 3 of the 20 unregistered names:
+ *   - `PermissionDenied`: a classifier-denied permission fires no tool call,
+ *     so nothing else can prove a still-open escalation is resolved. Wired
+ *     into the SAME external-resolution funnel PreToolUse/PostToolUse use
+ *     (`AutoApproveGate.cancelExternallyResolved`), taking advantage of its
+ *     `tool_use_id` — the one permission edge where Claude Code sends an
+ *     exact id rather than requiring the tool_name+tool_input signature
+ *     fallback (`PermissionRequest` itself never carries one).
+ *   - `Elicitation` / `ElicitationResult`: an MCP dialog previously arrived
+ *     only as a PTY orphan (`hook-event-bridge.ts`'s `handleNotification`
+ *     logs and ignores `notification_type === 'elicitation_dialog'`, and the
+ *     dedicated `Elicitation` hook was never registered at all, so it never
+ *     fired). `Elicitation` now builds an answerable, free-text `Question`
+ *     card (`HookEventBridge.handleElicitation`); `ElicitationResult`
+ *     resolves it by `elicitation_id` — an exact correlation key both events
+ *     carry — the same "close the lingering-card gap" shape as
+ *     `PermissionDenied` above. Both stay observe-only (#889): neither hook
+ *     response encodes `action`/`content` to answer the MCP dialog
+ *     programmatically; the user's own answer (if any) rides the existing
+ *     generic PTY-inject path any non-held Question uses.
+ * All three keep the existing `DEFAULT_HOOK_TIMEOUT` (5s, `hook-config-
+ * manager.ts`) — `hookTimeoutFor` only special-cases `PermissionRequest`, and
+ * none of these three needs a longer budget (no eval, no hold; #889's own
+ * text said "~1s", which does not match this codebase's actual default —
+ * see the PR for the measured per-event latency instead).
  */
 export const REMI_REGISTERED_HOOK_EVENTS = [
   'PreToolUse',
@@ -633,6 +659,9 @@ export const REMI_REGISTERED_HOOK_EVENTS = [
   'SubagentStop',
   'StopFailure',
   'SessionEnd',
+  'PermissionDenied',
+  'Elicitation',
+  'ElicitationResult',
 ] as const satisfies readonly HookEventName[];
 
 export type RemiRegisteredHookEvent = (typeof REMI_REGISTERED_HOOK_EVENTS)[number];

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -625,10 +625,21 @@ export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
  *   - `PermissionDenied`: a classifier-denied permission fires no tool call,
  *     so nothing else can prove a still-open escalation is resolved. Wired
  *     into the SAME external-resolution funnel PreToolUse/PostToolUse use
- *     (`AutoApproveGate.cancelExternallyResolved`), taking advantage of its
- *     `tool_use_id` — the one permission edge where Claude Code sends an
- *     exact id rather than requiring the tool_name+tool_input signature
- *     fallback (`PermissionRequest` itself never carries one).
+ *     (`AutoApproveGate.cancelExternallyResolved`).
+ *
+ *     It DOES carry a `tool_use_id`, unlike `PermissionRequest` — but that id
+ *     buys nothing yet, and an earlier draft of this comment claimed it did
+ *     ("taking advantage of its exact `tool_use_id`"). Matching is
+ *     `tool_name` + `tool_input` + `agentId`; the id is consulted only when
+ *     BOTH sides carry one (`findOpenQuestionMatching`,
+ *     `auto-approve-gate.ts`). The registered side is built from the
+ *     `PermissionRequest` that opened the escalation, and that event never
+ *     sends a `tool_use_id` (see `PermissionRequestHookInput` above, read out
+ *     of the binary), so `sig.toolUseId` is always `undefined` and the exact-id
+ *     branch is unreachable from this path today. Passing the id through is
+ *     forward-compatible dead weight, not a live disambiguator — worth stating
+ *     precisely, because "it matches on an exact id" would read as stronger
+ *     than the signature match it actually performs.
  *   - `Elicitation` / `ElicitationResult`: an MCP dialog previously arrived
  *     only as a PTY orphan (`hook-event-bridge.ts`'s `handleNotification`
  *     logs and ignores `notification_type === 'elicitation_dialog'`, and the

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage, Question, UUID } from '@remi/shared';
 import { generateId } from '@remi/shared';
-import type { MessageAPI } from '../../../src/api/message-api.ts';
+import { MessageAPI } from '../../../src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../src/api/question-presence-tracker.ts';
 import { SubagentViewRegistry } from '../../../src/api/subagent-view-registry.ts';
 import { __resetLoggerForTests, configureLogger } from '../../../src/cli/logger.ts';
@@ -231,14 +231,37 @@ describe('setupHookBridge', () => {
        *  Defaults to undefined (dep not wired, matches production callers
        *  that skip subagent-view tracking). */
       subagentViews?: SubagentViewRegistry;
+      /**
+       * Construct the REAL `MessageAPI` (real `QuestionDedup` inside it),
+       * wired exactly as `message-api-setup.ts`'s `onQuestion` callback wires
+       * it (`sessionRegistry.addQuestion`) -- per ADR 0014, tests that assert
+       * a card actually reached the registry (not just "the bridge called a
+       * stub N times") must construct the real push path, not `fakeMessageAPI`.
+       * Defaults to false (the existing fake, unchanged for every pre-#889
+       * test in this file).
+       */
+      realMessageApi?: boolean;
     } = {},
-  ): { tracker: QuestionPresenceTracker } {
-    const localMessageApi = fakeMessageAPI(
-      messageApiLog,
-      opts.throwOnQuestionTimes !== undefined
-        ? { throwOnQuestionTimes: opts.throwOnQuestionTimes }
-        : {},
-    );
+  ): { tracker: QuestionPresenceTracker; messageApi: MessageAPI } {
+    const localMessageApi: MessageAPI = opts.realMessageApi
+      ? new MessageAPI(
+          { sessionId: SID, initialBulletId: 1 },
+          {
+            onQuestion: (question) => {
+              messageApiLog.questionCalls += 1;
+              sessionRegistry.addQuestion(SID, question, question.source ?? 'unknown');
+            },
+            onStatusChange: (status) => {
+              messageApiLog.statusCalls.push(status);
+            },
+          },
+        )
+      : fakeMessageAPI(
+          messageApiLog,
+          opts.throwOnQuestionTimes !== undefined
+            ? { throwOnQuestionTimes: opts.throwOnQuestionTimes }
+            : {},
+        );
     const tracker: QuestionPresenceTracker = opts.realTracker
       ? new QuestionPresenceTracker((q) => localMessageApi.handleQuestion(q))
       : makePassthroughTracker(localMessageApi);
@@ -339,10 +362,10 @@ describe('setupHookBridge', () => {
       },
     );
     bridgeHandles.push(handle);
-    return { tracker };
+    return { tracker, messageApi: localMessageApi };
   }
 
-  test('registers 10 .on() listeners + the synchronous PermissionRequest resolver (#496)', () => {
+  test('registers 13 .on() listeners + the synchronous PermissionRequest resolver (#496)', () => {
     build();
     const events = new Set(hookServer.listeners.keys());
     // PermissionRequest is NO LONGER a .on() listener — it is the synchronous
@@ -360,6 +383,10 @@ describe('setupHookBridge', () => {
         'PostToolUseFailure',
         'SubagentStart',
         'SubagentStop',
+        // Wired for Q4 (#889).
+        'PermissionDenied',
+        'Elicitation',
+        'ElicitationResult',
       ]),
     );
     expect(hookServer.permissionResolver).not.toBeNull();
@@ -1671,10 +1698,16 @@ describe('setupHookBridge', () => {
     expect(pushed.length).toBe(0);
   });
 
-  test('Phase 4 wiring: subagent Notification(permission_prompt) records in tracker', async () => {
+  test('Phase 4 wiring: subagent Notification(permission_prompt) no longer records in tracker (#890, Q5)', async () => {
     // Notification(permission_prompt) used to be dropped at the listener
-    // when agent_id was present. Under phase 4 it flows to the tracker
-    // just like its PermissionRequest sibling.
+    // when agent_id was present; phase 4 (#419) made it flow to the tracker
+    // like its PermissionRequest sibling. #890/Q5 deleted the question
+    // synthesis Notification(permission_prompt) fed into that tracker slot
+    // entirely (a capture corpus found the stash it fed always superseded
+    // by the richer paired PermissionRequest, 68/68 pairs, 0 unpaired) --
+    // the bridge's onQuestion callback now only stashes `source ===
+    // 'permission_request'`, so a Notification with no preceding
+    // PermissionRequest leaves the tracker with nothing pending at all.
     const { tracker } = build({ realTracker: true });
 
     hookServer.fire('SessionStart', {
@@ -1693,7 +1726,7 @@ describe('setupHookBridge', () => {
       message: 'Claude needs your permission to use Bash',
     });
 
-    expect(tracker.hasPendingForTest()).toBe(true);
+    expect(tracker.hasPendingForTest()).toBe(false);
   });
 
   test('#807: a subagent never reaches an approve verdict — passthrough, no inject, no escalate', async () => {
@@ -2387,6 +2420,269 @@ describe('setupHookBridge', () => {
       });
 
       expect(broadcastResolvedLog).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #889 (Q4): a classifier-denied permission fires no tool call, so
+  // PreToolUse/PostToolUse never observe it -- PermissionDenied is wired into
+  // the SAME `cancelExternallyResolved` funnel, taking advantage of its exact
+  // `tool_use_id` (future-proofing: PermissionRequest itself never sends one
+  // today, so matching still falls through to the tool_name+tool_input
+  // signature, same as every other caller of this funnel).
+  // ---------------------------------------------------------------------------
+  describe('#889 (Q4): PermissionDenied external resolution', () => {
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('a matching MAIN PermissionDenied resolves the open (parked/passthrough) escalation', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-889-denied-main');
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-889-denied-main',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'curl evil.example' },
+      });
+      expect(decision).toBe('passthrough');
+      expect(broadcastResolvedLog).toHaveLength(0); // still open
+
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-889-denied-main',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'curl evil.example' },
+        tool_use_id: 'tu-1',
+        reason: 'blocked by classifier',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('a matching SUBAGENT PermissionDenied resolves the parked escalation, scoped to that agent', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      const { tracker } = build({
+        autoApprove: true,
+        autoApproveDecision: 'escalate',
+        broadcastResolvedLog,
+      });
+      lock('claude-889-denied-sub');
+
+      await hookServer.firePermission({
+        session_id: 'claude-889-denied-sub',
+        agent_id: 'agent-889-1',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/x' },
+      });
+      expect(tracker.awaitingPTYCountForTest()).toBe(1);
+
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-889-denied-sub',
+        agent_id: 'agent-889-1',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /tmp/x' },
+        tool_use_id: 'tu-2',
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('a non-matching PermissionDenied (different tool_input) leaves the open escalation untouched', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-889-denied-nomatch');
+
+      await hookServer.firePermission({
+        session_id: 'claude-889-denied-nomatch',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-889-denied-nomatch',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf /' }, // different command -> no signature match
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(0);
+    });
+
+    test('PermissionDenied for a FOREIGN session_id is dropped by the admit gate (no cross-session resolution)', async () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-889-denied-foreign');
+
+      await hookServer.firePermission({
+        session_id: 'claude-889-denied-foreign',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-OTHER',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+
+      expect(broadcastResolvedLog).toHaveLength(0);
+    });
+
+    test('with NO open escalation at all, PermissionDenied is a clean no-op (never throws)', () => {
+      build({ autoApprove: true, autoApproveDecision: 'escalate' });
+      lock('claude-889-denied-empty');
+
+      expect(() =>
+        hookServer.fire('PermissionDenied', {
+          session_id: 'claude-889-denied-empty',
+          hook_event_name: 'PermissionDenied',
+          tool_name: 'Bash',
+          tool_input: { command: 'echo hi' },
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #889 (Q4): an MCP Elicitation dialog previously arrived only as a PTY
+  // orphan. These tests construct the REAL MessageAPI (ADR 0014: the push
+  // path is directly involved -- the claim under test is "the card actually
+  // reached the registry via the real dedup", not just "a stub was called").
+  // ---------------------------------------------------------------------------
+  describe('#889 (Q4): Elicitation / ElicitationResult (real MessageAPI, ADR 0014)', () => {
+    function lock(id: string): void {
+      hookServer.fire('SessionStart', {
+        session_id: id,
+        transcript_path: path.join(tmpDir, `${id}.jsonl`),
+        hook_event_name: 'SessionStart',
+      });
+    }
+
+    test('Elicitation builds a free-text card that reaches sessionRegistry through the real dedup', () => {
+      build({ realMessageApi: true });
+      lock('claude-889-elicit-1');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-1',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-abc',
+      });
+
+      const questions = [...(sessionRegistry.getSession(SID)?.currentQuestions.values() ?? [])];
+      expect(questions).toHaveLength(1);
+      expect(questions[0]?.text).toBe('weather-mcp: Which city?');
+      expect(questions[0]?.source).toBe('elicitation');
+      expect(questions[0]?.allowsFreeText).toBe(true);
+      expect(questions[0]?.options).toEqual([]);
+    });
+
+    test('ElicitationResult resolves the exact card by elicitation_id', () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ realMessageApi: true, broadcastResolvedLog });
+      lock('claude-889-elicit-2');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-2',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-xyz',
+      });
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-2',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-xyz',
+        action: 'accept',
+      });
+
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('ElicitationResult with an UNKNOWN elicitation_id is a no-op (card, if any, stays)', () => {
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ realMessageApi: true, broadcastResolvedLog });
+      lock('claude-889-elicit-3');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-3',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-real',
+      });
+
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-3',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-DOES-NOT-EXIST',
+      });
+
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1); // untouched
+      expect(broadcastResolvedLog).toHaveLength(0);
+    });
+
+    test('an Elicitation with NO elicitation_id still creates a card, but is not resolvable by ElicitationResult', () => {
+      build({ realMessageApi: true });
+      lock('claude-889-elicit-4');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-4',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        // no elicitation_id
+      });
+
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+      // A later ElicitationResult (even with a real id from some OTHER
+      // dialog) cannot possibly correlate -- graceful degradation, same as
+      // PermissionRequest's own missing tool_use_id.
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-4',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'some-other-id',
+      });
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1); // still there
+    });
+
+    test('Elicitation for a FOREIGN session_id is dropped by the admit gate', () => {
+      build({ realMessageApi: true });
+      lock('claude-889-elicit-5');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-OTHER',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-foreign',
+      });
+
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
     });
   });
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -215,6 +215,10 @@ describe('setupHookBridge', () => {
        *  contract through the bridge wiring. Defaults to the passthrough
        *  tracker used by the legacy assertion-style tests. */
       realTracker?: boolean;
+      /** Shorten `QuestionPresenceTracker`'s orphan-PTY debounce (default
+       *  1.5s) so a test can drive the real hooked-session orphan path without
+       *  a long wait. Only meaningful with `realTracker`. */
+      orphanDebounceMs?: number;
       /** Capture every message the bridge sends via sendAndRecord (#576: the
        *  auto-approve status broadcasts). Defaults to a no-op send. */
       sendLog?: ProtocolMessage[];
@@ -232,11 +236,20 @@ describe('setupHookBridge', () => {
        *  that skip subagent-view tracking). */
       subagentViews?: SubagentViewRegistry;
       /**
-       * Construct the REAL `MessageAPI` (real `QuestionDedup` inside it),
-       * wired exactly as `message-api-setup.ts`'s `onQuestion` callback wires
-       * it (`sessionRegistry.addQuestion`) -- per ADR 0014, tests that assert
-       * a card actually reached the registry (not just "the bridge called a
-       * stub N times") must construct the real push path, not `fakeMessageAPI`.
+       * Construct the REAL `MessageAPI` (real `QuestionDedup` inside it) -- per
+       * ADR 0014, tests that assert a card actually reached the registry (not
+       * just "the bridge called a stub N times") must construct the real push
+       * path, not `fakeMessageAPI`.
+       *
+       * The `onQuestion` callback below reproduces only the ONE step these
+       * tests assert on, `sessionRegistry.addQuestion`; it is deliberately not
+       * a copy of `message-api-setup.ts`'s callback, which also does
+       * `sendAndRecord`, the push/held decision and `claudeSessionId` stamping.
+       * What is real here is `MessageAPI` itself and the dedup inside it --
+       * the component whose behavior the elicitation tests turn on. Say which,
+       * because "wired exactly as production" would be the kind of coverage
+       * overclaim ADR 0014 exists to catch.
+       *
        * Defaults to false (the existing fake, unchanged for every pre-#889
        * test in this file).
        */
@@ -263,7 +276,15 @@ describe('setupHookBridge', () => {
             : {},
         );
     const tracker: QuestionPresenceTracker = opts.realTracker
-      ? new QuestionPresenceTracker((q) => localMessageApi.handleQuestion(q))
+      ? new QuestionPresenceTracker(
+          (q) => localMessageApi.handleQuestion(q),
+          // Only pass deps when a test asked for a shortened orphan debounce,
+          // so the pre-existing realTracker tests keep their exact wiring
+          // (default 1.5s window, no hasLiveQuestions dep).
+          opts.orphanDebounceMs !== undefined
+            ? { orphanDebounceMs: opts.orphanDebounceMs }
+            : undefined,
+        )
       : makePassthroughTracker(localMessageApi);
     sessionRegistry.registerSession(
       SID,
@@ -1729,6 +1750,69 @@ describe('setupHookBridge', () => {
     expect(tracker.hasPendingForTest()).toBe(false);
   });
 
+  test('#890 residual path: an UNPAIRED permission_prompt whose prompt renders still surfaces a card', async () => {
+    // Q5's safety argument has two halves. The test above proves the first
+    // (nothing is stashed anymore). This proves the second, which the PR
+    // asserted in a comment but never exercised: with the stash gone, a
+    // permission_prompt that arrives with NO paired PermissionRequest and then
+    // DOES render must still reach the user, via the same orphan-PTY fallback
+    // every genuinely hook-less prompt uses. If that were wrong, deleting the
+    // synthesis would have turned the rare unpaired case into silence -- the
+    // exact outcome the capture gate was meant to rule out.
+    //
+    // Driven through `onOrphanPTYPrompt`, which is what cli.ts routes to when a
+    // hookServer is active, not the non-hooked `onPTYPromptVisible` core.
+    const { tracker } = build({
+      realTracker: true,
+      realMessageApi: true,
+      orphanDebounceMs: 5,
+    });
+
+    hookServer.fire('SessionStart', {
+      session_id: 'claude-890-unpaired',
+      hook_event_name: 'SessionStart',
+      transcript_path: path.join(tmpDir, 'unpaired.jsonl'),
+      source: 'startup',
+      model: 'test',
+    });
+
+    // No PermissionRequest -- this is the unpaired case by construction.
+    hookServer.fire('Notification', {
+      session_id: 'claude-890-unpaired',
+      hook_event_name: 'Notification',
+      notification_type: 'permission_prompt',
+      message: 'Claude needs your permission to use Bash',
+    });
+    expect(tracker.hasPendingForTest()).toBe(false);
+    expect(sessionRegistry.getSession(SID)?.currentQuestions.size ?? 0).toBe(0);
+
+    // The prompt renders anyway.
+    tracker.onOrphanPTYPrompt({
+      id: 'pty-q-890' as UUID,
+      text: 'Allow Bash: curl example.com?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      source: 'pty',
+    });
+
+    // Poll the debounce out rather than sleeping a guess.
+    const deadline = Date.now() + 2000;
+    while (
+      (sessionRegistry.getSession(SID)?.currentQuestions.size ?? 0) === 0 &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    const questions = [...(sessionRegistry.getSession(SID)?.currentQuestions.values() ?? [])];
+    expect(questions).toHaveLength(1);
+    // The PTY's own text and provenance survive -- nothing was merged over it,
+    // because there is no hook record to merge.
+    expect(questions[0]?.text).toBe('Allow Bash: curl example.com?');
+    expect(questions[0]?.source).toBe('pty');
+  });
+
   test('#807: a subagent never reaches an approve verdict — passthrough, no inject, no escalate', async () => {
     // Regression guard for the dev.3 misfiring: a background subagent's
     // PermissionRequest cannot answer by injecting into the MAIN PTY because
@@ -2497,6 +2581,61 @@ describe('setupHookBridge', () => {
 
       expect(broadcastResolvedLog).toHaveLength(1);
       expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
+    });
+
+    test('with two escalations open on the SAME signature, PermissionDenied resolves only its own agent', async () => {
+      // Review gap: dropping the `sig.agentId !== observed.agentId` check in
+      // `findOpenQuestionMatching` left all 160 tests in the two files this PR
+      // touches green. The shared matcher is covered in
+      // `auto-approve-gate.test.ts`, but nothing proved the `agentId:
+      // input.agent_id` passthrough on THIS wiring path actually scopes -- and
+      // a PermissionDenied closing another agent's still-open question is the
+      // swallow class #925 was. Same tool + same tool_input on purpose, so
+      // agent identity is the ONLY thing that can disambiguate.
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ autoApprove: true, autoApproveDecision: 'escalate', broadcastResolvedLog });
+      lock('claude-889-denied-2agents');
+
+      await hookServer.firePermission({
+        session_id: 'claude-889-denied-2agents',
+        agent_id: 'agent-A',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+      await hookServer.firePermission({
+        session_id: 'claude-889-denied-2agents',
+        agent_id: 'agent-B',
+        agent_type: 'general-purpose',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+      expect(broadcastResolvedLog).toHaveLength(0);
+
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-889-denied-2agents',
+        agent_id: 'agent-A',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+
+      // Exactly one resolution: agent-B's question must survive, because it is
+      // still open and only the PTY can answer it.
+      expect(broadcastResolvedLog).toHaveLength(1);
+
+      // And agent-B's own denial still resolves it afterward -- proving the
+      // survivor was genuinely still tracked, not silently dropped.
+      hookServer.fire('PermissionDenied', {
+        session_id: 'claude-889-denied-2agents',
+        agent_id: 'agent-B',
+        hook_event_name: 'PermissionDenied',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push' },
+      });
+      expect(broadcastResolvedLog).toHaveLength(2);
     });
 
     test('a non-matching PermissionDenied (different tool_input) leaves the open escalation untouched', async () => {

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2620,6 +2620,48 @@ describe('setupHookBridge', () => {
       expect(broadcastResolvedLog[0]?.reason).toBe('cancelled');
     });
 
+    test('a re-fired Elicitation for the same id keeps the live card resolvable (review finding)', () => {
+      // The dedup drops the second emission (same text, same 0 options, same
+      // allowsFreeText -> never "richer", and status never left 'waiting' to
+      // reset the baseline), so its returned id names a card that was never
+      // registered. Blindly overwriting the correlation pointed
+      // ElicitationResult at that phantom and orphaned card A -- the card the
+      // user is actually looking at -- with no automated way to clear it.
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ realMessageApi: true, broadcastResolvedLog });
+      lock('claude-889-elicit-dup');
+
+      const fire = (): void => {
+        hookServer.fire('Elicitation', {
+          session_id: 'claude-889-elicit-dup',
+          hook_event_name: 'Elicitation',
+          mcp_server_name: 'weather-mcp',
+          message: 'Which city?',
+          elicitation_id: 'elicit-dup',
+        });
+      };
+      fire();
+      const cardA = [...(sessionRegistry.getSession(SID)?.currentQuestions.keys() ?? [])][0];
+      expect(cardA).toBeDefined();
+
+      fire();
+      // The repeat never became a second card, so there is still exactly one.
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-dup',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-dup',
+        action: 'accept',
+      });
+
+      // The still-live card A is the one that resolves, not a phantom.
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.questionId).toBe(cardA as UUID);
+    });
+
     test('ElicitationResult with an UNKNOWN elicitation_id is a no-op (card, if any, stays)', () => {
       const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
       build({ realMessageApi: true, broadcastResolvedLog });

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -2510,10 +2510,21 @@ describe('setupHookBridge', () => {
   // ---------------------------------------------------------------------------
   // #889 (Q4): a classifier-denied permission fires no tool call, so
   // PreToolUse/PostToolUse never observe it -- PermissionDenied is wired into
-  // the SAME `cancelExternallyResolved` funnel, taking advantage of its exact
-  // `tool_use_id` (future-proofing: PermissionRequest itself never sends one
-  // today, so matching still falls through to the tool_name+tool_input
-  // signature, same as every other caller of this funnel).
+  // the SAME `cancelExternallyResolved` funnel. Matching is
+  // tool_name+tool_input+agentId; `PermissionDenied` also carries a
+  // `tool_use_id`, but it is forward-compatible only.
+  //
+  // Deliberately NO test for exact-`tool_use_id` disambiguation through this
+  // path, and that absence is the honest outcome rather than a gap: the
+  // registered signature is built from the `PermissionRequest` that opened the
+  // escalation, and that event never sends a `tool_use_id`, so
+  // `findOpenQuestionMatching`'s "both sides carry one" branch cannot be
+  // reached from here. Writing such a test would mean fabricating a
+  // `PermissionRequest` with an id Claude Code does not send -- a test that
+  // passes about an input shape that never occurs, which is exactly the
+  // coverage claim ADR 0014 says not to make. The branch itself IS covered,
+  // generically, by `auto-approve-gate.test.ts`. Reconsider when a capture
+  // shows `PermissionRequest` carrying an id.
   // ---------------------------------------------------------------------------
   describe('#889 (Q4): PermissionDenied external resolution', () => {
     function lock(id: string): void {

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import type { AgentStatus, Question } from '@remi/shared';
 import { HookEventBridge } from '../../src/hooks/hook-event-bridge.ts';
 import type {
+  ElicitationHookInput,
   NotificationHookInput,
   PermissionRequestHookInput,
   PostToolUseFailureHookInput,
@@ -72,7 +73,7 @@ describe('HookEventBridge', () => {
     expect(statuses).toEqual([{ status: 'thinking' }]);
   });
 
-  it('maps standalone Notification(permission_prompt) to the honest Yes/No 2-set', () => {
+  it('Notification(permission_prompt) sets waiting status but no longer synthesizes a question (#890, Q5)', () => {
     const { bridge, statuses, questions } = createBridge();
 
     bridge.handleNotification({
@@ -83,16 +84,12 @@ describe('HookEventBridge', () => {
     } as NotificationHookInput);
 
     expect(statuses).toEqual([{ status: 'waiting' }]);
-    expect(questions.length).toBe(1);
-    expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
-    // Fallback 2-option set (not parsed from message); this event never
-    // carries permission_suggestions (#718).
-    expect(questions[0]?.options.length).toBe(2);
-    expect(questions[0]?.options[0]?.label).toBe('Yes');
-    expect(questions[0]?.options[0]?.isYes).toBe(true);
-    expect(questions[0]?.options[1]?.label).toBe('No');
-    expect(questions[0]?.options[1]?.isNo).toBe(true);
-    expect(questions[0]?.optionsAreFallback).toBe(true);
+    // #890/Q5: the generic Yes/No-fallback Question this event used to
+    // synthesize is DELETED -- a capture corpus (4244 events / 5 sessions /
+    // one day) found the stash it fed always superseded by a richer paired
+    // PermissionRequest (68/68 paired, 0 unpaired). See handleNotification's
+    // own comment for the full argument.
+    expect(questions.length).toBe(0);
   });
 
   it('maps Notification(idle_prompt) to idle status', () => {
@@ -136,8 +133,8 @@ describe('HookEventBridge', () => {
     expect(sessionInfos[0]?.transcriptPath).toBe('/tmp/test.jsonl');
   });
 
-  it('provides default text for empty standalone Notification', () => {
-    const { bridge, questions } = createBridge();
+  it('an empty-message standalone Notification(permission_prompt) still only sets status (#890, Q5)', () => {
+    const { bridge, statuses, questions } = createBridge();
 
     bridge.handleNotification({
       ...makeCommon(),
@@ -146,11 +143,8 @@ describe('HookEventBridge', () => {
       message: '',
     } as NotificationHookInput);
 
-    expect(questions[0]?.text).toBe('Allow this action?');
-    expect(questions[0]?.options.length).toBe(2);
-    // #718: a generic Notification never carries permission_suggestions, so
-    // it is always the honest Yes/No fallback.
-    expect(questions[0]?.optionsAreFallback).toBe(true);
+    expect(statuses).toEqual([{ status: 'waiting' }]);
+    expect(questions.length).toBe(0);
   });
 
   it('hookHandlers returns handlers that delegate to bridge methods', () => {
@@ -784,6 +778,56 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.options[1]?.isNo).toBe(true);
   });
 
+  describe('Elicitation (#889, Q4)', () => {
+    it('builds a free-text answerable card, not fabricated Accept/Decline options', () => {
+      const { bridge, statuses, questions } = createBridge();
+
+      const id = bridge.handleElicitation({
+        ...makeCommon(),
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'some-mcp-server',
+        message: 'Please provide your API key',
+        elicitation_id: 'elicit-1',
+      } as ElicitationHookInput);
+
+      expect(statuses).toEqual([{ status: 'waiting' }]);
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.id).toBe(id);
+      expect(questions[0]?.text).toBe('some-mcp-server: Please provide your API key');
+      expect(questions[0]?.options).toEqual([]);
+      expect(questions[0]?.allowsFreeText).toBe(true);
+      expect(questions[0]?.source).toBe('elicitation');
+    });
+
+    it('falls back to a generic prompt when no message is present', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleElicitation({
+        ...makeCommon(),
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'some-mcp-server',
+      } as ElicitationHookInput);
+
+      expect(questions[0]?.text).toBe('some-mcp-server is requesting input');
+    });
+
+    it('carries agent_id and prompt_id through like every other hook-born question', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handleElicitation({
+        ...makeCommon(),
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'some-mcp-server',
+        message: 'Confirm?',
+        agent_id: 'subagent-1',
+        prompt_id: 'prompt-1',
+      } as ElicitationHookInput);
+
+      expect(questions[0]?.agentId).toBe('subagent-1');
+      expect(questions[0]?.promptId).toBe('prompt-1');
+    });
+  });
+
   it('maps SessionEnd to idle status', () => {
     const { bridge, statuses } = createBridge();
 
@@ -809,13 +853,13 @@ describe('HookEventBridge', () => {
   });
 
   describe('PermissionRequest + Notification forwarding', () => {
-    it('emits BOTH question events when PermissionRequest is followed by Notification(permission_prompt)', () => {
-      // Phase 3: the 5 s `lastPermissionEmitAt` dedup window is gone. Both
-      // hook events now forward their metadata; QuestionPresenceTracker
-      // (cli.ts wiring) collapses them into a single push because the
-      // tracker only holds one `pending` slot at a time and PTY confirms
-      // once. This test pins the bridge contract: hand both events through.
-      const { bridge, questions } = createBridge();
+    it('a following Notification(permission_prompt) no longer emits a second question (#890, Q5)', () => {
+      // Phase 3: the 5 s `lastPermissionEmitAt` dedup window is gone. #890/Q5:
+      // the Notification-sourced synthesis this test used to also exercise
+      // is deleted -- Claude still fires Notification(permission_prompt)
+      // shortly after PermissionRequest, but it now only flips status; the
+      // ONE question the pair produces is the PermissionRequest's own.
+      const { bridge, statuses, questions } = createBridge();
 
       bridge.handlePermissionRequest({
         ...makeCommon(),
@@ -831,11 +875,19 @@ describe('HookEventBridge', () => {
         message: 'Allow Edit: /tmp/foo.ts?',
       } as NotificationHookInput);
 
-      expect(questions.length).toBe(2);
+      expect(questions.length).toBe(1);
+      expect(questions[0]?.source).toBe('permission_request');
+      // Both events set 'waiting'; the second is idempotent.
+      expect(statuses).toEqual([{ status: 'waiting' }, { status: 'waiting' }]);
     });
 
-    it('allows standalone Notification when no preceding PermissionRequest', () => {
-      const { bridge, questions } = createBridge();
+    it('a standalone Notification with no preceding PermissionRequest sets status but emits nothing (#890, Q5)', () => {
+      // The theoretical "unpaired" case (0/68 observed in a real capture
+      // corpus, see handleNotification's own comment). Since no
+      // PermissionRequest ever fired either, the auto-approve gate has
+      // nothing to escalate -- this event's only remaining job is the
+      // status flip, which is exactly what fires here.
+      const { bridge, statuses, questions } = createBridge();
 
       bridge.handleNotification({
         ...makeCommon(),
@@ -844,9 +896,8 @@ describe('HookEventBridge', () => {
         message: 'Claude needs your permission to use Bash',
       } as NotificationHookInput);
 
-      expect(questions.length).toBe(1);
-      expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
-      expect(questions[0]?.options.length).toBe(2);
+      expect(questions.length).toBe(0);
+      expect(statuses).toEqual([{ status: 'waiting' }]);
     });
 
     it('PermissionRequest includes tool context in question text', () => {
@@ -862,7 +913,7 @@ describe('HookEventBridge', () => {
       expect(questions[0]?.text).toBe('Allow Bash: ssh hallu "uv run pytest"');
     });
 
-    it('stamps source so the tracker can prefer the rich request over the generic notification (#574)', () => {
+    it('PermissionRequest stamps source: permission_request (#574) -- the only source the tracker stashes now', () => {
       const { bridge, questions } = createBridge();
 
       bridge.handlePermissionRequest({
@@ -878,8 +929,8 @@ describe('HookEventBridge', () => {
         message: 'Claude needs your permission to use Bash',
       } as NotificationHookInput);
 
+      expect(questions.length).toBe(1);
       expect(questions[0]?.source).toBe('permission_request');
-      expect(questions[1]?.source).toBe('notification');
     });
   });
 
@@ -939,11 +990,11 @@ describe('HookEventBridge', () => {
       expect(questions[1]?.text).toContain('dig example.com');
     });
 
-    it('forwards Notification(permission_prompt) during a Task tool call', () => {
+    it('Notification(permission_prompt) during a Task tool call still sets waiting, still no question (#890, Q5)', () => {
       // Mirror of the PermissionRequest test above. The bridge no longer
       // drops Notification(permission_prompt) based on subagent context;
-      // the tracker collapses hook+PTY events into a single push.
-      const { bridge, questions } = createBridge();
+      // it never emitted a question of its own to begin with post-#890.
+      const { bridge, statuses, questions } = createBridge();
 
       bridge.handlePreToolUse({
         ...makeCommon(),
@@ -960,8 +1011,8 @@ describe('HookEventBridge', () => {
         message: 'Claude needs your permission to use Bash',
       } as NotificationHookInput);
 
-      expect(questions).toHaveLength(1);
-      expect(questions[0]?.text).toBe('Claude needs your permission to use Bash');
+      expect(questions).toHaveLength(0);
+      expect(statuses.at(-1)).toEqual({ status: 'waiting' });
     });
 
     it('concurrent Task calls: context exits only when all complete', () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -283,8 +283,17 @@ export interface QuestionStep {
  * Provenance of a {@link Question} (#574). Drives the daemon's
  * QuestionPresenceTracker merge policy (richer hook text must win over the
  * generic notification fallback) and is otherwise inert on the wire.
+ *
+ * `'elicitation'` (#889/Q4): an MCP `Elicitation` hook dialog, surfaced as a
+ * first-class card instead of a PTY orphan. Deliberately NOT routed through
+ * `QuestionPresenceTracker.recordPendingHook` (the `hook-bridge-setup.ts`
+ * `onQuestion` callback only stashes `'permission_request'` there — the ONLY
+ * source it stashes since #890/Q5 deleted the `'notification'` synthesis) —
+ * like a source-less `StopFailure` "Retry?" card, it emits directly, since it
+ * is not part of the permission-escalation PTY-arbiter funnel (ADR 0004
+ * scopes that to permission hooks specifically).
  */
-export type QuestionSource = 'permission_request' | 'notification' | 'pty';
+export type QuestionSource = 'permission_request' | 'notification' | 'pty' | 'elicitation';
 
 /** Sentinel agent key for the primary (main) agent, whose questions carry no
  *  `agentId`. Normalize `agentId ?? MAIN_AGENT_ID` when building collection keys. */


### PR DESCRIPTION
## Summary

Q4 (#889) + Q5 (#890) of epic #885, one PR (shared file surface:
`hook-types.ts`, `hook-bridge-setup.ts`, `hook-event-bridge.ts`).

- **Q4**: registers `PermissionDenied`, `Elicitation`, `ElicitationResult` —
  observe-only, no hook-response decisions.
- **Q5**: deletes the redundant `Notification(permission_prompt)` question
  synthesis after the capture gate closed out.

## Q5 — pairing re-run + the routing argument

Re-ran the pairing query against `~/.remi/hook-diag.jsonl` myself (script not
checked in; happy to share):

```
Total events: 4244   Distinct sessions: 5   prompt_id present: 100%
Span: 2026-07-29T12:42Z .. 2026-07-29T23:46Z (~11h, one working day)

PermissionRequest total: 171   subagent-tagged: 73
Tools on PermissionRequest: AskUserQuestion, Bash, Monitor, Skill, WebFetch,
  mcp__claude-in-chrome__browser_batch, mcp__claude-in-chrome__navigate,
  mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__tabs_create_mcp

Notification(permission_prompt) total: 68
  paired with a PermissionRequest by prompt_id: 68
  UNPAIRED: 0
```

**Correction (review finding).** An earlier draft of this section said these
"match the issue's own capture-data comment numbers (up 12 events ...; same
68/68/0)". That was wrong, and wrong in the direction that flatters the
deletion. Issue #890's comment recorded a **first slice: 543 events, 10
permission_prompt notifications, 10 paired, 0 unpaired** — and said so
explicitly: "n=10, from a few hours on one machine, one workflow ... Ten
successes tell us the common path is paired; they say nothing about the rare
path a fallback exists for, and that is precisely the shape of evidence that
flatters a deletion."

The honest statement of the evidence is therefore: 543 → 4244 events (not a
12-event delta), 10 → 68 notifications, **0 unpaired in both**. The capture did
what the issue asked — it kept running and the unpaired count stayed at zero
across ~8× more data — but the issue's own warning still stands: **one day, one
machine, and 68 successes still say nothing about the rare path the fallback
existed for.** That is why the residual failure mode is analyzed in code
comments and now covered by a test (see the review-fixes section), rather than
treated as ruled out.

**Routing, verified against code, not assumed**: `hook-bridge-setup.ts`'s
`onQuestion` callback routed both `'permission_request'` and `'notification'`
sources to `tracker.recordPendingHook`. Read `recordPendingHook`'s full body
(`question-presence-tracker.ts`): it touches only `this.pending` (a `Map`) —
no call to the push sink anywhere in the method. Confirmed: the stash is
never pushed on its own. A pending rich `permission_request` is also never
evicted by a later `'notification'` for the same agent (`recordPendingHook`'s
"richer wins" rule), so in the paired case (68/68 observed) the notification
stash was always dead weight, immediately superseded.

**Both checks held** (0 unpaired, stash-only confirmed), so per the issue's
own instruction I deleted the synthesis rather than just documenting the
unpaired class.

**Residual failure mode, argued not assumed**: if a `permission_prompt`
notification ever *does* arrive unpaired:
- prompt never renders on the PTY either -> no observable effect before OR
  after this change (the pre-existing stash was never pushed regardless).
- prompt DOES render -> `QuestionPresenceTracker.consumeAndMerge` finds no
  stashed `hookRecord` and falls through to the bare PTY-parsed question
  (`source: 'pty'`), the SAME orphan-PTY fallback every other genuinely
  hook-less prompt already uses (subagent native prompts, #712). I want to
  correct the issue's own framing here rather than just repeat it: this is
  **not** "the user would get nothing" -- it's the existing fallback, and
  arguably *richer* than the deleted synthesis would have contributed (the
  old merge rule let the hook's generic "Claude needs your permission to use
  Bash" text win over the PTY's own real text whenever a hookRecord existed
  at all, fallback or not). Traced this precisely by reading
  `consumeAndMerge`'s `useHookOptions`/`text` merge logic, not by assertion.

`onStatusChange('waiting')` is deliberately **kept** (not deleted with the
Question): idempotent in the paired case (PermissionRequest already set
`'waiting'` moments earlier), and it remains the only wait-signal at all for
the theoretical unpaired case.

## Q4 -- PermissionDenied

Wired into the exact same `AutoApproveGate.cancelExternallyResolved` funnel
PreToolUse/PostToolUse already use (signature match, `agentId`-scoped,
`tool_use_id` compared only when both sides carry one -- `PermissionRequest`
itself still never sends one, so this stays a no-guess safety net today, not
a behavior change for the common path). A no-op when nothing open matches --
never fabricates a resolution, matching "every ambiguous path resolves
toward showing the user."

## Q4 -- Elicitation / ElicitationResult

`Elicitation` builds a card and pushes it directly (like a source-less
`StopFailure` "Retry?" card -- new `QuestionSource` value `'elicitation'`).
Deliberately **not** a fixed Accept/Decline/Cancel set: this codebase has no
live capture of what Claude's own on-screen elicitation-dialog convention is
(numbered choice? y/n? something else? -- `docs/claude-code-hook-contract.md`
"What's pending"), and typing a guessed literal string onto the PTY via the
generic answer path would be worse than the orphan this fixes if wrong.
Instead: `options: []` + `allowsFreeText: true` -- an existing, tested shape
(`question-parser.ts` already uses it for PTY free-text prompts; `QuestionCard.tsx`
already renders a free-text row for zero options, verified by reading both,
no web changes needed) -- so the card shows the dialog's own text and the
user types whatever they would have typed at the terminal, submitted
verbatim.

`ElicitationResult` resolves the exact card by `elicitation_id` (an EXACT
correlation key both events carry, unlike the tool-signature matching
`PermissionDenied` needs) via a small per-session `Map` in `hook-bridge-setup.ts`,
capped at 32 entries (same motivation as `AutoApproveGate.MAX_PARKED_INPUTS`
but deliberately smaller — that one is **64**; an earlier draft of this line
said "mirrors", which was wrong on the number), cleared on session rotation.

**Known accepted limitation, not fixed here**: if the user answers an
elicitation card through remi's own UI *before* `ElicitationResult` arrives,
the correlation map isn't told (that cleanup lives in `input-events.ts`,
outside this PR's file surface), so a later `ElicitationResult` still fires
a redundant `question_resolved(..., 'cancelled')` broadcast for an
already-removed id. `removeQuestion`/the broadcast are both safe no-ops for
a gone id -- this is a cosmetic extra dismiss, not a hidden-question risk (it
errs toward *more* dismiss broadcasts, never toward losing one — note this
held for the case analyzed here but **not** for the duplicate-`Elicitation`
case review found, see review fixes below), and is the
same shape as this codebase's existing multi-device already-answered races.
Flagging explicitly rather than leaving it implicit.

## `REMI_REGISTERED_HOOK_EVENTS`: 11 -> 14 (intended, unlike Q7a)

Grows by `PermissionDenied`, `Elicitation`, `ElicitationResult` -- Q4's whole
point, explicitly scoped by the issue as "Q4's call to make." All three keep
the existing `DEFAULT_HOOK_TIMEOUT` (5s) -- `hookTimeoutFor` only
special-cases `PermissionRequest`.

## Latency -- measured, not assumed

Real `HookServer` + real `setupHookBridge` (real `SessionRegistry`, real
`AutoApproveGate`, real `TranscriptBinder`), 300 real HTTP POSTs per event
over loopback (script not checked in):

```
Stop (baseline, pre-existing)              n=300  median=0.11ms  mean=0.11ms  p95=0.15ms  max=0.49ms
PermissionDenied (no match, common case)   n=300  median=0.07ms  mean=0.07ms  p95=0.08ms  max=0.34ms
Elicitation (builds a card)                n=300  median=0.07ms  mean=0.07ms  p95=0.08ms  max=0.32ms
ElicitationResult (resolves the card)      n=300  median=0.06ms  mean=0.07ms  p95=0.08ms  max=0.29ms
ElicitationResult (no match, common case)  n=300  median=0.07ms  mean=0.07ms  p95=0.08ms  max=0.32ms
```

All new handlers are cheaper than the pre-existing `Stop` baseline (the
common no-match `PermissionDenied` path hits `findOpenQuestionMatching`'s
early `size === 0` return). Well under the issue's own 5ms bar.

## `HookServer` answer-before-process -- checked, and it does NOT hold as described

The issue says "`HookServer` must answer `{}` **before** doing work." Read
`handleRequest` (`hook-server.ts`): for the plain-dispatch path (every event
here), `this.dispatch(body)` -- which runs every synchronous `.on()` listener
-- is called and *completes* **before** the `Response` object is constructed
and returned. So the actual order is process-then-answer, not
answer-then-process, for every event registered here (the PermissionRequest
resolver path is different by design -- Model B needs to compute the
decision before answering, that's the whole point).

This matters for what I built: since listener work runs before the response
leaves the server, the real constraint is "keep each new handler's
synchronous work cheap," not "make sure a response fires first." All three
new handlers are synchronous, no `await`, no I/O beyond in-memory `Map`/
`SessionRegistry` operations -- which is exactly what the latency numbers
above confirm.

## Break-it-then-fix-it

**PermissionDenied**: commented out the `cancelExternallyResolved` call.
`bun test hook-bridge-setup.test.ts -t PermissionDenied` -> **2 of 5 red**
(the two positive-resolution tests; the 3 no-op/foreign-session tests stayed
green, as expected since they assert nothing changes). Restored -> **5/5
green**.

**ElicitationResult**: commented out the `resolveElicitation` call.
`bun test hook-bridge-setup.test.ts -t Elicitation` -> **1 of 5 red** (the
resolution test; the build/no-op/no-id/foreign-session tests stayed green).
Restored -> **5/5 green**.

## Anything contradicting the issue text

- **The referenced `AGENTS.md` "## Verify before you describe" section did
  not exist on the stale branch state this worktree started on.** It turned
  out to exist on `develop` (added by an earlier PR, ADR 0011) -- my worktree
  had simply not been rebased yet. Re-checked after branching from
  `origin/develop`: present, read, followed. Flagging because it's exactly
  the kind of "trust but verify" moment the epic keeps testing for, even
  though in this case the resolution was "my checkout was stale," not "the
  task was wrong."
- **The issue says "~1s timeout on both."** The codebase's actual
  `DEFAULT_HOOK_TIMEOUT` for every non-`PermissionRequest` hook (including
  these 3 new ones) is **5s** (`hook-config-manager.ts`), unchanged and not
  special-cased for this PR. Measured latency (well under 1ms) makes the
  exact timeout value moot either way, but the "~1s" figure itself is not
  what ships.
- **"HookServer must answer `{}` before doing work"** -- see above: the
  actual order in `handleRequest` is process-then-answer for every event
  this PR touches, not answer-then-process. Corrected in the doc comments
  added to `hook-types.ts` and this PR body rather than left standing.
- **Elicitation's "surface it as a first-class question" framing invites
  building a richer, decision-capable card.** I deliberately built the
  cheapest, most honest version (free-text passthrough, no fabricated
  options) because the alternative requires knowing what Claude's own
  elicitation-dialog TUI convention is, which nobody has captured yet.
  Flagging as a scope judgment call, not an oversight.

## Gates run

- `bun run typecheck`: clean.
- `bun run typecheck:web`: clean.
- `bunx biome check .`: 0 errors / 48 warnings (repo baseline, unchanged).
- `typos` (the 8 touched src/test/doc files): clean.
- `bun test packages/daemon/tests --path-ignore-patterns="**/auto-approve/**"`:
  **2662 pass / 0 fail** (148 files).
- `bun test packages/daemon/tests/auto-approve/auto-approve-gate.test.ts`
  (targeted, per repo convention): **150 pass / 0 fail** -- confirms
  `cancelExternallyResolved`'s pre-existing behavior is untouched.
- `cd packages/web && bun test`: **506 pass / 0 fail** (30 files).
- One flaky, unrelated failure observed once and not reproduced on rerun:
  `hook-server.test.ts`'s random test-port range (19876 + rand(0..999))
  collided with a real local process already bound to 19924 (a known
  category, `[port_selection]`/#146 -- not touched by this PR, and a rerun
  was clean).

## Test plan

- [x] New: `#889 (Q4): PermissionDenied external resolution` (5 tests,
      `hook-bridge-setup.test.ts`) -- matching/non-matching signature, main +
      subagent, foreign session, no-open-escalation no-op.
- [x] New: `#889 (Q4): Elicitation / ElicitationResult (real MessageAPI, ADR 0014)`
      (5 tests) -- real `MessageAPI`/`QuestionDedup`/`SessionRegistry`, card
      reaches the registry, resolves by id, unknown-id no-op, missing-id
      graceful degradation, foreign session dropped.
- [x] New: `HookEventBridge` `Elicitation` unit tests (3 tests) -- shape,
      default text, agentId/promptId passthrough.
- [x] Updated: the pre-existing `Notification(permission_prompt)` /
      "PermissionRequest + Notification forwarding" tests for Q5's deletion.
- [x] `registers 13 .on() listeners` updated (was 10).
- [x] Break-it-then-fix-it for both PermissionDenied and ElicitationResult
      (counts above).

Closes #889. Closes #890.


---

## Review fixes before merge

Three fresh-context reviews (correctness / tests / claim-accuracy) plus a
coordinator pass. One real bug, two coverage gaps, five inaccurate claims.

### Bug: a re-fired `Elicitation` could orphan the live card

`handleElicitation` returns a minted id unconditionally, but the emission
behind it is fire-and-forget: `MessageAPI.handleQuestion` returns `void` and
skips `addQuestion` entirely when `QuestionDedup` suppresses. A second
`Elicitation` for the same `elicitation_id` is *guaranteed* to be suppressed
inside the 5s window — identical text, identical `options: []`, identical
`allowsFreeText: true`, so never "richer", and status never leaves `'waiting'`
to reset the baseline because `handleElicitation` emits before its own
`onStatusChange('waiting')`. The correlation map was then repointed at a card
that had never been registered: `ElicitationResult` resolved the phantom, and
the card the user could actually see was left with no automated way to clear
(user answer or LRU only).

Same defect class as #925 — a resolution path that cannot reach the question
it is for. Two guards: never displace a still-live card, and never track an id
that did not reach `sessionRegistry` (the confirmed-delivery gate #888
landed). Note the rule is the **opposite** of `cancelExternallyResolved`-
before-register: there the newer request genuinely re-renders so newest wins;
here the newer card is the one that does not exist. Documented in place so the
asymmetry does not read as an inconsistency to clean up.

### Coverage gaps closed

- **Agent scoping through this wiring path.** Deleting `sig.agentId !==
  observed.agentId` from `findOpenQuestionMatching` left all 160 tests in the
  two files this PR touches green. The shared matcher is covered in
  `auto-approve-gate.test.ts`, but nothing proved the `agentId: input.agent_id`
  passthrough here actually scopes. New test opens two escalations on an
  identical (tool, tool_input) signature under different agents and asserts a
  `PermissionDenied` for one resolves exactly one — then that the survivor is
  still resolvable, proving it was tracked rather than quietly dropped.
  Verified red under the mutation, green with the check restored.
- **Q5's residual path, end-to-end.** The existing test stopped at "nothing is
  stashed". The second half of the safety argument — an unpaired
  `permission_prompt` whose prompt *does* render still surfaces via the
  orphan-PTY fallback — was asserted in a comment but never exercised. Now
  driven through `onOrphanPTYPrompt` (what `cli.ts` actually routes to when a
  hookServer is active), asserting the PTY's own text and `source: 'pty'`
  survive.

### Inaccurate claims corrected

- `MAX_PENDING_ELICITATIONS` was described as "mirroring `MAX_PARKED_INPUTS`".
  That constant is **64**, not 32. Reworded to state the real number and why
  this cap is deliberately smaller.
- The "every ambiguous path resolves toward showing the user" maxim was cited
  to #889. It is a pre-existing codebase-wide rule from `auto-approve-gate.ts`
  (see `question-presence-tracker.ts`'s own citation). Re-attributed.
- The process-vs-answer ordering correction lived only in this PR body. It is
  now written into `hook-types.ts` at the registration decision point:
  `dispatch()` runs to completion **before** the `{}` response, synchronously,
  so a listener's work is on Claude's critical path and there is no
  answer-first escape hatch. #889's text asserted the opposite. The three new
  registrations are safe because each handler is a map lookup or a signature
  compare — not because responding is free.
- `docs/claude-code-hook-contract.md` still marked all three newly-registered
  events as unregistered in its **Reg.** column and gave the count as 11. This
  is the canonical record of what remi registers, and this PR is what made it
  wrong (ADR 0011 rule 3). Corrected to 14.
- `question-presence-tracker.ts` and `cli.ts` both listed "MCP elicitation
  dialogs" among prompts that reach ONLY the PTY, which #889 makes false; and
  a merge comment named `'notification'` as an authoritative hook source after
  Q5 removed its only producer. Both corrected.
- The `realMessageApi` test helper claimed it wired `MessageAPI` "exactly as
  `message-api-setup.ts`" — it reproduces only `addQuestion`, not
  `sendAndRecord`/push/stamping. Reworded, since "exactly as production" is
  the coverage overclaim ADR 0014 exists to catch.

### Documented, deliberately not changed

- The "richer wins" guard in `recordPendingHook` is now structurally
  unreachable (both entry points pass only `'permission_request'` after Q5).
  Kept, with a comment: it is the invariant that makes adding a future stashed
  source safe, and re-deriving it after a regression is how #574 was found.
- `'notification'` stays in the `QuestionSource` union with no producer.
  Removing it is a wire-format decision (persisted questions may still carry
  it), not this PR's.
- ADR 0013's compile-time exhaustiveness is scoped to `ProtocolMessage`, not
  hook events — `HookServer` dispatches through a runtime Map, so registering
  an event with no consumer would not fail `tsc`. The "13 listeners" test is
  the only thing pinning that set. Worth knowing; not changed here.
