### PR TITLE
Suppress status bar repaints during live questions (#932)

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2748,8 +2748,10 @@ if (cliDaemonMode) {
 
   // Start drawing the reserved-row bar now that the PTY is up. Reads the live
   // StatusWriter state and repaints on a 1Hz timer (the cadence of the
-  // `evaluating Ns` counter), which also re-asserts the bar if Claude's output
-  // scrolled it. Inert until started, and a no-op when detached.
+  // `evaluating Ns` counter). Inert until started, and a no-op when detached
+  // or while a question is pending (#932 -- see status-bar.ts's module doc:
+  // the bar and Claude's own output share one fd, so painting over a live
+  // prompt risks corrupting or erasing it).
   if (statusBarActive) {
     statusBar = new StatusBar({
       getStdoutFd: getPtyStdoutFd,
@@ -2759,6 +2761,8 @@ if (cliDaemonMode) {
         rows: process.stdout.rows || 40,
       }),
       isEnabled: () => !isWrapperDetached(),
+      hasLiveQuestions: () =>
+        (sessionRegistry.getSession(sessionId)?.currentQuestions.size ?? 0) > 0,
       log: (m) => log(m),
     });
     statusBar.start();

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -76,6 +76,12 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   // this client already receives, so the attach-path bar gets the same
   // pause-while-live protection as the wrapper bar.
   let liveQuestionIds = new Set<UUID>();
+  // #932: whether at least one `question_snapshot` has been observed for
+  // this attach cycle. `startStatusBar()`'s first paint must not run before
+  // this is true, or it can read `hasLiveQuestions()` as false for a
+  // session that already has a live question -- see that function's doc.
+  let receivedQuestionSnapshot = false;
+  let questionSnapshotTimer: ReturnType<typeof setTimeout> | null = null;
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -104,6 +110,10 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     if (rawPtyTimer) {
       clearTimeout(rawPtyTimer);
       rawPtyTimer = null;
+    }
+    if (questionSnapshotTimer) {
+      clearTimeout(questionSnapshotTimer);
+      questionSnapshotTimer = null;
     }
     if (resizeNudgeTimer) {
       clearTimeout(resizeNudgeTimer);
@@ -177,8 +187,35 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
    * Reserving the row = reporting `rows - 1` to the daemon's PTY, exactly like
    * wrapper mode; the StatusBar itself is the same class, drawing on this
    * terminal's bottom row from the broadcast snapshots.
+   *
+   * #932: `.start()` paints immediately, so that first paint must not read
+   * `hasLiveQuestions()` before `liveQuestionIds` reflects reality. The
+   * daemon always sends `question_snapshot` -- even empty -- right after
+   * hello_ack (`resendPendingQuestions`), but it necessarily arrives as a
+   * LATER message than the hello_ack/remi_status that can trigger this
+   * call, so calling straight through here could paint "no question" for a
+   * session that already has one live. Deferred (not blocked) until one
+   * arrives, bounded by a short timeout that creates the bar anyway --
+   * `createStatusBar()` bypasses the wait -- so an older daemon that never
+   * sends a snapshot doesn't lose the bar entirely, only that first paint's
+   * protection-1 coverage: the same fail-open default `hasLiveQuestions`
+   * already has elsewhere in this file.
    */
   function startStatusBar(): void {
+    if (!statusBarEligible || statusBar !== null || resolved) return;
+    if (!receivedQuestionSnapshot) {
+      if (!questionSnapshotTimer) {
+        questionSnapshotTimer = setTimeout(() => {
+          questionSnapshotTimer = null;
+          createStatusBar();
+        }, 500);
+      }
+      return;
+    }
+    createStatusBar();
+  }
+
+  function createStatusBar(): void {
     if (!statusBarEligible || statusBar !== null || resolved) return;
     statusBar = new StatusBar({
       getStdoutFd: () => (outputBroken ? null : outputFd),
@@ -278,6 +315,15 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       // `liveQuestionIds`'s declaration for why this is the right signal.
       question_snapshot: (m) => {
         liveQuestionIds = new Set(m.questionIds);
+        if (!receivedQuestionSnapshot) {
+          receivedQuestionSnapshot = true;
+          if (questionSnapshotTimer) {
+            clearTimeout(questionSnapshotTimer);
+            questionSnapshotTimer = null;
+          }
+          // Release a startStatusBar() that deferred waiting for this.
+          if (attachedSessionId) startStatusBar();
+        }
       },
       replay_batch: (m) => {
         for (const nested of m.messages) {

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -31,6 +31,11 @@ export interface AttachClientOptions {
   timeout?: number;
   /** File descriptor for output. Defaults to 1 (stdout). Override in tests. */
   outputFd?: number;
+  /** Whether the reserved-row status bar (#754) is eligible to start.
+   *  Defaults to `process.stdout.isTTY === true`, same as production. Tests
+   *  run without a real TTY, so this is the hook that lets them exercise the
+   *  bar's actual wiring (including #932's `hasLiveQuestions`) end to end. */
+  statusBarEligible?: boolean;
 }
 
 export interface AttachClientResult {
@@ -59,9 +64,18 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   // #754: latest daemon status snapshot (remi_status broadcast) + the
   // reserved-row bar rendering it — the same StatusBar the wrapper draws.
   // Only on a real TTY: piped/test output must never receive bar escapes.
-  const statusBarEligible = process.stdout.isTTY === true;
+  const statusBarEligible = opts.statusBarEligible ?? process.stdout.isTTY === true;
   let latestStatus: RemiStatus | null = null;
   let statusBar: StatusBar | null = null;
+  // #932: the authoritative live-question id set for this session, kept
+  // current by `question_snapshot` (sent unconditionally on attach via
+  // `resendPendingQuestions`, and again on every change via
+  // `onQuestionsChanged` -- see that broadcast's doc). Mirrors the wrapper's
+  // own `hasLiveQuestions` (`cli.ts:1525`,
+  // `sessionRegistry.getSession(id)?.currentQuestions.size > 0`) using data
+  // this client already receives, so the attach-path bar gets the same
+  // pause-while-live protection as the wrapper bar.
+  let liveQuestionIds = new Set<UUID>();
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -174,6 +188,7 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
         rows: process.stdout.rows || 40,
       }),
       isEnabled: () => latestStatus !== null,
+      hasLiveQuestions: () => liveQuestionIds.size > 0,
       log: (msg) => process.stderr.write(`${msg}\n`),
     });
     statusBar.start();
@@ -257,6 +272,13 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
           writeOutput('\r\n\x1b[2m[remi] question answered\x1b[0m\r\n');
         }
       },
+      // #932: the authoritative live set, always overwritten (never merged --
+      // matches `QuestionStore`'s own "full current set, never a delta"
+      // contract). Feeds the status bar's `hasLiveQuestions`; see
+      // `liveQuestionIds`'s declaration for why this is the right signal.
+      question_snapshot: (m) => {
+        liveQuestionIds = new Set(m.questionIds);
+      },
       replay_batch: (m) => {
         for (const nested of m.messages) {
           renderMessage(nested, true);
@@ -309,7 +331,6 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       hub_status: 'ignore',
       session_rotated: 'ignore',
       session_views: 'ignore',
-      question_snapshot: 'ignore',
     };
     dispatchMessage(msg, handlers);
   }

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -324,6 +324,20 @@ export class StatusBar {
    *  comment below for why both edges force a fresh paint. */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
+    // fd/room checks come BEFORE hasLiveQuestions() is read and
+    // wasQuestionLive is mutated (#932 review fix): a transition landing on
+    // a tick where a paint isn't even possible must not be consumed. If it
+    // were, the flag would flip with no write to show for it, and the NEXT
+    // successful tick would compute onset/resumed against the
+    // already-flipped flag -- neither true -- and freeze on stale content
+    // for the rest of the window: the exact bug this whole mechanism exists
+    // to prevent, reintroduced through ordering. Same pattern
+    // `disabled`/`isEnabled()` above already use: return before touching
+    // any state a later, capable tick still needs to see as unconsumed.
+    const fd = this.getStdoutFd();
+    if (fd === null) return;
+    const { cols, rows } = this.getSize();
+    if (rows < MIN_ROWS_FOR_BAR || cols < 1) return;
     const questionLive = this.hasLiveQuestions();
     const wasLive = this.wasQuestionLive;
     this.wasQuestionLive = questionLive;
@@ -335,19 +349,15 @@ export class StatusBar {
     // up to `HEARTBEAT_MS` stale. `onset` is true only on the first
     // render() call after the transition into "live"; it forces one fresh
     // paint below, capturing the status at that instant. Every later call
-    // while still live hits the early return just below and never touches
-    // the fd. `resumed` is the mirror on the way back out: the dialog may
-    // have redrawn or consumed row N while it owned the screen, so the
-    // physical row cannot be trusted to still match `lastRendered` either --
-    // the very first render() after the question clears also forces a fresh
-    // paint, then normal dedup/heartbeat cadence takes back over.
+    // while still live hits the early return just below. `resumed` is the
+    // mirror on the way back out: the dialog may have redrawn or consumed
+    // row N while it owned the screen, so the physical row cannot be
+    // trusted to still match `lastRendered` either -- the very first
+    // render() after the question clears also forces a fresh paint, then
+    // normal dedup/heartbeat cadence takes back over.
     const onset = questionLive && !wasLive;
     const resumed = !questionLive && wasLive;
     if (questionLive && !onset) return;
-    const fd = this.getStdoutFd();
-    if (fd === null) return;
-    const { cols, rows } = this.getSize();
-    if (rows < MIN_ROWS_FOR_BAR || cols < 1) return;
     // The whole draw stays inside the try: an exception escaping into the
     // setInterval callback would surface as an uncaughtException and could take
     // the wrapper down — the one thing a cosmetic bar must never do. The

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -37,8 +37,11 @@
  *      pending question, so the ~250ms timer cannot paint over a live prompt.
  *   2. A paint whose built escape sequence is byte-identical to the last one
  *      actually written is skipped -- most ticks rewrite identical bytes, and
- *      every write is an exposure window. `stop()` resets this so the next
- *      `render()` after a restart always writes unconditionally.
+ *      every write is an exposure window -- but only up to `HEARTBEAT_MS`: an
+ *      unbounded skip would stop reasserting DECSTBM (see `buildBarSequence`)
+ *      and trade this exposure for the region-reset bleed it exists to
+ *      prevent. `stop()` resets this so the next `render()` after a restart
+ *      always writes unconditionally.
  */
 
 import * as fs from 'node:fs';
@@ -59,6 +62,16 @@ export const APPROVED_FRESH_S = 5;
  *  single transient write error (e.g. an interrupted syscall) must not silence
  *  the bar for the whole session; a genuinely dead fd trips this within seconds. */
 export const MAX_RENDER_ERRORS = 3;
+/** Upper bound (ms) on how long an unchanged-status paint can be skipped
+ *  (#932). Every paint re-asserts DECSTBM (see `buildBarSequence`); skipping
+ *  unchanged paints forever would mean that assertion never fires while the
+ *  status happens to sit still, and Claude's own binary can reset the region
+ *  (`ESC[r`) at any time. 2000ms keeps that gap bounded to well under what a
+ *  user would notice as "the bar stopped updating," while still cutting the
+ *  write rate roughly 8x versus the old unconditional 250ms cadence -- most
+ *  of protection 2's exposure reduction. Not configurable: it exists to keep
+ *  the dedup and the region invariant coupled, not to be tuned per caller. */
+export const HEARTBEAT_MS = 2000;
 
 /**
  * Rows to report to the child PTY given the real terminal height and whether
@@ -132,8 +145,11 @@ export function formatStatusBar(status: Readonly<RemiStatus>, nowMs: number): st
  * on output and the bar bleeds up into Claude's content (#565). With the region
  * pinned to `1..row-1`, the terminal can only scroll the rows above the bar, so
  * `row` stays fixed. The region is re-asserted on every paint in case Claude
- * ever resets it. DECSTBM homes the cursor, but DECSC/DECRC (ESC7/ESC8) restore
- * it, and DECRC does not touch the region, so the region persists after.
+ * ever resets it (#932: this is why `StatusBar.render()`'s change-detection
+ * dedup is bounded by `HEARTBEAT_MS` rather than unconditional -- skipping
+ * this call forever would mean the region is never reasserted). DECSTBM
+ * homes the cursor, but DECSC/DECRC (ESC7/ESC8) restore it, and DECRC does
+ * not touch the region, so the region persists after.
  */
 export function buildBarSequence(row: number, cols: number, text: string): string {
   const visible = text.length > cols ? text.slice(0, cols) : text;
@@ -191,12 +207,12 @@ export interface StatusBarDeps {
  * ~250ms timer (#576) so the `evaluating Ns` counter stays smooth. Each tick
  * still calls `render()` unconditionally, but `render()` itself now (#932)
  * skips the actual fd write when the built sequence is unchanged from the
- * last one written, or while a question is live -- so a byte-identical status
- * (the common case) costs no write, at the tradeoff that a status-unchanged
- * scroll-away (Claude's inline output pushing the bar off row N) is not
- * re-asserted until the status next changes. `stop()` clears the row and
- * halts the loop. All draws are no-ops unless `isEnabled()` and a live fd and
- * enough rows.
+ * last one written AND less than `HEARTBEAT_MS` has passed since the last
+ * write, or while a question is live -- so a byte-identical status (the
+ * common case) mostly costs no write, while the DECSTBM re-assertion
+ * `buildBarSequence` depends on still happens at least every `HEARTBEAT_MS`
+ * regardless. `stop()` clears the row and halts the loop. All draws are
+ * no-ops unless `isEnabled()` and a live fd and enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -208,8 +224,14 @@ export class StatusBar {
   private disabled = false;
   /** The last escape sequence actually written, or null before the first
    *  write (or right after `stop()`). #932 protection 2: a paint identical to
-   *  this is skipped rather than rewritten. */
+   *  this is skipped rather than rewritten, bounded by `lastWriteAtMs` /
+   *  `HEARTBEAT_MS` below. */
   private lastRendered: string | null = null;
+  /** Epoch ms of the last actual write, or null before the first write (or
+   *  right after `stop()`). #932: a paint is forced once `HEARTBEAT_MS` has
+   *  elapsed since this, even if `lastRendered` is unchanged -- see
+   *  `HEARTBEAT_MS`'s doc for why this must stay bounded. */
+  private lastWriteAtMs: number | null = null;
   private readonly getStdoutFd: () => number | null;
   private readonly getStatus: () => Readonly<RemiStatus>;
   private readonly getSize: () => { cols: number; rows: number };
@@ -255,6 +277,7 @@ export class StatusBar {
     // bar sequence -- reset so a future render() after a restart always
     // writes unconditionally rather than comparing against stale content.
     this.lastRendered = null;
+    this.lastWriteAtMs = null;
   }
 
   /** Paint the reserved row now. Safe no-op when disabled / detached / no
@@ -275,11 +298,18 @@ export class StatusBar {
     try {
       const text = formatStatusBar(this.getStatus(), this.now());
       const sequence = buildBarSequence(rows, cols, text);
+      const nowMs = this.now();
+      const heartbeatDue =
+        this.lastWriteAtMs === null || nowMs - this.lastWriteAtMs >= HEARTBEAT_MS;
       // #932 protection 2: skip the write when nothing changed since the last
-      // successful paint -- most ticks would rewrite identical bytes.
-      if (sequence === this.lastRendered) return;
+      // successful paint AND the heartbeat hasn't elapsed -- most ticks would
+      // otherwise rewrite identical bytes. The heartbeat still forces a write
+      // at least every HEARTBEAT_MS so buildBarSequence's DECSTBM
+      // re-assertion stays bounded (see that doc and HEARTBEAT_MS's).
+      if (sequence === this.lastRendered && !heartbeatDue) return;
       this.writeToFd(fd, sequence);
       this.lastRendered = sequence;
+      this.lastWriteAtMs = nowMs;
       this.consecutiveErrors = 0;
       this.errorLogged = false;
     } catch (err) {

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -26,6 +26,19 @@
  * the wrapper has detached (stdout fd is null), or when the terminal is too
  * short to spare a row. A render error backs the bar off rather than crashing
  * the wrapper.
+ *
+ * Exposure reduction (#932): this bar and Claude's own PTY output are two
+ * unsynchronized writers on the same fd, and the DECSC/DECRC pair above
+ * shares Claude's own cursor-save slot -- a paint that lands mid-render can
+ * corrupt or erase the very question remi exists to deliver. This does not
+ * fix that race (root fix would mean serializing the two writers); it just
+ * cuts how often a paint is attempted at all:
+ *   1. `render()` no-ops entirely while `hasLiveQuestions()` reports a
+ *      pending question, so the ~250ms timer cannot paint over a live prompt.
+ *   2. A paint whose built escape sequence is byte-identical to the last one
+ *      actually written is skipped -- most ticks rewrite identical bytes, and
+ *      every write is an exposure window. `stop()` resets this so the next
+ *      `render()` after a restart always writes unconditionally.
  */
 
 import * as fs from 'node:fs';
@@ -152,6 +165,14 @@ export interface StatusBarDeps {
   readonly getSize: () => { cols: number; rows: number };
   /** Master enable (config flag + wrapper mode + a real TTY). */
   readonly isEnabled: () => boolean;
+  /** True iff the session currently has at least one pending question
+   *  (mirrors `hasLiveQuestions` in `question-presence-tracker.ts`, backed by
+   *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`). #932:
+   *  `render()` no-ops while this is true so the bar can never paint over a
+   *  live prompt. Optional; defaults to always-false (no suppression) so a
+   *  caller that omits it keeps the pre-#932 behavior instead of silently
+   *  losing the bar. */
+  readonly hasLiveQuestions?: () => boolean;
   /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
   readonly writeToFd?: (fd: number, data: string) => void;
   /** Current epoch ms. Injectable for tests; defaults to Date.now. */
@@ -167,10 +188,15 @@ export interface StatusBarDeps {
 
 /**
  * Owns the reserved-row redraw loop. `start()` paints immediately and then on a
- * ~250ms timer (#576); the unconditional periodic repaint keeps the bar asserted
- * even if Claude's output scrolled it (inline mode) since the last tick and keeps
- * the `evaluating Ns` counter smooth. `stop()` clears the row and halts the loop.
- * All draws are no-ops unless `isEnabled()` and a live fd and enough rows.
+ * ~250ms timer (#576) so the `evaluating Ns` counter stays smooth. Each tick
+ * still calls `render()` unconditionally, but `render()` itself now (#932)
+ * skips the actual fd write when the built sequence is unchanged from the
+ * last one written, or while a question is live -- so a byte-identical status
+ * (the common case) costs no write, at the tradeoff that a status-unchanged
+ * scroll-away (Claude's inline output pushing the bar off row N) is not
+ * re-asserted until the status next changes. `stop()` clears the row and
+ * halts the loop. All draws are no-ops unless `isEnabled()` and a live fd and
+ * enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -180,10 +206,15 @@ export class StatusBar {
   /** Set after MAX_RENDER_ERRORS consecutive failures; the bar backs off for
    *  good (the fd has gone bad). A success before then clears the streak. */
   private disabled = false;
+  /** The last escape sequence actually written, or null before the first
+   *  write (or right after `stop()`). #932 protection 2: a paint identical to
+   *  this is skipped rather than rewritten. */
+  private lastRendered: string | null = null;
   private readonly getStdoutFd: () => number | null;
   private readonly getStatus: () => Readonly<RemiStatus>;
   private readonly getSize: () => { cols: number; rows: number };
   private readonly isEnabled: () => boolean;
+  private readonly hasLiveQuestions: () => boolean;
   private readonly writeToFd: (fd: number, data: string) => void;
   private readonly now: () => number;
   private readonly log: (msg: string) => void;
@@ -194,6 +225,7 @@ export class StatusBar {
     this.getStatus = deps.getStatus;
     this.getSize = deps.getSize;
     this.isEnabled = deps.isEnabled;
+    this.hasLiveQuestions = deps.hasLiveQuestions ?? (() => false);
     this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
     this.now = deps.now ?? (() => Date.now());
     this.log = deps.log;
@@ -219,11 +251,18 @@ export class StatusBar {
       this.timer = null;
     }
     this.clearRow();
+    // #932: the physical row is now the clear sequence, not `lastRendered`'s
+    // bar sequence -- reset so a future render() after a restart always
+    // writes unconditionally rather than comparing against stale content.
+    this.lastRendered = null;
   }
 
-  /** Paint the reserved row now. Safe no-op when disabled / detached / no room. */
+  /** Paint the reserved row now. Safe no-op when disabled / detached / no
+   *  room / a question is currently live (#932). */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
+    // #932 protection 1: never paint over a live question prompt.
+    if (this.hasLiveQuestions()) return;
     const fd = this.getStdoutFd();
     if (fd === null) return;
     const { cols, rows } = this.getSize();
@@ -235,7 +274,12 @@ export class StatusBar {
     // practice only the fd write can fail here.
     try {
       const text = formatStatusBar(this.getStatus(), this.now());
-      this.writeToFd(fd, buildBarSequence(rows, cols, text));
+      const sequence = buildBarSequence(rows, cols, text);
+      // #932 protection 2: skip the write when nothing changed since the last
+      // successful paint -- most ticks would rewrite identical bytes.
+      if (sequence === this.lastRendered) return;
+      this.writeToFd(fd, sequence);
+      this.lastRendered = sequence;
       this.consecutiveErrors = 0;
       this.errorLogged = false;
     } catch (err) {

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -28,13 +28,24 @@
  * the wrapper.
  *
  * Exposure reduction (#932): this bar and Claude's own PTY output are two
- * unsynchronized writers on the same fd, and the DECSC/DECRC pair above
- * shares Claude's own cursor-save slot -- a paint that lands mid-render can
- * corrupt or erase the very question remi exists to deliver. This does not
- * fix that race (root fix would mean serializing the two writers); it just
- * cuts how often a paint is attempted at all:
- *   1. `render()` no-ops entirely while `hasLiveQuestions()` reports a
- *      pending question, so the ~250ms timer cannot paint over a live prompt.
+ * writers on the same fd, both synchronous `fs.writeSync` in the same
+ * process and thread -- so byte-level interleaving WITHIN one write is not
+ * the mechanism. The real hazard is a paint landing BETWEEN two PTY-
+ * forwarding chunks, at a boundary that happens to split one of Claude's
+ * own escape sequences (the DECSC/DECRC pair above shares Claude's own
+ * cursor-save slot -- 166/421 occurrences in the installed binary). This
+ * does not fix that (the durable fix is a quiescence + clean-boundary gate
+ * on the PTY-forwarding side, tracked on #932 as its own follow-up -- NOT
+ * a write queue, since same-process/same-thread writeSync calls have no
+ * concurrency to serialize); it just cuts how often a paint is attempted:
+ *   1. `render()` no-ops while `hasLiveQuestions()` reports a pending
+ *      question -- except for one fresh paint on the transition INTO that
+ *      state (see `render()`'s `onset`), so the bar is current the moment
+ *      Claude's native statusLine (#560) disappears for an AskUserQuestion
+ *      dialog, then freezes rather than risk a later paint landing
+ *      mid-render. One more forced paint on the transition back OUT (see
+ *      `resumed`) recovers row N before normal cadence resumes, since the
+ *      dialog may have redrawn it while it owned the screen.
  *   2. A paint whose built escape sequence is byte-identical to the last one
  *      actually written is skipped -- most ticks rewrite identical bytes, and
  *      every write is an exposure window -- but only up to `HEARTBEAT_MS`: an
@@ -42,6 +53,10 @@
  *      and trade this exposure for the region-reset bleed it exists to
  *      prevent. `stop()` resets this so the next `render()` after a restart
  *      always writes unconditionally.
+ *
+ * Protection 2 is also a restoration, not a new optimization: #565 specified
+ * redraw "on: status change ... and on resize." The unconditional ~250ms
+ * timer was added later, in #576, and exceeded that original design.
  */
 
 import * as fs from 'node:fs';
@@ -184,10 +199,22 @@ export interface StatusBarDeps {
   /** True iff the session currently has at least one pending question
    *  (mirrors `hasLiveQuestions` in `question-presence-tracker.ts`, backed by
    *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`). #932:
-   *  `render()` no-ops while this is true so the bar can never paint over a
-   *  live prompt. Optional; defaults to always-false (no suppression) so a
-   *  caller that omits it keeps the pre-#932 behavior instead of silently
-   *  losing the bar. */
+   *  `render()` paints once on the transition into this being true, then
+   *  freezes for as long as it stays true, then paints once more on the
+   *  transition back out before resuming normal cadence -- so the bar can
+   *  never paint over a live prompt but also never freezes on stale content
+   *  (see `render()`'s `onset` / `resumed`). Optional; defaults to
+   *  always-false (no suppression) so a caller that omits it keeps the
+   *  pre-#932 behavior instead of silently losing the bar.
+   *
+   *  Session-wide, not agent-scoped: it is true whenever ANY agent in the
+   *  session has a pending question, so in a concurrent multi-agent session
+   *  (Agent Teams, Task-tool subagents) the freeze can span output from an
+   *  UNRELATED agent that is still actively writing to this same PTY/fd
+   *  while a different agent's question sits open. The protection this
+   *  buys is deliberately biased toward never painting over a real prompt,
+   *  not toward a precise per-agent freeze window -- see #932's PR
+   *  discussion for the full reasoning on why that tradeoff was kept. */
   readonly hasLiveQuestions?: () => boolean;
   /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
   readonly writeToFd?: (fd: number, data: string) => void;
@@ -208,11 +235,14 @@ export interface StatusBarDeps {
  * still calls `render()` unconditionally, but `render()` itself now (#932)
  * skips the actual fd write when the built sequence is unchanged from the
  * last one written AND less than `HEARTBEAT_MS` has passed since the last
- * write, or while a question is live -- so a byte-identical status (the
- * common case) mostly costs no write, while the DECSTBM re-assertion
- * `buildBarSequence` depends on still happens at least every `HEARTBEAT_MS`
- * regardless. `stop()` clears the row and halts the loop. All draws are
- * no-ops unless `isEnabled()` and a live fd and enough rows.
+ * write -- so a byte-identical status (the common case) mostly costs no
+ * write, while the DECSTBM re-assertion `buildBarSequence` depends on still
+ * happens at least every `HEARTBEAT_MS` regardless. While a question is
+ * live, every tick is a no-op EXCEPT the first one after the transition
+ * into "live" and the first one after the transition back out, both of
+ * which always write (edge-triggered onset/resume paints, not the
+ * dedup/heartbeat path). `stop()` clears the row and halts the loop. All
+ * draws are no-ops unless `isEnabled()` and a live fd and enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -232,6 +262,12 @@ export class StatusBar {
    *  elapsed since this, even if `lastRendered` is unchanged -- see
    *  `HEARTBEAT_MS`'s doc for why this must stay bounded. */
   private lastWriteAtMs: number | null = null;
+  /** True while the last `render()` call observed a live question. #932:
+   *  `render()` compares this against the current `hasLiveQuestions()` read
+   *  to detect both transitions -- INTO "live" and back OUT (edge, not
+   *  level) -- see `render()` for why each edge forces a fresh paint. Reset
+   *  by `stop()` so a restart starts from "not live" again. */
+  private wasQuestionLive = false;
   private readonly getStdoutFd: () => number | null;
   private readonly getStatus: () => Readonly<RemiStatus>;
   private readonly getSize: () => { cols: number; rows: number };
@@ -278,14 +314,36 @@ export class StatusBar {
     // writes unconditionally rather than comparing against stale content.
     this.lastRendered = null;
     this.lastWriteAtMs = null;
+    this.wasQuestionLive = false;
   }
 
   /** Paint the reserved row now. Safe no-op when disabled / detached / no
-   *  room / a question is currently live (#932). */
+   *  room. While a question is live (#932), paints once on the transition
+   *  into that state and freezes after; paints once more on the transition
+   *  back out, then resumes normal cadence -- see the `onset`/`resumed`
+   *  comment below for why both edges force a fresh paint. */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
-    // #932 protection 1: never paint over a live question prompt.
-    if (this.hasLiveQuestions()) return;
+    const questionLive = this.hasLiveQuestions();
+    const wasLive = this.wasQuestionLive;
+    this.wasQuestionLive = questionLive;
+    // #932 protection 1 is edge-triggered, not level-triggered. Freezing row
+    // N while a question is live is right, but freezing it on WHATEVER was
+    // last painted is wrong: Claude's native statusLine (#560) disappears
+    // entirely while an AskUserQuestion dialog is open, so this bar is
+    // exactly the cue that has to be current the moment that happens -- not
+    // up to `HEARTBEAT_MS` stale. `onset` is true only on the first
+    // render() call after the transition into "live"; it forces one fresh
+    // paint below, capturing the status at that instant. Every later call
+    // while still live hits the early return just below and never touches
+    // the fd. `resumed` is the mirror on the way back out: the dialog may
+    // have redrawn or consumed row N while it owned the screen, so the
+    // physical row cannot be trusted to still match `lastRendered` either --
+    // the very first render() after the question clears also forces a fresh
+    // paint, then normal dedup/heartbeat cadence takes back over.
+    const onset = questionLive && !wasLive;
+    const resumed = !questionLive && wasLive;
+    if (questionLive && !onset) return;
     const fd = this.getStdoutFd();
     if (fd === null) return;
     const { cols, rows } = this.getSize();
@@ -305,8 +363,10 @@ export class StatusBar {
       // successful paint AND the heartbeat hasn't elapsed -- most ticks would
       // otherwise rewrite identical bytes. The heartbeat still forces a write
       // at least every HEARTBEAT_MS so buildBarSequence's DECSTBM
-      // re-assertion stays bounded (see that doc and HEARTBEAT_MS's).
-      if (sequence === this.lastRendered && !heartbeatDue) return;
+      // re-assertion stays bounded (see that doc and HEARTBEAT_MS's). The
+      // question onset/resume paints always write regardless of either check
+      // -- each is a fresh capture (or recovery), not a routine repaint.
+      if (!onset && !resumed && sequence === this.lastRendered && !heartbeatDue) return;
       this.writeToFd(fd, sequence);
       this.lastRendered = sequence;
       this.lastWriteAtMs = nowMs;

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -705,6 +705,20 @@ describe('runAttachClient', () => {
       },
     });
 
+    // Peek the output mid-freeze (t=900: after the status-B send at t=600,
+    // well ahead of the resolve at t=1200), via a separate read handle so
+    // the write fd stays open. This is what actually proves suppression is
+    // holding rather than merely coinciding on a final count: if
+    // hasLiveQuestions() were broken (e.g. wired to a constant), the status
+    // change at t=600 would have produced its own repaint by the very next
+    // ~250ms tick, long before t=900 -- and the final bars.length could
+    // still land on 2 by coincidence (a plain dedup repaint at t=600 plus
+    // nothing else), masking the regression.
+    let midFreezeOutput = '';
+    setTimeout(() => {
+      midFreezeOutput = fs.readFileSync(outputPath, 'utf-8');
+    }, 900);
+
     await runAttachClient({
       host: 'localhost',
       port: TEST_PORT + 13,
@@ -714,14 +728,18 @@ describe('runAttachClient', () => {
       statusBarEligible: true,
     });
 
+    const midBars = [...midFreezeOutput.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
+    expect(midBars.length).toBe(1); // still frozen: only the onset paint so far
+    expect(midBars[0]).toContain('idle'); // not yet "thinking" -- the freeze held
+
     const output = readOutput();
     const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
-    // Exactly two real paints: the bar's first-ever paint (deferred until
-    // question_snapshot arrives, which doubles as the onset paint since the
-    // question is already live by then -- status A, stored earlier), and
-    // the resumed paint on the transition back out (status B, reflecting
-    // the change made during the freeze). Every tick while frozen wrote
-    // nothing, despite the status having changed mid-freeze.
+    // Exactly two real paints total: the bar's first-ever paint (deferred
+    // until question_snapshot arrives, which doubles as the onset paint
+    // since the question is already live by then -- status A, stored
+    // earlier), and the resumed paint on the transition back out (status B,
+    // reflecting the change made during the freeze). Every tick while
+    // frozen wrote nothing, despite the status having changed mid-freeze.
     expect(bars.length).toBe(2);
     expect(bars[0]).toContain('idle');
     expect(bars[1]).toContain('thinking');

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -605,6 +605,10 @@ describe('runAttachClient', () => {
                   createRemiStatus(targetSessionId as UUID, mkRemiStatus(targetSessionId as UUID)),
                 ),
               );
+              // #932: the daemon always sends question_snapshot (even empty)
+              // right after hello_ack via resendPendingQuestions; the bar's
+              // first paint is gated on having observed one.
+              ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [])));
             }, 50);
             setTimeout(() => ws.close(), 200);
           }
@@ -631,10 +635,13 @@ describe('runAttachClient', () => {
   // #754) had NO hasLiveQuestions wiring at all before this fix -- the
   // ~250ms timer painted straight through a live question on this path.
   // question_snapshot (sent on attach and on every change, #753/#798) is the
-  // signal that now drives it. Proves the mechanism end to end on the REAL
-  // attach-client code path (not a StatusBar unit test): onset paint on the
-  // transition into "live", freeze through a status change made during the
-  // freeze, forced paint reflecting that change on the transition back out.
+  // signal that now drives it, and the bar's first-ever paint is deferred
+  // until one has been observed (a second review fix) so it cannot read
+  // "no question" for a session that already has one live. Proves the
+  // mechanism end to end on the REAL attach-client code path (not a
+  // StatusBar unit test): the deferred first paint doubling as the onset
+  // paint, freeze through a status change made during the freeze, forced
+  // paint reflecting that change on the transition back out.
   test('a live question (question_snapshot) suppresses the bar, then the resumed paint reflects a status change made during the freeze', async () => {
     setupOutput();
     const targetSessionId = generateId();
@@ -655,7 +662,9 @@ describe('runAttachClient', () => {
 
           if (msg.type === 'hello') {
             ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
-            // Bar starts, immediate paint with status A ("idle").
+            // remi_status arrives first, but (#932) startStatusBar() defers
+            // its first paint until a question_snapshot has been observed --
+            // status A ("idle") is only stored, not yet painted.
             setTimeout(() => {
               ws.send(
                 serialize(
@@ -666,7 +675,10 @@ describe('runAttachClient', () => {
                 ),
               );
             }, 50);
-            // Question goes live well before the first ~250ms timer tick.
+            // question_snapshot arrives with the question already live: this
+            // unblocks the deferred start AND is simultaneously the
+            // transition into "live", so the bar's first-ever paint IS the
+            // onset paint (reflecting status A, stored above).
             setTimeout(() => {
               ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [questionId])));
             }, 150);
@@ -704,15 +716,65 @@ describe('runAttachClient', () => {
 
     const output = readOutput();
     const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
-    // Exactly three real paints: the initial one (status A), the onset paint
-    // on the transition into "live" (still status A -- B has not been sent
-    // yet), and the resumed paint on the transition back out (status B,
-    // reflecting the change made during the freeze). Every tick while frozen
-    // wrote nothing, despite the status having changed mid-freeze.
-    expect(bars.length).toBe(3);
+    // Exactly two real paints: the bar's first-ever paint (deferred until
+    // question_snapshot arrives, which doubles as the onset paint since the
+    // question is already live by then -- status A, stored earlier), and
+    // the resumed paint on the transition back out (status B, reflecting
+    // the change made during the freeze). Every tick while frozen wrote
+    // nothing, despite the status having changed mid-freeze.
+    expect(bars.length).toBe(2);
     expect(bars[0]).toContain('idle');
-    expect(bars[1]).toContain('idle');
-    expect(bars[2]).toContain('thinking');
+    expect(bars[1]).toContain('thinking');
+  });
+
+  // #932: an older daemon that never sends question_snapshot must not lose
+  // the bar entirely -- deferring is a bound (createStatusBar()'s 500ms
+  // fallback), not a block.
+  test('the bar still starts via the fallback timeout when no question_snapshot ever arrives', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 14,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            // Deliberately never sends question_snapshot.
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(targetSessionId as UUID, mkRemiStatus(targetSessionId as UUID)),
+                ),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 900);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 14,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+      statusBarEligible: true,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('\x1b[7m'); // the bar started anyway, past the fallback bound
   });
 
   // #898: renderMessage's total-dispatch handler for raw_pty_output was

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -11,6 +11,7 @@ import {
   createPing,
   createQuestion,
   createQuestionResolved,
+  createQuestionSnapshot,
   createRawPtyOutput,
   createRemiStatus,
   createReplayBatch,
@@ -19,7 +20,14 @@ import {
   now,
   serialize,
 } from '@remi/shared';
-import type { Message, MessageHandlers, ProtocolMessageMap, Question, UUID } from '@remi/shared';
+import type {
+  Message,
+  MessageHandlers,
+  ProtocolMessageMap,
+  Question,
+  RemiStatus,
+  UUID,
+} from '@remi/shared';
 import { runAttachClient } from '../../src/cli/attach-client.ts';
 
 const TEST_PORT = 9873;
@@ -269,6 +277,23 @@ describe('runAttachClient', () => {
     });
     expect(pongMsg).toBeTruthy();
   });
+
+  function mkRemiStatus(targetSessionId: UUID, overrides: Partial<RemiStatus> = {}): RemiStatus {
+    return {
+      pid: 1,
+      connections: 1,
+      sessionStatus: 'idle',
+      adapters: ['ws'],
+      wsPort: 19924,
+      sessionId: targetSessionId,
+      repo: 'remi',
+      branch: 'develop',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'none', lastVerdictAtS: 0 },
+      attached: true,
+      queuedCount: 0,
+      ...overrides,
+    };
+  }
 
   function makeQuestion(text: string, held = true): Question {
     return {
@@ -550,6 +575,144 @@ describe('runAttachClient', () => {
     expect(output).not.toContain('| attached');
     expect(output).not.toContain('\x1b[7m');
     expect(output).not.toContain('\x1b[1;');
+  });
+
+  // #932: statusBarEligible lets a test force the bar on without a real TTY,
+  // proving the positive case the "not a TTY" test above only proves the
+  // negative of.
+  test('paints the reserved-row bar when statusBarEligible is forced true', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+
+    server = Bun.serve({
+      port: TEST_PORT + 12,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(targetSessionId as UUID, mkRemiStatus(targetSessionId as UUID)),
+                ),
+              );
+            }, 50);
+            setTimeout(() => ws.close(), 200);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 12,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+      statusBarEligible: true,
+    });
+
+    const output = readOutput();
+    expect(output).toContain('\x1b[7m'); // reverse-video bar paint
+    expect(output).toContain('\x1b[1;'); // DECSTBM scroll-region assertion
+  });
+
+  // #932: attach-client's own StatusBar (the same class the wrapper draws,
+  // #754) had NO hasLiveQuestions wiring at all before this fix -- the
+  // ~250ms timer painted straight through a live question on this path.
+  // question_snapshot (sent on attach and on every change, #753/#798) is the
+  // signal that now drives it. Proves the mechanism end to end on the REAL
+  // attach-client code path (not a StatusBar unit test): onset paint on the
+  // transition into "live", freeze through a status change made during the
+  // freeze, forced paint reflecting that change on the transition back out.
+  test('a live question (question_snapshot) suppresses the bar, then the resumed paint reflects a status change made during the freeze', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const questionId = generateId() as UUID;
+
+    server = Bun.serve({
+      port: TEST_PORT + 13,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            // Bar starts, immediate paint with status A ("idle").
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'idle' }),
+                  ),
+                ),
+              );
+            }, 50);
+            // Question goes live well before the first ~250ms timer tick.
+            setTimeout(() => {
+              ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [questionId])));
+            }, 150);
+            // Status changes to B ("thinking") WHILE the question is still
+            // live -- must not paint until the freeze ends.
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'thinking' }),
+                  ),
+                ),
+              );
+            }, 600);
+            // Question resolves, well ahead of the next timer tick.
+            setTimeout(() => {
+              ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [])));
+            }, 1200);
+            setTimeout(() => ws.close(), 1700);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 13,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+      statusBarEligible: true,
+    });
+
+    const output = readOutput();
+    const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
+    // Exactly three real paints: the initial one (status A), the onset paint
+    // on the transition into "live" (still status A -- B has not been sent
+    // yet), and the resumed paint on the transition back out (status B,
+    // reflecting the change made during the freeze). Every tick while frozen
+    // wrote nothing, despite the status having changed mid-freeze.
+    expect(bars.length).toBe(3);
+    expect(bars[0]).toContain('idle');
+    expect(bars[1]).toContain('idle');
+    expect(bars[2]).toContain('thinking');
   });
 
   // #898: renderMessage's total-dispatch handler for raw_pty_output was

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -323,27 +323,47 @@ describe('StatusBar', () => {
     bar.stop();
   });
 
