### PR TITLE
Refuse injection for stale pty-sourced card answers (#920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,28 +112,36 @@ All notable changes to Remi are documented here.
   (ADR 0004) is unchanged — only bookkeeping moved, never a push/arbitration
   decision.
 
-- **Answering a card whose on-screen prompt is gone no longer injects into
-  the live PTY** (#920). `#888`'s own reclassification found the residual
-  leak this issue tracks was never a memory problem: a `source: 'pty'` card
-  can sit in the store, still "active," long after its prompt scrolled off
-  screen, and the ONLY gate on the answer path was whether the question was
-  still registered — never whether its prompt was still on screen. Answering
-  one submitted the resolved option value (or free text verbatim) into
-  whatever Claude was doing at that moment; this reproduced live twice in one
-  working session (two bare `1`s landing as apparent user input, minutes
-  apart, with no prompt pending). Had either landed while a real numbered
-  prompt was up, it would have silently selected option 1 on a question the
-  user never saw. `input-events.ts`'s answer handler now calls
-  `QuestionPresenceTracker.isPromptCurrent` — the same gate
-  `AutoApproveGate.answerRenderedParked` already uses immediately before its
-  own PTY write — right before the injection, scoped to `source: 'pty'` cards
-  only (a hook-paired question's merged id/text are the hook's, never the raw
-  PTY parse, so a blanket check would misfire on that cohort). A refused
-  answer clears the stale card (`question_resolved` fires so every client's
-  view updates) and returns the existing `STALE_ANSWER` error the client
-  already handles, rather than failing silently. No tracker wired for a
-  session fails toward refusing, not injecting. Free-form PTY input (#795)
-  and held-hook answers (never PTY-submitted) are untouched.
+- **Answering a `source: 'pty'` card whose on-screen prompt is gone no
+  longer injects into the live PTY** (#920). `#888`'s own reclassification
+  found the residual leak this issue tracks was never a memory problem: a
+  `source: 'pty'` card can sit in the store, still "active," long after its
+  prompt scrolled off screen, and the ONLY gate on the answer path was
+  whether the question was still registered — never whether its prompt was
+  still on screen. Answering one submitted the resolved option value (or
+  free text verbatim) into whatever Claude was doing at that moment; this
+  reproduced live twice in one working session (two bare `1`s landing as
+  apparent user input, minutes apart, with no prompt pending). Had either
+  landed while a real numbered prompt was up, it would have silently
+  selected option 1 on a question the user never saw. `input-events.ts`'s
+  answer handler now calls `QuestionPresenceTracker.isPromptCurrent` — the
+  same gate `AutoApproveGate.answerRenderedParked` already uses immediately
+  before its own PTY write — right before the injection, scoped to
+  `source: 'pty'` cards only (a hook-paired question's merged id/text are
+  the hook's, never the raw PTY parse, so a blanket check would misfire on
+  that cohort). A refused answer clears the stale card (`question_resolved`
+  fires so every client's view updates) and returns the existing
+  `STALE_ANSWER` error the client already handles, rather than failing
+  silently. No tracker wired for a session fails toward refusing, not
+  injecting. Free-form PTY input (#795) and held-hook answers (never
+  PTY-submitted) are untouched. **Does not cover `source: 'elicitation'`
+  cards**, which take the same unguarded `submitInput` path with
+  `allowsFreeText: true` — an arbitrary-free-text variant of this same
+  hazard, worse than a stray digit. `isPromptCurrent` cannot be widened to
+  catch it: elicitation ids/text are hook-minted and never observed by the
+  PTY tracker, so the check would report "not current" for every
+  elicitation card and refuse them all. Needs a different mechanism; filed
+  separately as #940.
 
 - **A question is now identified by one id for its whole prompt cycle**
   (#887). Up to three ids used to exist for a single subagent permission: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,29 @@ All notable changes to Remi are documented here.
   (ADR 0004) is unchanged — only bookkeeping moved, never a push/arbitration
   decision.
 
+- **Answering a card whose on-screen prompt is gone no longer injects into
+  the live PTY** (#920). `#888`'s own reclassification found the residual
+  leak this issue tracks was never a memory problem: a `source: 'pty'` card
+  can sit in the store, still "active," long after its prompt scrolled off
+  screen, and the ONLY gate on the answer path was whether the question was
+  still registered — never whether its prompt was still on screen. Answering
+  one submitted the resolved option value (or free text verbatim) into
+  whatever Claude was doing at that moment; this reproduced live twice in one
+  working session (two bare `1`s landing as apparent user input, minutes
+  apart, with no prompt pending). Had either landed while a real numbered
+  prompt was up, it would have silently selected option 1 on a question the
+  user never saw. `input-events.ts`'s answer handler now calls
+  `QuestionPresenceTracker.isPromptCurrent` — the same gate
+  `AutoApproveGate.answerRenderedParked` already uses immediately before its
+  own PTY write — right before the injection, scoped to `source: 'pty'` cards
+  only (a hook-paired question's merged id/text are the hook's, never the raw
+  PTY parse, so a blanket check would misfire on that cohort). A refused
+  answer clears the stale card (`question_resolved` fires so every client's
+  view updates) and returns the existing `STALE_ANSWER` error the client
+  already handles, rather than failing silently. No tracker wired for a
+  session fails toward refusing, not injecting. Free-form PTY input (#795)
+  and held-hook answers (never PTY-submitted) are untouched.
+
 - **A question is now identified by one id for its whole prompt cycle**
   (#887). Up to three ids used to exist for a single subagent permission: the
   hook bridge minted one at `PermissionRequest`, the PTY parser minted a

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1012,6 +1012,14 @@ const binderClosers: Map<UUID, () => void> = new Map();
 // (multi-session daemons). Populated in createNewSession after setupHookBridge;
 // removed on session close. Empty when no hookServer is configured.
 const sessionGateHandles: Map<UUID, SessionGateHandle> = new Map();
+// Per-session QuestionPresenceTracker (#920): the answer handler needs
+// `isPromptCurrent` to refuse a PTY submit for a `source: 'pty'` card whose
+// on-screen prompt is already gone (input-events.ts's prompt-currency
+// guard). Unlike `sessionGateHandles`, a tracker is constructed for EVERY
+// session in `createNewSession` regardless of whether a hook server is
+// active, so this map is populated unconditionally there; removed on
+// session close, same lifecycle as the other per-session maps below.
+const sessionTrackers: Map<UUID, QuestionPresenceTracker> = new Map();
 /**
  * Per-session "does this binder claim the event?" filters (#914).
  *
@@ -1105,6 +1113,10 @@ const sessionRegistry = new SessionRegistry(
       // Drop the per-session gate handle (#573); any held hook was already
       // released by the gate's closeBinder/cancelStale on teardown.
       sessionGateHandles.delete(sessionId);
+      // Drop the per-session QuestionPresenceTracker (#920): a stale entry
+      // here would make `isPromptCurrent` resolve against a dead session's
+      // last-observed PTY state instead of falling back to "no tracker".
+      sessionTrackers.delete(sessionId);
       // #914: drop the admits filter with the session, so a closed session's
       // binder can never keep admitting turns on its behalf.
       sessionAdmitsHandles.delete(sessionId);
@@ -1551,6 +1563,9 @@ async function createNewSession(
     isQuestionLive: (questionId) =>
       sessionRegistry.getQuestion(sessionId, questionId as UUID) !== null,
   });
+  // #920: register this session's tracker so the answer handler's
+  // prompt-currency guard (input-events.ts) can reach it by sessionId.
+  sessionTrackers.set(sessionId, tracker);
 
   const outputProcessor = new OutputProcessor(
     { sessionId, streamStatusOnly: true },
@@ -1865,6 +1880,13 @@ const inputHandlers: InputHandlers = createInputHandlers({
   // every other client.
   onQuestionResolved: (sessionId, questionId) =>
     onQuestionResolved(sessionId, questionId, 'answered'),
+  // #920: prompt-currency guard for a `source: 'pty'` card-answer, backed by
+  // the RIGHT session's tracker (populated per session in createNewSession,
+  // same map-per-sessionId shape as sessionGateHandles above). No tracker for
+  // this sessionId (session already closed, or never wired one) => "not
+  // current" — fail toward refusing the injection.
+  isPromptCurrent: (sessionId, questionId, ptyText) =>
+    sessionTrackers.get(sessionId)?.isPromptCurrent(questionId, ptyText) ?? false,
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -70,6 +70,21 @@ export interface InputHandlerDeps {
    * break answer handling. Absent => no dismissal broadcast (tests/old callers).
    */
   onQuestionResolved?: (sessionId: UUID, questionId: UUID) => void;
+  /**
+   * Prompt-currency check for a resolved card-answer PTY submit (#920).
+   * Backed by the session's `QuestionPresenceTracker.isPromptCurrent` — the
+   * same gate `AutoApproveGate.answerRenderedParked` uses immediately before
+   * its own PTY write (auto-approve-gate.ts:1830) — so answering a card whose
+   * on-screen prompt is gone is refused instead of typing into whatever
+   * Claude is doing now. Consulted ONLY for `Question.source === 'pty'`
+   * cards (the genuinely hook-less cohort #920 traced the leak to); every
+   * other source is left alone, see the call site's comment for why a
+   * blanket check would misfire on hook-paired questions. Absent (no
+   * tracker wired for this session) is treated as "not current" — fail
+   * toward refusing, matching `isQuestionLive`'s own default in
+   * question-presence-tracker.ts.
+   */
+  isPromptCurrent?: (sessionId: UUID, questionId: UUID, ptyText: string) => boolean;
 }
 
 /**
@@ -224,6 +239,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     releaseHeldAsPassthrough,
     cancelAutoApproveForQuestion,
     onQuestionResolved,
+    isPromptCurrent,
   } = deps;
 
   // #627: in-flight AskUserQuestion runs, keyed `${sessionId}:${questionId}`, so a
@@ -548,6 +564,10 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     // and the throw still propagates (relay -> HTTP 500, WS -> caller-logged).
     const decision = mapAnswerToDecision(active.options, answer);
     let hadHold = false;
+    // Overridden below only on the #920 prompt-currency refusal, so the
+    // `finally` block's removal carries an honest signal instead of the
+    // default 'user_answer' (this card was never actually answered).
+    let removalReason = 'user_answer';
     try {
       if (decision !== null) {
         hadHold =
@@ -579,6 +599,69 @@ export function createInputHandlers(deps: InputHandlerDeps) {
             `[Answer] "${answer}" matched no option (${active.options.length}); submitting verbatim`,
           );
         }
+
+        // #920 prompt-currency guard, checked as late as possible (the same
+        // idiom `AutoApproveGate.answerRenderedParked` uses immediately before
+        // its own PTY write, auto-approve-gate.ts) — nothing else runs between
+        // this check and the injection below. The active-question lookup
+        // above only proves the CARD is still registered; a `source: 'pty'`
+        // question has no hook and so no other staleness signal (#920's own
+        // diagnosis), meaning a card can sit in the store, still "active",
+        // long after its prompt scrolled off screen. Answering it would type
+        // the resolved option value (or free text verbatim, per the review
+        // comment on #920) into whatever Claude is doing right now.
+        //
+        // Scoped to `source === 'pty'` ONLY, not every card: a hook-paired
+        // question's merged `id`/`text` are the HOOK's (tool + command text),
+        // never the raw PTY parse (`consumeAndMerge` in
+        // question-presence-tracker.ts), so `isPromptCurrent`'s id/text match
+        // would almost never succeed for that cohort — a blanket check here
+        // would refuse legitimate hook-sourced answers, not just stale PTY
+        // ones. Free-form `user_input` (#795) is a completely different
+        // handler and never reaches this branch at all.
+        //
+        // Absent `isPromptCurrent` (no tracker wired for this session) is
+        // treated as NOT current — fail toward refusing the injection, not
+        // toward it, mirroring `isQuestionLive`'s own default in
+        // question-presence-tracker.ts: a refused legitimate answer costs the
+        // user a re-answer with the question still visible; an accepted stale
+        // one injects into a live session with nothing to undo it. Those
+        // costs are not symmetric, so ambiguity resolves toward not
+        // injecting.
+        if (
+          active.source === 'pty' &&
+          !(isPromptCurrent?.(session.sessionId, questionId, active.text) ?? false)
+        ) {
+          log(
+            `[Answer] refusing PTY submit for ${questionId.slice(0, 8)}: prompt no longer on screen (source=pty)`,
+          );
+          traceQuestionEvent({
+            action: 'stale_answer',
+            sessionId: session.sessionId,
+            questionId,
+            promptId: active.promptId,
+            signal: 'STALE_ANSWER',
+            callSite: 'input-events.handleAnswer:promptCurrencyGuard',
+            detail: { reason: 'prompt-not-current', source: active.source },
+          });
+          removalReason = 'user_answer:stale_prompt';
+          if (!viaRelay) {
+            send(
+              connectionId,
+              createError(
+                'STALE_ANSWER',
+                'The prompt for this question is no longer on screen; refusing to submit',
+                {
+                  sessionId,
+                  questionId,
+                  pendingQuestionIds: [...session.currentQuestions.keys()],
+                },
+              ),
+            );
+          }
+          return 'stale';
+        }
+
         await session.pty.submitInput(ptyInput);
       } else {
         log(
@@ -611,8 +694,11 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       cancelAutoApproveForQuestion?.(session.sessionId, questionId, 'user-answered');
     } finally {
       // Remove only the answered question; sibling prompts remain answerable.
-      // In `finally` so a throwing submit cannot leave a zombie question.
-      sessionRegistry.removeQuestion(session.sessionId, questionId, 'user_answer');
+      // In `finally` so a throwing submit cannot leave a zombie question, AND
+      // so the #920 prompt-currency refusal above (which `return`s from
+      // inside this `try`) still clears the stale card — `removalReason`
+      // carries the honest signal for that path.
+      sessionRegistry.removeQuestion(session.sessionId, questionId, removalReason);
       // Cross-client dismissal (#585, P7): tell every client this question is
       // resolved so its card clears and the lock-screen push is dismissed.
       // Throw-safe: a broadcast/push failure must never break answer handling,

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -315,6 +315,193 @@ describe('createInputHandlers', () => {
       expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
     });
 
+    describe('prompt-currency guard (#920)', () => {
+      function addPtySourcedQuestion(sessionId: UUID): void {
+        sessionRegistry.addQuestion(sessionId, {
+          id: QID,
+          text: 'Proceed? (y/n)',
+          options: [
+            { value: 'y', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+            { value: 'n', label: 'No', isRecommended: false, isYes: false, isNo: true },
+          ],
+          allowsFreeText: false,
+          isAnswered: false,
+          source: 'pty',
+        });
+      }
+
+      // A stale `source: 'pty'` card (#920: the residual leak cohort -- no
+      // hook, so the active-question lookup alone cannot tell a live prompt
+      // from one that scrolled off screen minutes ago) must NOT reach the
+      // PTY, must clear itself, and must tell the client why.
+      test('refuses the PTY submit and clears the card when the prompt is gone', async () => {
+        const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+        const sessionId = sessionRegistry.createSessionId();
+        sessionRegistry.registerSession(
+          sessionId,
+          '/test/dir',
+          fakePTY(ptyCapture),
+          fakeMessageAPI(new Map()),
+        );
+        addPtySourcedQuestion(sessionId);
+
+        const resolvedCalls: Array<{ sessionId: UUID; questionId: UUID }> = [];
+        const handlers = createInputHandlers({
+          sessionRegistry,
+          bindingStore,
+          send,
+          isPromptCurrent: () => false, // the on-screen prompt is gone
+          onQuestionResolved: (s, q) => resolvedCalls.push({ sessionId: s, questionId: q }),
+        });
+
+        await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+        expect(ptyCapture.submits).toEqual([]);
+        expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+        const errors = sendCalls.filter((c) => c.message.type === 'error');
+        expect(errors).toHaveLength(1);
+        expect((errors[0]?.message as unknown as { code: string }).code).toBe('STALE_ANSWER');
+        // The card must clear on every client (#585), not just refuse locally.
+        expect(resolvedCalls).toEqual([{ sessionId, questionId: QID }]);
+      });
+
+      // The regression test that matters: a `source: 'pty'` card whose prompt
+      // IS still on screen must submit exactly as before the guard existed.
+      test('still submits normally when the prompt IS current', async () => {
+        const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+        const sessionId = sessionRegistry.createSessionId();
+        sessionRegistry.registerSession(
+          sessionId,
+          '/test/dir',
+          fakePTY(ptyCapture),
+          fakeMessageAPI(new Map()),
+        );
+        addPtySourcedQuestion(sessionId);
+
+        const checked: Array<{ sessionId: UUID; questionId: UUID; ptyText: string }> = [];
+        const handlers = createInputHandlers({
+          sessionRegistry,
+          bindingStore,
+          send,
+          isPromptCurrent: (s, q, ptyText) => {
+            checked.push({ sessionId: s, questionId: q, ptyText });
+            return true;
+          },
+        });
+
+        await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+        expect(ptyCapture.submits).toEqual(['y']);
+        expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+        expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+        expect(checked).toEqual([{ sessionId, questionId: QID, ptyText: 'Proceed? (y/n)' }]);
+      });
+
+      // A hook-paired question's merged id/text are the HOOK's, never the raw
+      // PTY parse (question-presence-tracker.ts consumeAndMerge), so a blanket
+      // currency check would misfire on this cohort. The guard is scoped to
+      // `source === 'pty'` ONLY; proven with a spy that throws if consulted.
+      test('a non-pty-sourced card is never checked', async () => {
+        const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+        const sessionId = sessionRegistry.createSessionId();
+        sessionRegistry.registerSession(
+          sessionId,
+          '/test/dir',
+          fakePTY(ptyCapture),
+          fakeMessageAPI(new Map()),
+        );
+        sessionRegistry.addQuestion(sessionId, {
+          id: QID,
+          text: 'Allow Bash: git push',
+          options: [
+            { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+            { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+          ],
+          allowsFreeText: false,
+          isAnswered: false,
+          source: 'permission_request',
+        });
+
+        const handlers = createInputHandlers({
+          sessionRegistry,
+          bindingStore,
+          send,
+          isPromptCurrent: () => {
+            throw new Error('isPromptCurrent must not be called for a non-pty source');
+          },
+        });
+
+        await handlers.onAnswer(CID, sessionId, QID, '1');
+
+        expect(ptyCapture.submits).toEqual(['1']);
+        expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+      });
+
+      // Held-hook answers resolve via the hook response and never PTY-submit
+      // (the `hadHold` branch) -- the guard lives only on the `!hadHold`
+      // PTY-submit branch, so it must never be consulted here, even for a
+      // pty-sourced question with an (unusual but not impossible) hold.
+      test('a held-hook answer is unaffected, even for a pty-sourced question', async () => {
+        const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+        const sessionId = sessionRegistry.createSessionId();
+        sessionRegistry.registerSession(
+          sessionId,
+          '/test/dir',
+          fakePTY(ptyCapture),
+          fakeMessageAPI(new Map()),
+        );
+        addPtySourcedQuestion(sessionId);
+
+        const handlers = createInputHandlers({
+          sessionRegistry,
+          bindingStore,
+          send,
+          resolveHeldPermission: () => true, // a hold existed and was resolved
+          isPromptCurrent: () => {
+            throw new Error('isPromptCurrent must not be called on the held-hook branch');
+          },
+        });
+
+        await handlers.onAnswer(CID, sessionId, QID, 'y');
+
+        expect(ptyCapture.submits).toEqual([]); // held -> no PTY submit
+        expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+        expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+      });
+
+      // #795: free-form PTY submission (raw keystrokes and structured input)
+      // is a deliberate feature -- any attached client can type into the
+      // session. The guard lives ONLY inside handleAnswer's card-submit
+      // branch, never on onUserInput; proven with a spy that throws if
+      // consulted.
+      test('free-form user_input (raw and structured) is unaffected', async () => {
+        const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+        const sessionId = sessionRegistry.createSessionId();
+        sessionRegistry.registerSession(
+          sessionId,
+          '/test/dir',
+          fakePTY(ptyCapture),
+          fakeMessageAPI(new Map()),
+        );
+        sessionRegistry.attachConnection(sessionId, CID);
+
+        const handlers = createInputHandlers({
+          sessionRegistry,
+          bindingStore,
+          send,
+          isPromptCurrent: () => {
+            throw new Error('isPromptCurrent must not be called for free-form user_input');
+          },
+        });
+
+        await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
+        await handlers.onUserInput(CID, sessionId, 'hello world', false);
+
+        expect(ptyCapture.writes).toEqual(['\x1b[A']);
+        expect(ptyCapture.submits).toEqual(['hello world']);
+      });
+    });
+
     // #627: cancel/escape sends Esc to the PTY and clears the question — the
     // universal unstick, regardless of whether the prompt was understood.
     test('cancel sends Esc to the PTY and clears the question', async () => {


### PR DESCRIPTION
## Summary

- **Scope: `source: 'pty'` cards only.** Answering a `source: 'pty'` card
  whose on-screen prompt is gone used to submit the resolved option value
  (or free text verbatim) straight into the live PTY. The only gate on that
  path was whether the question was still registered in the store, never
  whether its prompt was still on screen. This reproduced live twice in one
  working session (two bare `1`s landing as apparent user input, minutes
  apart, with no prompt pending) — had either landed while a real numbered
  prompt was up, it would have silently selected option 1 on a question the
  user never saw.
- `input-events.ts`'s answer handler now calls
  `QuestionPresenceTracker.isPromptCurrent` — the same gate
  `AutoApproveGate.answerRenderedParked` already uses immediately before its
  own PTY write — right before the injection. Scoped to `Question.source ===
  'pty'` cards only: a hook-paired question's merged `id`/`text` are the
  hook's, never the raw PTY parse, so a blanket check would misfire on that
  cohort and refuse legitimate hook-sourced answers.
- On refusal: the stale card is removed (`question_resolved` fires so every
  connected client's view updates) and the client gets the existing
  `STALE_ANSWER` error it already handles, instead of failing silently. No
  tracker wired for a session fails toward refusing the injection, not toward
  it.
- Free-form `user_input` (#795, raw and structured) and held-hook answers
  (which resolve via the hook response and never PTY-submit) are untouched —
  the guard lives only on the resolved-card-answer PTY-submit branch.

**Not covered by this PR, filed as #940:** `source: 'elicitation'` cards take
the same unguarded `submitInput` path and, with `allowsFreeText: true`, submit
arbitrary free text verbatim — worse than a stray digit. This guard cannot be
widened to catch it: elicitation ids/text are hook-minted and never observed
by the PTY tracker, so `isPromptCurrent` would report "not current" for every
elicitation card and refuse them all. That cohort needs a different
mechanism.

## Wiring

`QuestionPresenceTracker` is constructed once per session in
`createNewSession` (`cli.ts`) but was not previously reachable from
`input-events.ts`. Added a `sessionTrackers` map, populated/torn down with
the same lifecycle as the existing `sessionGateHandles` map, and threaded
`isPromptCurrent` through `InputHandlerDeps`.

## Investigation

Checked `~/.remi/question-trace.jsonl` for a correlation with the two stray
`1` submissions the issue mentions. The trace schema does not record the
answer payload or `Question.source` on removal events, so it cannot settle
which specific removal corresponds to those two events; the file is also
heavily interleaved with synthetic test-fixture data since this shell has
`REMI_QUESTION_TRACE=1` set (`bun test` runs append real entries). The
causal link stays attributed, not traced, consistent with what the issue
already states.

## Test plan

- [x] `bunx biome check` (foreground, clean — 48 pre-existing warnings in
      unrelated files, none in changed files)
- [x] `bun run typecheck` (foreground, clean)
- [x] `bun test packages/daemon/tests/cli/ packages/daemon/tests/api/`
      (foreground, 1166 pass / 0 fail)
- [x] New tests (`describe('prompt-currency guard (#920)')`): stale
      `source:'pty'` card refuses submit + clears + errors; current
      `source:'pty'` card still submits (the regression test that matters);
      a non-pty source is never checked; a held-hook answer is never
      checked; free-form `user_input` (raw + structured) is untouched.
      Verified by command: `origin/develop`'s baseline for this file is 62
      tests (`git show origin/develop:...input-events.test.ts | grep -c
      '^\s*test('`); running with `-t "prompt-currency guard"` isolates the
      5 new ones (`62 filtered out`, `5 pass`). 62 + 5 = 67 total, matching
      the full-file run.
- [x] Mutation check: neutered the guard condition
      (`false && active.source === 'pty' && ...`) and ran just the new
      block. Both failures are for the right reason, but not the same
      reason: the stale-card test fails because `submitInput` is now
      called with `'y'` on a card that should have been refused (the exact
      injection this PR prevents); the "still current" regression test
      fails differently — with the condition short-circuited,
      `isPromptCurrent` is never invoked at all, so its `checked` spy array
      comes back empty instead of holding one entry. That second failure
      mode is the stronger result: it shows the regression test is
      load-bearing (it actually exercises `isPromptCurrent`), not vacuous.
      Restored the guard, confirmed all 67 tests in the file green again.

Closes #920