### PR TITLE
Contain a handler throw at the inbound message seam (#916)

### DIFF
--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -627,7 +627,24 @@ export class RelayAdapter implements ConnectionAdapter {
       // defense in depth + exhaustiveness (mirrors connection.ts).
       auth_response: (m) => this.routeAuthResponse(m),
     };
-    const routed = routeClientMessage(msg, handlers);
+    // #916: NOT a crash-prevention fix like connection.ts's mirror-image
+    // change -- routeMessage's only caller, handleRelayMessage, already
+    // wraps this call in its own try/catch, so a synchronous handler throw
+    // was already contained before this. What that outer catch did NOT do is
+    // reply to the peer (it only logs, mislabeled as "Failed to parse relay
+    // payload"), leaving the client hanging with zero signal. This inner
+    // try/catch fixes the misdiagnosis and adds the reply the issue
+    // requires, matching connection.ts's behavior.
+    let routed: boolean;
+    try {
+      routed = routeClientMessage(msg, handlers);
+    } catch (err) {
+      console.error(`Relay handler for '${msg.type}' failed: ${errorToString(err)}`);
+      this.client?.sendRelay(
+        JSON.stringify(createError('INTERNAL_ERROR', `Handler for '${msg.type}' failed`)),
+      );
+      return;
+    }
     if (!routed) {
       console.warn(`Unknown relay message type: ${msg.type}`);
       this.client?.sendRelay(

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -309,7 +309,23 @@ export class Connection {
       // UNKNOWN_MESSAGE would have given.
       auth_response: (m) => this.routeAuthResponse(m),
     };
-    const routed = routeClientMessage(message, handlers);
+    // #916: a handler is trusted to guard its own throws (most are `async`
+    // and unawaited, so a throw there is already a survivable unhandled
+    // rejection -- see process-guards.ts). This is the backstop for one that
+    // forgets and throws SYNCHRONOUSLY: uncaught, that would escape all the
+    // way to `uncaughtException`, whose policy is a fatal exit(1) -- correct
+    // for real state corruption, wrong for a client payload. Contain it here
+    // instead: log via the same onError path routeAuthResponse's catch uses,
+    // and answer the sender rather than silently dropping the message.
+    let routed: boolean;
+    try {
+      routed = routeClientMessage(message, handlers);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.events.onError?.(error);
+      this.sendError('INTERNAL_ERROR', `Handler for '${message.type}' failed: ${error.message}`);
+      return;
+    }
     if (!routed) {
       this.sendError('UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
     }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -258,76 +258,92 @@ export class Connection {
       return;
     }
 
-    // In authenticating state, only accept auth_response
-    if (this.state === 'authenticating') {
-      if (message.type === 'auth_response') {
-        this.routeAuthResponse(message);
-      } else if (message.type === 'ping') {
-        this.handlePing(message);
-      } else {
-        this.sendError('AUTH_REQUIRED', 'Authentication required before other messages');
-      }
-      return;
-    }
-
-    // Route by message type (#899): a total map over every client-to-daemon
-    // type, so a new registry key breaks this object's compile until it is
-    // decided, rather than silently falling through a switch's default.
-    const handlers: ClientMessageHandlers = {
-      hello: (m) => this.handleHello(m),
-      user_input: (m) => this.handleUserInput(m),
-      answer: (m) => this.handleAnswer(m),
-      bullet_expand_request: (m) => this.handleBulletExpandRequest(m),
-      session_list_request: (m) => this.handleSessionListRequest(m),
-      transcript_load_request: (m) => this.handleTranscriptLoadRequest(m),
-      create_session_request: (m) => this.handleCreateSessionRequest(m),
-      terminal_resize: (m) => this.handleTerminalResize(m),
-      kill_session_request: (m) => this.handleKillSessionRequest(m),
-      resume_session_request: (m) => this.handleResumeSessionRequest(m),
-      session_history_request: (m) => this.handleSessionHistoryRequest(m),
-      detach_session: (m) => this.handleDetachSession(m),
-      register_device_token: (m) => this.handleRegisterDeviceToken(m),
-      unregister_device_token: (m) => this.handleUnregisterDeviceToken(m),
-      ping: (m) => this.handlePing(m),
-      pong: () => {
-        // Explicit protocol-level liveness reply. Redundant with the
-        // any-message reset above (kept as documentation of intent and a
-        // second line of defense if that reset is ever narrowed).
-        this.missedPongs = 0;
-      },
-      // Client acknowledging our message - just track (no-op). #899's trap:
-      // `ack` is tagged 'both' (not 'c2d') precisely because this case is
-      // real and accepting, not a forgotten one -- see MESSAGE_DIRECTION's
-      // comment on `ack` and ClientToDaemonType's doc comment.
-      ack: 'ignore',
-      // Reachable only if a client resends auth_response after already
-      // completing (or skipping) the handshake -- the authenticating-state
-      // branch above intercepts the normal case before this map is ever
-      // consulted. Kept as a real handler (not 'ignore') for defense in
-      // depth: `handleAuthResponse` itself guards on state and answers
-      // INVALID_STATE, a more specific reply than falling through to
-      // UNKNOWN_MESSAGE would have given.
-      auth_response: (m) => this.routeAuthResponse(m),
-    };
-    // #916: a handler is trusted to guard its own throws (most are `async`
-    // and unawaited, so a throw there is already a survivable unhandled
-    // rejection -- see process-guards.ts). This is the backstop for one that
-    // forgets and throws SYNCHRONOUSLY: uncaught, that would escape all the
-    // way to `uncaughtException`, whose policy is a fatal exit(1) -- correct
-    // for real state corruption, wrong for a client payload. Contain it here
-    // instead: log via the same onError path routeAuthResponse's catch uses,
-    // and answer the sender rather than silently dropping the message.
-    let routed: boolean;
+    // #916: everything below -- the authenticating-state branch AND the
+    // connected-state routing -- runs inside one try/catch. A handler is
+    // trusted to guard its own throws (most are `async` and unawaited, so a
+    // throw there is already a survivable unhandled rejection -- see
+    // process-guards.ts). This is the backstop for one that forgets and
+    // throws SYNCHRONOUSLY: uncaught, that would escape all the way to
+    // `uncaughtException`, whose policy is a fatal exit(1) -- correct for
+    // real state corruption, wrong for a client payload. The authenticating
+    // branch is in scope too: `handlePing` reaches `this.ws.send` just like
+    // any routed handler does, and was not covered before this.
     try {
-      routed = routeClientMessage(message, handlers);
+      // In authenticating state, only accept auth_response
+      if (this.state === 'authenticating') {
+        if (message.type === 'auth_response') {
+          this.routeAuthResponse(message);
+        } else if (message.type === 'ping') {
+          this.handlePing(message);
+        } else {
+          this.sendError('AUTH_REQUIRED', 'Authentication required before other messages');
+        }
+        return;
+      }
+
+      // Route by message type (#899): a total map over every client-to-daemon
+      // type, so a new registry key breaks this object's compile until it is
+      // decided, rather than silently falling through a switch's default.
+      const handlers: ClientMessageHandlers = {
+        hello: (m) => this.handleHello(m),
+        user_input: (m) => this.handleUserInput(m),
+        answer: (m) => this.handleAnswer(m),
+        bullet_expand_request: (m) => this.handleBulletExpandRequest(m),
+        session_list_request: (m) => this.handleSessionListRequest(m),
+        transcript_load_request: (m) => this.handleTranscriptLoadRequest(m),
+        create_session_request: (m) => this.handleCreateSessionRequest(m),
+        terminal_resize: (m) => this.handleTerminalResize(m),
+        kill_session_request: (m) => this.handleKillSessionRequest(m),
+        resume_session_request: (m) => this.handleResumeSessionRequest(m),
+        session_history_request: (m) => this.handleSessionHistoryRequest(m),
+        detach_session: (m) => this.handleDetachSession(m),
+        register_device_token: (m) => this.handleRegisterDeviceToken(m),
+        unregister_device_token: (m) => this.handleUnregisterDeviceToken(m),
+        ping: (m) => this.handlePing(m),
+        pong: () => {
+          // Explicit protocol-level liveness reply. Redundant with the
+          // any-message reset above (kept as documentation of intent and a
+          // second line of defense if that reset is ever narrowed).
+          this.missedPongs = 0;
+        },
+        // Client acknowledging our message - just track (no-op). #899's trap:
+        // `ack` is tagged 'both' (not 'c2d') precisely because this case is
+        // real and accepting, not a forgotten one -- see MESSAGE_DIRECTION's
+        // comment on `ack` and ClientToDaemonType's doc comment.
+        ack: 'ignore',
+        // Reachable only if a client resends auth_response after already
+        // completing (or skipping) the handshake -- the authenticating-state
+        // branch above intercepts the normal case before this map is ever
+        // consulted. Kept as a real handler (not 'ignore') for defense in
+        // depth: `handleAuthResponse` itself guards on state and answers
+        // INVALID_STATE, a more specific reply than falling through to
+        // UNKNOWN_MESSAGE would have given.
+        auth_response: (m) => this.routeAuthResponse(m),
+      };
+      const routed = routeClientMessage(message, handlers);
+      if (!routed) {
+        this.sendError('UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
+      }
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      this.events.onError?.(error);
-      this.sendError('INTERNAL_ERROR', `Handler for '${message.type}' failed: ${error.message}`);
-      return;
-    }
-    if (!routed) {
-      this.sendError('UNKNOWN_MESSAGE', `Unknown message type: ${message.type}`);
+      // Insurance consistent with this guard's own thesis (#916 review): NOT
+      // currently reachable -- the wired `onError` (trivial-events.ts) only
+      // logs and `send()` guards on `readyState`, so neither throws today --
+      // but `onError` is a caller-supplied callback and `ws.send` can still
+      // race a closing socket, and a guard whose own report can throw would
+      // undermine the reason this try/catch exists. Each half is independent
+      // and best-effort; `onError` runs first, so the fault is already
+      // logged before the reply is even attempted.
+      try {
+        this.events.onError?.(error);
+      } catch {
+        // Nothing left to safely report a throwing onError callback to.
+      }
+      try {
+        this.sendError('INTERNAL_ERROR', `Handler for '${message.type}' failed: ${error.message}`);
+      } catch {
+        // Socket likely closing; the peer gets no reply instead of a crash.
+      }
     }
   }
 

--- a/packages/daemon/tests/remote/relay-route-message-seam-guard.test.ts
+++ b/packages/daemon/tests/remote/relay-route-message-seam-guard.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #916: the relay's inbound dispatch, `RelayAdapter.routeMessage`, now
+ * try/catches its `routeClientMessage` call the same way `connection.ts`'s
+ * `handleMessage` does.
+ *
+ * Correction to the issue's premise, recorded here per AGENTS.md "Verify
+ * before you describe": unlike `connection.ts`, this seam was NOT actually
+ * exposed to a fatal `uncaughtException` exit. `routeMessage` has exactly one
+ * caller, `handleRelayMessage` (relay-adapter.ts:271-327), whose own
+ * try/catch already wraps the `routeMessage` call -- so a synchronous handler
+ * throw was already caught there, just mislabeled as "Failed to parse relay
+ * payload" and, critically, never replied to the peer at all (that catch
+ * only logs). This change does not close a crash gap on the relay side; it
+ * fixes the misdiagnosis and adds the reply the issue requires ("never
+ * swallow... send the client an error reply"), matching what `connection.ts`
+ * already does. Both are verified below.
+ *
+ * Constructs the REAL `RelayAdapter` (ADR 0014) through its documented
+ * `createTransport` test seam -- the same fake-transport pattern
+ * `relay-client-to-daemon-conformance.test.ts` uses -- with a throwing event
+ * callback wired through the adapter's real `AdapterEvents` extension point.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { createTerminalResize, createUserInput } from '@remi/shared';
+import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { AdapterEvents } from '../../src/adapters/connection-adapter.ts';
+import { RelayAdapter, type RelayTransport } from '../../src/remote/relay-adapter.ts';
+
+/** Minimal stand-in for the signaling Worker connection, via the same seam
+ *  `relay-client-to-daemon-conformance.test.ts` uses -- not a stand-in for
+ *  `RelayAdapter` itself, which is constructed for real below. */
+class FakeRelayTransport implements RelayTransport {
+  readonly isConnected = true;
+  readonly connectionCode: string | null = 'TEST-CODE';
+  readonly sent: string[] = [];
+  // biome-ignore lint/suspicious/noExplicitAny: matches RelayTransport's catch-all overload
+  private readonly listeners = new Map<string, Array<(...args: any[]) => void>>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: matches RelayTransport's catch-all overload
+  on(event: string, cb: (...args: any[]) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: forwarding whatever `on` was registered with
+  private fire(event: string, ...args: any[]): void {
+    for (const cb of this.listeners.get(event) ?? []) cb(...args);
+  }
+
+  sendRelay(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  connect(): void {}
+  close(): void {}
+
+  emitPeerConnected(): void {
+    this.fire('peer-connected');
+  }
+
+  emitRelay(message: ProtocolMessage): void {
+    this.fire('relay', JSON.stringify(message));
+  }
+}
+
+describe('RelayAdapter.routeMessage seam guard (#916)', () => {
+  test('a handler that throws synchronously is contained, replied to, and does not wedge the peer', async () => {
+    const transport = new FakeRelayTransport();
+    const events: Partial<AdapterEvents> = {
+      onTerminalResize: () => {
+        throw new Error('boom: relay handler forgot to guard itself');
+      },
+      onUserInput: () => {
+        // Used to prove routing still works afterward; no-op.
+      },
+    };
+
+    const adapter = new RelayAdapter(
+      {
+        enabled: true,
+        signalingUrl: 'wss://ignored.example.com',
+        createTransport: () => transport,
+      },
+      events,
+    );
+
+    await adapter.start();
+    transport.emitPeerConnected(); // no authenticator configured -> authenticated immediately
+
+    // (1) the throw must not escape the transport's 'relay' event handler.
+    expect(() => {
+      transport.emitRelay(createTerminalResize(80, 24));
+    }).not.toThrow();
+
+    // (2) the peer receives an error reply naming the failing type -- this is
+    // the behavioral change: before #916, handleRelayMessage's outer catch
+    // logged the throw but sent NOTHING back to the peer.
+    const lastSent = transport.sent.at(-1);
+    expect(lastSent).toBeDefined();
+    const reply = JSON.parse(lastSent as string) as { type: string; code?: string };
+    expect(reply.type).toBe('error');
+    expect(reply.code).toBe('INTERNAL_ERROR');
+
+    // (3) the adapter is not wedged: a later, unrelated message on the same
+    // peer connection still routes.
+    const before = transport.sent.length;
+    transport.emitRelay(createUserInput('sess-id' as UUID, 'hello', false));
+    // onUserInput is a no-op above; absence of a NEW error/UNSUPPORTED reply
+    // (and no throw) is the routing proof for a handled type.
+    expect(transport.sent.length).toBe(before);
+
+    await adapter.stop();
+  });
+});

--- a/packages/daemon/tests/server/handle-message-seam-guard.test.ts
+++ b/packages/daemon/tests/server/handle-message-seam-guard.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #916: `Connection.handleMessage` had NO enclosing try/catch anywhere on the
+ * path from the WebSocket server's bare `message(ws, data)` callback down to
+ * an individual handler (verified: `websocket-server.ts:614-620` calls
+ * `connection.handleMessage(data)` unguarded; `handleMessage` itself had no
+ * try/catch around `routeClientMessage`). Since `isValidMessage` only checks
+ * the envelope (type/id/timestamp), not payload shape, a handler that forgets
+ * to guard a synchronous throw would escape all the way to Bun's
+ * `uncaughtException`, whose policy (`process-guards.ts`) is a fatal
+ * `exit(1)` -- correct for real state corruption, wrong for one client's
+ * malformed payload on a hub that serves every session on the machine.
+ *
+ * This constructs the REAL `Connection` (ADR 0014 -- no synthetic stand-in
+ * for the class under test) with a real `MockWebSocket` transport, injects a
+ * throwing event callback through the class's actual `ConnectionEvents`
+ * extension seam (the same seam production wires to `sharedEvents` in
+ * cli.ts), and proves the seam contains the throw, replies to the sender,
+ * and leaves the connection able to keep routing.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { createPing, createTerminalResize, deserialize, serialize } from '@remi/shared';
+import type { ProtocolMessage } from '@remi/shared';
+import { Connection } from '../../src/server/connection.ts';
+
+/** Same pattern as connection-unregister-ack-order.test.ts and
+ *  connection-auth.test.ts: a real WebSocket-shaped object, not a mock of
+ *  Connection itself. */
+class MockWebSocket {
+  readyState = WebSocket.OPEN;
+  sentMessages: ProtocolMessage[] = [];
+
+  send(data: string): void {
+    const msg = deserialize(data);
+    if (msg) this.sentMessages.push(msg);
+  }
+
+  close(): void {}
+}
+
+describe('Connection.handleMessage seam guard (#916)', () => {
+  test('a handler that throws synchronously is contained, replied to, and does not wedge the connection', () => {
+    const ws = new MockWebSocket();
+    const onErrorCalls: Error[] = [];
+
+    // terminal_resize's private wrapper has no state gate, so it reaches
+    // `onTerminalResize` immediately without a hello handshake -- the
+    // simplest real path to a SYNCHRONOUS call into an injected event.
+    const conn = new Connection(
+      ws as unknown as WebSocket,
+      {
+        onTerminalResize: () => {
+          throw new Error('boom: handler forgot to guard itself');
+        },
+        onError: (err) => {
+          onErrorCalls.push(err);
+        },
+      },
+      {},
+    );
+
+    // (1) the throw must not escape handleMessage.
+    expect(() => {
+      conn.handleMessage(serialize(createTerminalResize(80, 24)));
+    }).not.toThrow();
+
+    // Logged via the same onError path the pre-existing auth-response catch
+    // uses (connection.ts's routeAuthResponse), not swallowed.
+    expect(onErrorCalls).toHaveLength(1);
+    expect(onErrorCalls[0]?.message).toContain('boom');
+
+    // (2) the sender receives an error reply naming the failing type.
+    const error = ws.sentMessages.find((m) => m.type === 'error') as
+      | (ProtocolMessage & { code: string; message: string })
+      | undefined;
+    expect(error).toBeDefined();
+    expect(error?.code).toBe('INTERNAL_ERROR');
+    expect(error?.message).toContain('terminal_resize');
+
+    // (3) the connection is not wedged: a later, unrelated message still
+    // routes normally on the SAME connection instance.
+    ws.sentMessages.length = 0;
+    const pingMsg = createPing();
+    conn.handleMessage(serialize(pingMsg));
+    const pong = ws.sentMessages.find((m) => m.type === 'pong');
+    expect(pong).toBeDefined();
+  });
+});

--- a/packages/daemon/tests/server/handle-message-seam-guard.test.ts
+++ b/packages/daemon/tests/server/handle-message-seam-guard.test.ts
@@ -16,12 +16,42 @@
  * extension seam (the same seam production wires to `sharedEvents` in
  * cli.ts), and proves the seam contains the throw, replies to the sender,
  * and leaves the connection able to keep routing.
+ *
+ * Two review-found gaps in the first version of this guard, both covered
+ * below:
+ *
+ * 1. The `state === 'authenticating'` branch (`handlePing` /
+ *    `routeAuthResponse` / `sendError('AUTH_REQUIRED', ...)`) ran BEFORE the
+ *    try/catch, which only wrapped the connected-state routing call -- so
+ *    the pre-handshake window was exactly as unguarded as before this PR.
+ *    Fixed by hoisting one try/catch around the whole dispatch region
+ *    (authenticating branch + routing) instead of adding a second targeted
+ *    one, matching the shape `relay-adapter.ts`'s `handleRelayMessage`
+ *    already uses (its single outer try covers its whole body, so new
+ *    branches are covered automatically).
+ * 2. The catch block's own reporting (`events.onError?.(error)` and
+ *    `sendError(...)`) was itself unguarded. `events.onError` is a
+ *    caller-supplied callback and `ws.send` can race a closing socket, so in
+ *    principle either could throw and escape as the very
+ *    `uncaughtException` this guard exists to prevent. NOT currently
+ *    reachable in production (`trivial-events.ts`'s wired `onError` only
+ *    logs; `send()` guards on `readyState`) -- this is insurance consistent
+ *    with the guard's own thesis, not a fix for a live bug.
  */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { createPing, createTerminalResize, deserialize, serialize } from '@remi/shared';
 import type { ProtocolMessage } from '@remi/shared';
+import { Authenticator } from '../../src/auth/authenticator.ts';
+import { IdentityStore } from '../../src/auth/identity-store.ts';
 import { Connection } from '../../src/server/connection.ts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'remi-handle-message-seam-guard-'));
+}
 
 /** Same pattern as connection-unregister-ack-order.test.ts and
  *  connection-auth.test.ts: a real WebSocket-shaped object, not a mock of
@@ -32,6 +62,32 @@ class MockWebSocket {
 
   send(data: string): void {
     const msg = deserialize(data);
+    if (msg) this.sentMessages.push(msg);
+  }
+
+  close(): void {}
+}
+
+/** Same as MockWebSocket, but its FIRST send of a given message type throws
+ *  -- simulating a socket that faults on one particular write (e.g. closing
+ *  mid-send) without breaking the constructor's own `send` calls (the
+ *  auth_challenge, in the authenticating-state test below) or the seam's own
+ *  error-reply send. */
+class OnceThrowingWebSocket {
+  readyState = WebSocket.OPEN;
+  sentMessages: ProtocolMessage[] = [];
+  private readonly throwOnceForTypes: Set<string>;
+
+  constructor(throwOnceForTypes: readonly string[]) {
+    this.throwOnceForTypes = new Set(throwOnceForTypes);
+  }
+
+  send(data: string): void {
+    const msg = deserialize(data);
+    if (msg && this.throwOnceForTypes.has(msg.type)) {
+      this.throwOnceForTypes.delete(msg.type);
+      throw new Error(`boom: send() faulted for '${msg.type}'`);
+    }
     if (msg) this.sentMessages.push(msg);
   }
 
@@ -84,5 +140,103 @@ describe('Connection.handleMessage seam guard (#916)', () => {
     conn.handleMessage(serialize(pingMsg));
     const pong = ws.sentMessages.find((m) => m.type === 'pong');
     expect(pong).toBeDefined();
+  });
+
+  test('a throwing onError callback does not escape handleMessage, and the error reply still lands (gap 2)', () => {
+    const ws = new MockWebSocket();
+
+    const conn = new Connection(
+      ws as unknown as WebSocket,
+      {
+        onTerminalResize: () => {
+          throw new Error('boom: handler forgot to guard itself');
+        },
+        onError: () => {
+          // The reporting path itself must not be trusted not to throw --
+          // it is a caller-supplied callback.
+          throw new Error('boom: onError callback also throws');
+        },
+      },
+      {},
+    );
+
+    expect(() => {
+      conn.handleMessage(serialize(createTerminalResize(80, 24)));
+    }).not.toThrow();
+
+    // The reply half of the reporting path is independent of onError's own
+    // fault: the sender still gets the INTERNAL_ERROR frame.
+    const error = ws.sentMessages.find((m) => m.type === 'error') as
+      | (ProtocolMessage & { code: string })
+      | undefined;
+    expect(error).toBeDefined();
+    expect(error?.code).toBe('INTERNAL_ERROR');
+
+    // Not wedged.
+    ws.sentMessages.length = 0;
+    conn.handleMessage(serialize(createPing()));
+    expect(ws.sentMessages.find((m) => m.type === 'pong')).toBeDefined();
+  });
+});
+
+describe('Connection.handleMessage seam guard: authenticating-state branch (#916 gap 1)', () => {
+  let tmpDir: string;
+  let authenticator: Authenticator;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    const store = new IdentityStore(tmpDir);
+    await store.generate();
+    const serverIdentity = await store.unlock();
+    authenticator = new Authenticator({ identity: serverIdentity, identityStore: store });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test('a throw reached via the pre-handshake ping path is contained and the connection survives', () => {
+    // Before this fix, the try/catch wrapped only the connected-state
+    // routing call; the `state === 'authenticating'` branch -- reachable
+    // BEFORE any hello/handshake -- ran outside it entirely. `handlePing`'s
+    // `this.send(createPong(...))` is the synchronous throw site here: the
+    // FIRST 'pong' send faults (simulating a socket that closes mid-send),
+    // while the constructor's own 'auth_challenge' send and this seam's
+    // 'error' reply are unaffected.
+    const ws = new OnceThrowingWebSocket(['pong']);
+    const onErrorCalls: Error[] = [];
+    const conn = new Connection(
+      ws as unknown as WebSocket,
+      { onError: (err) => onErrorCalls.push(err) },
+      { authenticator },
+    );
+
+    expect(conn.connectionState).toBe('authenticating');
+
+    expect(() => {
+      conn.handleMessage(serialize(createPing()));
+    }).not.toThrow();
+
+    expect(onErrorCalls).toHaveLength(1);
+    expect(onErrorCalls[0]?.message).toContain('boom');
+
+    const error = ws.sentMessages.find((m) => m.type === 'error') as
+      | (ProtocolMessage & { code: string })
+      | undefined;
+    expect(error).toBeDefined();
+    expect(error?.code).toBe('INTERNAL_ERROR');
+
+    // The fault did not corrupt the state machine.
+    expect(conn.connectionState).toBe('authenticating');
+
+    // Not wedged: the throw-once socket no longer faults 'pong', so a
+    // second ping on the SAME connection gets a normal pong back.
+    ws.sentMessages.length = 0;
+    conn.handleMessage(serialize(createPing()));
+    expect(ws.sentMessages.find((m) => m.type === 'pong')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Rescoped per the issue's latest comment (superseding both original options):
one try/catch at each inbound seam so a handler that throws synchronously is
contained, logged, and answered, instead of escaping to `uncaughtException`'s
fatal `exit(1)` (`process-guards.ts:79-108`). No payload schema validation
added (explicitly rejected, see #883).

- `Connection.handleMessage` (`packages/daemon/src/server/connection.ts`):
  wraps `routeClientMessage(message, handlers)` in try/catch. Logs via
  `this.events.onError?.(...)` (the same path `routeAuthResponse`'s existing
  catch uses) and replies `INTERNAL_ERROR` naming the failing message type.
  The connection is NOT closed, so it keeps routing afterward.
- `RelayAdapter.routeMessage` (`packages/daemon/src/remote/relay-adapter.ts`):
  same shape, replying over `sendRelay`.

## Correction to the issue's premise on the relay side

Verified against code before writing this (AGENTS.md "Verify before you
describe"): the relay side was **not actually exposed to the same crash**.
`routeMessage` has exactly one caller, `handleRelayMessage`
(`relay-adapter.ts:271-327`), and that function's own try/catch already wraps
the `routeMessage` call -- so a synchronous handler throw was already caught
there before this PR. What that outer catch did NOT do: reply to the peer (it
only logs, mislabeled as "Failed to parse relay payload," which is wrong when
the actual cause is a handler throwing on a well-formed envelope). So the
relay-side change here is not a crash fix, it is a diagnostics + reply-quality
fix -- it corrects the mislabel and adds the `INTERNAL_ERROR` reply the issue
requires ("never swallow... send the client an error reply"), matching what
`connection.ts` already needed for real. Said plainly rather than inflating
severity to match the WebSocket side.

The WebSocket side (`connection.ts`) has no such outer catch anywhere in its
call chain (`websocket-server.ts:614-620` calls `handleMessage` bare), so that
half of this PR is the real containment fix.

## Error code

Checked first: `ErrorMessage.code` (`packages/shared/src/protocol.ts`) is a
plain `string`, not an enum -- there is no formal error-code registry
analogous to ADR 0012's `ProtocolMessageMap` (that ADR covers protocol
*message types*, not error-code strings). Reused `INTERNAL_ERROR` rather than
inventing a new one-off code: it already exists as the established code for
exactly this "something broke server-side" case in
`packages/signaling/src/connection-room.ts:255`. No new registry was added --
doing so would have meant building a structure this codebase does not have
today for a single string constant, well past the requested scope.

## Handler audit (as requested -- do not assume reachability)

18 client-to-daemon message types total (`ClientToDaemonType`,
`packages/shared/src/protocol.ts:249`), same handler set shared by both
`Connection` and `RelayAdapter` (both wired from `cli.ts`'s single
`sharedEvents` object):

- **5 route to `async` top-level handlers** (`hello`->`onConnect`,
  `user_input`, `answer`, `create_session_request`, `resume_session_request`):
  a throw there is already a survivable unhandled rejection
  (`process-guards.ts:74-77` logs and keeps serving), matching the issue's own
  finding for `user_input`.
- **1 (`auth_response`)** is wrapped by its own `.catch()` in
  `routeAuthResponse` already (safe by construction).
- **3 are trivial no-ops** (`ping`, `pong`, `ack`) with no throw surface.
- **9 are fully synchronous** (`bullet_expand_request`, `session_list_request`,
  `transcript_load_request`, `terminal_resize`, `kill_session_request`,
  `session_history_request`, `detach_session`, `register_device_token`,
  `unregister_device_token`). I traced each one down through its I/O calls
  (`SessionRegistry`, `TranscriptDiscovery.discoverSessions`/
  `findTranscriptFiles`, `LiveSessionsRegistry.listLive`,
  `DeviceTokenStore.persist`, `BulletContentRegistry.get`) and found every
  risky operation already wrapped in its own try/catch, consistent with the
  defensive-I/O discipline used throughout this codebase (e.g.
  `session-events.ts`'s per-entry try/catch, `transcript-discovery.ts`'s
  `findTranscriptFiles` guarding its own `readdirSync`).

**No currently-reachable synchronous throw was found.** This extends, and
does not contradict, the issue's own preliminary finding (`user_input` and
`terminal_resize`). This PR is insurance against the next handler that
forgets to guard itself, not a fix for a live crash -- stated plainly per the
issue's instruction not to manufacture severity.

## Tests (ADR 0014: construct the real components)

- `packages/daemon/tests/server/handle-message-seam-guard.test.ts` --
  constructs a real `Connection` with a real `MockWebSocket` transport (same
  pattern as `connection-unregister-ack-order.test.ts`), injects a
  synchronously-throwing `onTerminalResize` through the class's real
  `ConnectionEvents` seam. Asserts: the throw does not escape
  `handleMessage`, `onError` is invoked, the sender receives an
  `INTERNAL_ERROR` reply naming `terminal_resize`, and a subsequent `ping` on
  the same connection still gets a `pong` (not wedged).
- `packages/daemon/tests/remote/relay-route-message-seam-guard.test.ts` --
  constructs a real `RelayAdapter` through its documented `createTransport`
  test seam (same fake-transport pattern as
  `relay-client-to-daemon-conformance.test.ts`), injects a
  synchronously-throwing `onTerminalResize`. Asserts the throw does not
  escape, the peer receives the `INTERNAL_ERROR` reply (the actual behavioral
  change on this side), and a subsequent `user_input` still routes.

## Review follow-up: two gaps found, both fixed

Two reviewers found the same real gap independently; a correctness-lens
review found a second, smaller one. Both fixed on this branch.

**Gap 1 -- the authenticating-state branch bypassed the guard entirely.**
`connection.ts`'s `state === 'authenticating'` branch (`handlePing` /
`routeAuthResponse` / `sendError('AUTH_REQUIRED', ...)`) ran BEFORE the
try/catch, which originally wrapped only the connected-state routing call --
so the pre-handshake window was exactly as unguarded as before this PR.
`handlePing` reaches `this.ws.send` the same way any routed handler does.
Fixed by hoisting one try/catch around the whole dispatch region
(authenticating branch + routing) instead of adding a second targeted one --
matching the shape `relay-adapter.ts`'s `handleRelayMessage` already uses
(one outer try around its whole body, so new branches inside it are covered
automatically; the WS side's narrower wrap was exactly why this gap existed
there and not on the relay).

**Gap 2 -- the guard's own reporting could itself throw.** Inside the catch,
neither `this.events.onError?.(error)` nor `this.sendError(...)` was
protected: `onError` is a caller-supplied callback, and `sendError` ->
`send()` guards on `readyState` but `ws.send()` can still throw on a socket
racing closed. Calibrated per review: this is **not currently reachable** --
the wired `onError` (`trivial-events.ts`) only logs and does not throw, and
this exact unguarded-catch-body shape already exists elsewhere in this file
(`routeAuthResponse`'s own catch). It is not a PR-introduced regression or a
live bug. Fixed anyway because leaving it contradicts this PR's own thesis
that this seam must never be able to kill the daemon, for the cost of two
small nested try/catches (no abstraction, no refactor of the other sites
sharing the pattern). `onError` runs first, so even when the reply's own
send is swallowed, the fault is already logged.

Both fixes are covered by two new tests in
`handle-message-seam-guard.test.ts` (real `Connection`, no mocks, same style
as the two above): one constructs a real `Authenticator`/`IdentityStore` (per
`connection-auth.test.ts`'s pattern) to reach the authenticating state and
throws via a socket that faults its first `pong` send; the other injects a
throwing `onError` callback alongside the already-throwing handler.

**Mutation-test evidence (both proved red before green):**

- Gap 1: temporarily un-hoisted the try/catch back to wrapping only the
  routing call. `bun test ... -t "authenticating"` failed with the raw
  `Error: boom: send() faulted for 'pong'` escaping `expect().not.toThrow()`.
  Restored the hoist; same test passed.
- Gap 2: temporarily removed the `try { this.events.onError?.(error) } catch
  {}` wrapper. `bun test ... -t "onError callback"` failed with
  `Error: boom: onError callback also throws` escaping. Restored the wrapper;
  same test passed.

Test count: 2 -> 4 in `handle-message-seam-guard.test.ts` (the two new ones
above), `relay-route-message-seam-guard.test.ts` unchanged at 1 -- 5 new
tests total across this PR.

## Gates (all run in the foreground)

- `bunx biome check .` -- clean (pre-existing warnings elsewhere, unrelated to
  this diff; my touched files have zero issues)
- `bun run typecheck` -- clean
- `bun test packages/daemon/tests/server/ packages/daemon/tests/remote/` --
  78 pass, 0 fail (was 76 before the two new tests)

## Scope

~35 lines of non-test production code in the first commit, plus a further
restructuring (hoist + two small nested try/catches, no new abstraction) in
the follow-up commit addressing review. No payload schema validation added.