-  // #932: the bar and Claude's own PTY output are two unsynchronized writers
-  // on the same fd; a paint that lands mid-render can corrupt or erase a live
-  // question prompt. These prove the two mitigations directly against the
+  // #932: the bar and Claude's own PTY output are two writers on the same
+  // fd; a paint that lands at the wrong moment can corrupt or erase a live
+  // question prompt. These prove the mitigations directly against the
   // fd-write count, independent of the timer.
-  test('a repaint is suppressed while a question is live', () => {
-    const { bar, writes } = harness({ hasLiveQuestions: () => true });
+  test('the onset paint happens on the transition into a live question and reflects its state', () => {
+    // Edge-triggered, not level-triggered: freezing row N is right, but
+    // freezing it on whatever was last painted is wrong -- Claude's native
+    // statusLine disappears entirely while a question dialog is open, so the
+    // bar has to be current the MOMENT that happens, not up to HEARTBEAT_MS
+    // stale. The first render() after the transition must still paint.
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      getStatus: () => mkStatus({ connections: 3 }),
+    });
     bar.render();
-    expect(writes).toHaveLength(0);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain('3 client(s)');
+  });
+
+  test('repaints are suppressed while a question stays live, after the onset paint', () => {
+    const { bar, writes } = harness({ hasLiveQuestions: () => true });
+    bar.render(); // onset: paints once
+    expect(writes).toHaveLength(1);
+    bar.render(); // still live: frozen
+    bar.render(); // still live: frozen
+    expect(writes).toHaveLength(1);
   });
 
   test('repaints resume once the question resolves', () => {
     let live = true;
     const { bar, writes } = harness({ hasLiveQuestions: () => live });
-    bar.render();
-    expect(writes).toHaveLength(0);
-    live = false;
-    bar.render();
+    bar.render(); // onset paint
     expect(writes).toHaveLength(1);
+    bar.render(); // frozen
+    expect(writes).toHaveLength(1);
+    live = false;
+    bar.render(); // resumes
+    expect(writes).toHaveLength(2);
   });
 
-  test('a resumed repaint reflects a status change that happened during suppression', () => {
+  test('the onset paint captures state at the transition, and the resumed repaint reflects a status change made during the freeze', () => {
     // The regression this guards against: a status change while a question is
     // live must not be lost -- the bar has to catch up, not stay stale
     // forever once the question resolves.
@@ -353,14 +373,16 @@ describe('StatusBar', () => {
       hasLiveQuestions: () => live,
       getStatus: () => mkStatus({ connections }),
     });
-    bar.render(); // suppressed: no write
+    bar.render(); // onset: paints the status AT the transition
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain('no clients');
     connections = 5; // status changes while the question is still live
-    bar.render(); // still suppressed
-    expect(writes).toHaveLength(0);
+    bar.render(); // frozen: no write
+    expect(writes).toHaveLength(1);
     live = false;
     bar.render(); // question resolved: must repaint with the NEW status
-    expect(writes).toHaveLength(1);
-    expect(writes[0]).toContain('5 client(s)');
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toContain('5 client(s)');
   });
 
   test('an unchanged status does not write a second time', () => {

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -418,4 +418,27 @@ describe('StatusBar', () => {
     expect(writes).toHaveLength(2);
     expect(writes[1]).toBe(writes[0]); // same content -- a heartbeat, not a change
   });
+
+  test('a transition during a room-too-short window still paints once the guard clears', () => {
+    // #932 review fix: the fd/room guards must run BEFORE hasLiveQuestions()
+    // is read and wasQuestionLive is mutated -- otherwise a transition that
+    // lands on a tick with no room gets "consumed" with no write to show
+    // for it, and the bar freezes on stale content for the rest of the
+    // window once room returns (the exact bug protection 1 exists to
+    // prevent, reintroduced through ordering).
+    let rows = 1; // too short: no room for the bar
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      getSize: () => ({ cols: 80, rows }),
+    });
+    // Question already live, but no room: no paint, and the transition
+    // must not be consumed here.
+    bar.render();
+    expect(writes).toHaveLength(0);
+    rows = 24; // room restored, question still live
+    // Onset must still fire now: the transition was never observed while
+    // room was unavailable.
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
 });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  HEARTBEAT_MS,
   MAX_RENDER_ERRORS,
   MIN_ROWS_FOR_BAR,
   StatusBar,
@@ -376,5 +377,23 @@ describe('StatusBar', () => {
     connections = 1;
     bar.render();
     expect(writes).toHaveLength(2);
+  });
+
+  test('a heartbeat repaint occurs after HEARTBEAT_MS even with an unchanged status', () => {
+    // buildBarSequence's DECSTBM re-assertion (the scroll region that keeps
+    // the bar's row fixed) rides on every paint; an unchanged-status dedup
+    // that never repaints would mean that assertion never fires either, so
+    // the heartbeat forces one at least every HEARTBEAT_MS regardless.
+    let nowMs = NOW_MS;
+    const { bar, writes } = harness({ now: () => nowMs });
+    bar.render();
+    expect(writes).toHaveLength(1);
+    nowMs += HEARTBEAT_MS - 1; // just under the threshold: still deduped
+    bar.render();
+    expect(writes).toHaveLength(1);
+    nowMs += 1; // now at the threshold: forced repaint despite same status
+    bar.render();
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toBe(writes[0]); // same content -- a heartbeat, not a change
   });
 });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -247,7 +247,11 @@ describe('StatusBar', () => {
   });
 
   test('the timer repaints on its interval', async () => {
-    const { bar, writes } = harness();
+    // #932 protection 2 skips a write when the built sequence is unchanged,
+    // so a changing status (not a fixed one) is what proves the timer is
+    // actually ticking rather than painting the same bytes over and over.
+    let connections = 0;
+    const { bar, writes } = harness({ getStatus: () => mkStatus({ connections: connections++ }) });
     bar.start();
     await new Promise((r) => setTimeout(r, 30)); // a few 5ms ticks
     bar.stop();
@@ -258,11 +262,13 @@ describe('StatusBar', () => {
     // No explicit intervalMs: exercise the constructor default. Within 320ms a
     // 250ms timer must have ticked at least once past the immediate paint
     // (the old 1000ms default would not have). Kept comfortably above 250ms to
-    // avoid CI timer jitter flaking the assertion.
+    // avoid CI timer jitter flaking the assertion. Status changes each read
+    // (#932 protection 2) so a repeat tick is not skipped as unchanged.
     const writes: string[] = [];
+    let connections = 0;
     const bar = new StatusBar({
       getStdoutFd: () => 1,
-      getStatus: () => mkStatus(),
+      getStatus: () => mkStatus({ connections: connections++ }),
       getSize: () => ({ cols: 80, rows: 24 }),
       isEnabled: () => true,
       writeToFd: (_fd, data) => writes.push(data),
@@ -314,5 +320,61 @@ describe('StatusBar', () => {
     expect(painted.length).toBeGreaterThan(0);
     expect(logs).toHaveLength(1);
     bar.stop();
+  });
+
+  // #932: the bar and Claude's own PTY output are two unsynchronized writers
+  // on the same fd; a paint that lands mid-render can corrupt or erase a live
+  // question prompt. These prove the two mitigations directly against the
+  // fd-write count, independent of the timer.
+  test('a repaint is suppressed while a question is live', () => {
+    const { bar, writes } = harness({ hasLiveQuestions: () => true });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('repaints resume once the question resolves', () => {
+    let live = true;
+    const { bar, writes } = harness({ hasLiveQuestions: () => live });
+    bar.render();
+    expect(writes).toHaveLength(0);
+    live = false;
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('a resumed repaint reflects a status change that happened during suppression', () => {
+    // The regression this guards against: a status change while a question is
+    // live must not be lost -- the bar has to catch up, not stay stale
+    // forever once the question resolves.
+    let live = true;
+    let connections = 0;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => live,
+      getStatus: () => mkStatus({ connections }),
+    });
+    bar.render(); // suppressed: no write
+    connections = 5; // status changes while the question is still live
+    bar.render(); // still suppressed
+    expect(writes).toHaveLength(0);
+    live = false;
+    bar.render(); // question resolved: must repaint with the NEW status
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toContain('5 client(s)');
+  });
+
+  test('an unchanged status does not write a second time', () => {
+    const { bar, writes } = harness();
+    bar.render();
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('a changed status writes again', () => {
+    let connections = 0;
+    const { bar, writes } = harness({ getStatus: () => mkStatus({ connections }) });
+    bar.render();
+    connections = 1;
+    bar.render();
+    expect(writes).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

remi's reserved-row status bar (#565) and Claude's own PTY output are two
writers on the same fd. The bar repaints unconditionally on a ~250ms timer,
and every paint brackets the write with DECSC/DECRC (ESC7/ESC8) -- the same
cursor-save slot Claude's own binary uses (166/421 occurrences confirmed in
the installed binary) -- and erases the reserved row with `ESC[2K`. Landing
at the wrong moment can corrupt or erase Claude's own question prompt,
which is exactly the thing remi exists to deliver. This is a live,
repeatedly-reported bug (#932): "the question becomes part of the footer
and not clickable," options that never render, or a prompt that never
shows up at all.

This PR implements protections 1 and 2 from the issue (not 3 or 4, out of
scope for this PR -- see #932 for the full list):

- **Protection 1 -- pause repaints while a question prompt is live, but
  never freeze on stale content.** `StatusBar.render()` paints once on the
  transition into `hasLiveQuestions()` being true (capturing the status at
  the instant the bar is needed most -- Claude's native statusLine
  disappears entirely while an `AskUserQuestion` dialog is open), then
  freezes for as long as it stays true, then paints once more on the
  transition back out before resuming normal cadence. Both edges are
  forced paints, bypassing the dedup below, because the dialog may have
  redrawn row N while it owned the screen -- the physical row cannot be
  trusted to still match what was last painted.
- **Protection 2 -- repaint only on change, bounded by a heartbeat.**
  `render()` skips the fd write when the built escape sequence is
  unchanged, since most 250ms ticks were rewriting identical bytes -- but
  only for up to `HEARTBEAT_MS` (2000ms). See "The dedup/DECSTBM coupling"
  below for why the bound exists.

Wired at **both** production call sites: the wrapper session (`cli.ts`,
via `sessionRegistry.getSession(id)?.currentQuestions.size > 0`, the same
signal already used for the #712 orphan-push check) and the `remi attach`
client (`attach-client.ts`, which runs the identical `StatusBar` class,
#754/#761 -- see "The second StatusBar" below).

`start()`, `stop()`, the disabled/detached/too-short fail-safes, and the
`MAX_RENDER_ERRORS` back-off are all unchanged. `stop()` now also resets
the dedup/heartbeat/live-question state so a later repaint after a restart
always writes unconditionally rather than comparing against stale content.

## What this does NOT claim to fix

Whether Claude actually emits `ESC7`/`ESC8` while rendering a permission
prompt specifically was not verified (only binary presence was
established) -- and no live reproduction was attempted. This PR is
exposure reduction: it makes the bar paint far less often, which cuts how
often the underlying races can even be attempted. It does not change
`buildBarSequence`'s escape sequence at all, and it is not a proof those
races are now impossible.

**Corrected mechanism for mode 1** (an earlier draft of this PR repeated
the issue's original "byte-level interleaving" framing, which was itself
corrected after independent verification): both writers -- the bar and the
PTY-output forwarder -- are synchronous `fs.writeSync` calls in the same
process and the same thread. Interleaving WITHIN one write is not
possible. The actual hazard is a paint landing BETWEEN two PTY-forwarding
chunks, at a boundary that happens to split one of Claude's own escape
sequences. Same symptom (a corrupted or offset render), different
mechanism. The durable fix for that is a quiescence + clean-boundary gate
on the PTY-forwarding side (gate `render()` on no-output-for-T-ms AND
not-mid-escape-sequence) -- tracked on #932 as its own follow-up, NOT
started here. A write queue is explicitly NOT the fix and is not planned:
same-process/same-thread `writeSync` calls have no concurrency to
serialize, so a queue would be a no-op.

## The dedup/DECSTBM coupling

`buildBarSequence` sets DECSTBM (`ESC[1;N-1r`) on **every** paint, and the
module doc already explained why: "the region is re-asserted on every
paint in case Claude ever resets it." An earlier version of protection 2
skipped the write whenever the built sequence was unchanged, with no
bound -- so a session sitting at a stable status could go minutes without
a single paint, and for that entire window DECSTBM was never reasserted.
Claude's own 2.1.220 binary contains `ESC[r` (reset scroll region to full
screen); if it emits that while the bar's dedup is holding, the terminal
scrolls the *whole* screen on output and the bar bleeds up into Claude's
content -- the exact failure #565's scroll region exists to prevent, and
specifically during normal active output, when the risk is highest.

Fixed by pairing the dedup with a heartbeat: `render()` also forces a
write once `HEARTBEAT_MS` (2000ms) has elapsed since the last real write,
regardless of content. 2000ms is well under what a user would perceive as
staleness, while still cutting the write rate roughly 8x versus the
unconditional 250ms cadence. Not configurable, by design -- the constant
and surrounding comments warn against "optimizing" the heartbeat away,
since it exists to keep the dedup and the DECSTBM invariant coupled.

**Protection 2 is a restoration, not a new optimization.** #565 originally
specified redraw "on: status change ... and on resize." The unconditional
~250ms timer was added later, in #576, and exceeded that design. This PR
returns to something close to the original spec, with the heartbeat as
the bound that keeps DECSTBM re-assertion from silently disappearing.

## Freezing on a fresh paint, not a stale one

An earlier version of protection 1 froze row N on whatever had last been
painted before the question went live -- which could be up to
`HEARTBEAT_MS` stale, and typically read something generic like `idle`.
That mattered because of what the bar is *for*: in Claude Code 2.1.220,
the native statusLine is visible in the normal REPL, disappears entirely
while an `AskUserQuestion` dialog is open (the dialog's own footer owns
the bottom rows), and returns on answer. The reserved-row bar exists
precisely to be the cue during that window, so freezing it on stale
content quietly degraded the one thing it is for.

Fixed with edge-triggered paints instead of a level-triggered skip:
`onset` (the first `render()` after the transition INTO live) and
`resumed` (the first `render()` after the transition back OUT) both force
a fresh write, bypassing the dedup/heartbeat check entirely. Every call in
between, while continuously live, is a pure no-op that never touches the
fd. `resumed` exists for the same reason `onset` does, not just symmetry:
the dialog may have redrawn or consumed row N while it owned the screen,
so the physical row cannot be trusted to still match `lastRendered`
either -- confirmed necessary by mutation testing (see below), not just
reasoned about.

## The second StatusBar (attach-client.ts)

`status-bar.ts` is instantiated at two production sites, not one:
`cli.ts` (the wrapper session) and `attach-client.ts` (the `remi attach`
client's own reserved-row bar, #754/#761 -- "the StatusBar itself is the
same class," per that file's own comment). The attach path had received NO
`hasLiveQuestions` at all through the earlier revisions of this PR, so
protection 1 did not exist there, and the module doc's claim was false for
that call site -- precisely the ADR 0011 failure this repo has hit before
(a description asserting protection that does not exist, which reads as
handled so nobody looks again).

Fixed rather than deferred: `attach-client.ts` already receives
`question_snapshot` (the daemon's authoritative live-question-id set,
sent unconditionally on attach via `resendPendingQuestions` and again on
every change via `onQuestionsChanged`) and was previously ignoring it. It
now tracks the set into `liveQuestionIds` and feeds `hasLiveQuestions: ()
=> liveQuestionIds.size > 0` to its own `StatusBar` -- no new protocol
surface. A `statusBarEligible` test-only override was added to
`AttachClientOptions` (mirroring the existing `outputFd` override) so
`attach-client.test.ts`, which had zero `StatusBar` coverage before this
PR, can exercise the real bar end to end without a TTY.

## Two ordering/timing bugs found in re-review, both fixed

**1. `wasQuestionLive` was consumed before a paint could happen.** It was
mutated unconditionally ahead of the fd-null and room-too-short guards. A
transition landing on a tick where a paint isn't structurally possible
(fd null, or the terminal transiently too short) got "consumed" with no
write to show for it; the next successful tick then computed
`onset`/`resumed` against the already-flipped flag -- neither true -- and
froze on stale content for the rest of the window. The exact bug
protection 1 exists to prevent, reintroduced through ordering. Fixed by
moving the fd/room checks above the point where `hasLiveQuestions()` is
read and `wasQuestionLive` is mutated, matching the pattern
`disabled`/`isEnabled()` already use: return before touching any state a
later, capable tick still needs to see as unconsumed.

**2. The attach bar's first paint could precede its first
`question_snapshot`.** `startStatusBar()` is called synchronously from the
`remi_status` handler (and, to cover a documented race, from the
`hello_ack` handler too), and `.start()` paints immediately. But the
daemon sends `question_snapshot` strictly *after* hello_ack on the same
connection (`resendPendingQuestions`), so it necessarily arrives as a
later message. `liveQuestionIds` starts empty, so that first paint could
read `hasLiveQuestions()` as `false` for a session that already has a live
question -- a one-paint exposure that was documented nowhere. Fixed by
deferring the bar's actual construction (`createStatusBar()`) until a
`question_snapshot` has been observed, bounded by a 500ms fallback timer
so an older daemon that never sends one doesn't lose the bar entirely --
only that first paint's protection-1 coverage, the same fail-open default
`hasLiveQuestions` already has elsewhere in the file.

## Multi-agent caveat (documented, not changed)

`hasLiveQuestions()` is session-wide (`currentQuestions.size > 0` across
every agent), not agent-scoped. In a concurrent multi-agent session
(Agent Teams, Task-tool subagents), the freeze can span output from an
UNRELATED agent that is still actively writing to the same shared PTY/fd
while a different agent's question sits open -- so "Claude is waiting for
input, not producing output" is not a complete guarantee, only true for
the dominant single-agent/HELD-hook case. This is documented directly on
`StatusBarDeps.hasLiveQuestions`'s JSDoc, not just here, so a future
reader of the code alone learns it. Left unbounded in code anyway: the
overlap needed for it to matter is a narrower three-way intersection than
protection 2's every-idle-stretch case, a live question is the
highest-value moment for the bar to be correct, and bounding it would
require the same `ESC7`/`ESC8` exposure protection 1 exists to avoid
during a live prompt.

## Mutation-test evidence

Every claim below was produced by neutering the specific mechanism,
confirming the relevant test(s) go red, then restoring and confirming
green -- not by reasoning alone.

**Protection 1 (suppression):** neutered `if (this.hasLiveQuestions())
return;`: 3 tests red (32 pass/3 fail). Restored: green.

**Protection 2 (dedup):** removed the `sequence === this.lastRendered`
skip: 1 test red. Restored: green.

**Heartbeat:** neutered `!heartbeatDue`: 1 test red (35 pass/1 fail).
Restored: green.

**Onset (edge-triggered rising edge):** neutered `onset` to always
`false`: 4 tests red (33 pass/4 fail). Restored: green.

**Resumed (edge-triggered falling edge):** neutered `resumed` to always
`false`: 1 test red (36 pass/1 fail) -- proves `resumed` is load-bearing,
not cosmetic symmetry. Restored: green.

**Attach-client wiring:** neutered `hasLiveQuestions: () =>
liveQuestionIds.size > 0` to a constant `false`: 1 test red (17 pass/1
fail, the mid-freeze checkpoint below catches it at `midBars.length` 2
instead of 1). Restored: green.

**fd/room guard ordering (review finding 1):** reverted to mutating
`wasQuestionLive` before the fd/room checks: 1 test red (37 pass/1 fail,
reproducing the reviewer's exact reported shape -- 0 paints instead of 1
once room returns). Restored: green.

**Deferred first paint (review finding 2):** neutered the
`receivedQuestionSnapshot` gate in `startStatusBar()`: 1 test red (17
pass/1 fail, `bars.length` 3 instead of 2 -- the collapsed onset paint
splits back into two separate paints, one of them premature). Restored:
green.

**Fallback timeout:** while fixing finding 2, the first implementation of
the 500ms fallback had its own bug -- the timeout callback recursively
called `startStatusBar()` instead of bypassing the wait, so with no
`question_snapshot` ever arriving it re-armed the same wait forever and
the bar never started. Caught by writing the dedicated fallback test
*before* trusting the implementation: reverting the fix (recursive retry
instead of `createStatusBar()`) reproduces it -- 1 test red (17 pass/1
fail, no bar escape ever appears). Restored: green.

**Mid-freeze checkpoint strengthening:** the original `bars.length`-only
assertion on the attach-client suppression test stopped being sufficient
once the deferred-first-paint fix (finding 2) started absorbing what used
to be a separate onset paint -- neutering `hasLiveQuestions` to a constant
`false` no longer went red, because the total paint count could still
coincidentally land on 2 (one plain paint at start, one plain repaint when
the status changed at t=600) even with zero real suppression. Fixed by
adding a mid-freeze read (a separate `fs.readFileSync` on the output path
at t=900, well after the status change and well before the resolve) that
asserts exactly one paint and the pre-change content -- this is what
actually distinguishes "suppression is holding" from "the final count
happened to match." Verified both directions: neutered `hasLiveQuestions`
red (17 pass/1 fail, `midBars.length` 2 instead of 1), restored green.

## Test plan

- [x] `bunx biome check .` -- clean on all touched files (48 pre-existing
      warnings elsewhere, unrelated to this change)
- [x] `bun run typecheck` -- clean
- [x] `bun test packages/daemon/tests/cli/` -- 1031 pass, 0 fail
- [x] `packages/daemon/tests/cli/status-bar.test.ts` -- suppression,
      resume, onset/resumed edge-triggered paints, unchanged/changed
      dedup, heartbeat, the fd/room-guard-ordering regression test, all
      existing fail-safe tests unmodified
- [x] `packages/daemon/tests/cli/attach-client.test.ts` -- a positive
      control, the full end-to-end onset/freeze/resume proof (with a
      mid-freeze checkpoint) over the real ~250ms timer cadence, and the
      fallback-timeout test -- all real WS server, real fs writes, no
      mocks, verified stable across repeated runs

Part of #932 -- protections 3 and 4 from that issue are intentionally out
of scope for this PR and remain open, as does the quiescence + clean-
boundary gate described above under "corrected mechanism for mode 1."
