### PR TITLE
Durable fix for #932: quiescence + clean-boundary gate

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -166,6 +166,7 @@ import type { LiveSessionsCollectResult } from './cli/live-sessions-watcher.ts';
 import { startLiveSessionsWatcher } from './cli/live-sessions-watcher.ts';
 import { endLogFileSession, startLogFileSession, writeToLog } from './cli/log-file.ts';
 import { installProcessGuards } from './cli/process-guards.ts';
+import { PtyQuiescenceGate } from './cli/pty-quiescence-gate.ts';
 import { setupHookBridge } from './cli/session-phases/hook-bridge-setup.ts';
 import type { SessionGateHandle } from './cli/session-phases/hook-bridge-setup.ts';
 import { createMessageApiForSession } from './cli/session-phases/message-api-setup.ts';
@@ -1440,6 +1441,17 @@ function collectLiveSessionsUpdate(): LiveSessionsCollectResult | null {
 // can clear the row on shutdown.
 let statusBar: StatusBar | null = null;
 
+// #932 durable fix: the quiescence + clean-boundary gate for the wrapper's
+// own local terminal fd -- the same fd `statusBar` draws into. Module-level
+// (like `statusBar`) so `createNewSession`'s `observeLocalPtyOutput` wiring
+// (constructed once, before the bar itself exists) and the bar's own
+// `isBoundaryClean`/`isQuiescent` deps (wired after, in the wrapper block
+// below) share one instance regardless of call order. Harmless to construct
+// unconditionally in daemon mode too: it is only ever fed via
+// `observeLocalPtyOutput`, which `pty-session-setup.ts`'s `onRawData` only
+// invokes when `passThrough` is true -- daemon-mode sessions never feed it.
+const wrapperPtyGate = new PtyQuiescenceGate();
+
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
 ): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
@@ -1683,6 +1695,14 @@ async function createNewSession(
       onQuestionResolved: (sid, questionId) => onQuestionResolved(sid, questionId, 'answered'),
       cancelAutoApproveForQuestion: (sid, questionId, reason) =>
         sessionGateHandles.get(sid)?.cancelEvalForQuestion(questionId, reason),
+      // #932 durable fix: feed the wrapper's quiescence + clean-boundary
+      // gate with every chunk actually forwarded to the local terminal, and
+      // -- when the chunk completes a bare ESC[r (DECSTBM full-screen
+      // reset) -- ask the bar to repaint immediately instead of leaving row
+      // N unprotected until the next tick or the heartbeat.
+      observeLocalPtyOutput: (data) => {
+        if (wrapperPtyGate.observe(data)) statusBar?.notifyScrollRegionReset();
+      },
     },
     { sessionId, workingDirectory, extraArgs: binding.args, passThrough, reservedRows },
   );
@@ -2763,6 +2783,12 @@ if (cliDaemonMode) {
       isEnabled: () => !isWrapperDetached(),
       hasLiveQuestions: () =>
         (sessionRegistry.getSession(sessionId)?.currentQuestions.size ?? 0) > 0,
+      // #932 durable fix: gate every paint on the same PTY-forwarding gate
+      // `observeLocalPtyOutput` (above) feeds. `wrapperPtyGate` is
+      // module-level so it exists before this StatusBar does and keeps
+      // accumulating state across a detach/reattach within one process.
+      isBoundaryClean: () => wrapperPtyGate.isBoundaryClean(),
+      isQuiescent: () => wrapperPtyGate.isQuiescent(),
       log: (m) => log(m),
     });
     statusBar.start();

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -22,6 +22,7 @@ import type {
 import { performAuthHandshake } from './auth-helper.ts';
 import { capabilityWsOptions } from './capability-client.ts';
 import { DetachScanner } from './detach-scanner.ts';
+import { PtyQuiescenceGate } from './pty-quiescence-gate.ts';
 import { StatusBar, childRows } from './status-bar.ts';
 
 export interface AttachClientOptions {
@@ -82,6 +83,13 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
   // session that already has a live question -- see that function's doc.
   let receivedQuestionSnapshot = false;
   let questionSnapshotTimer: ReturnType<typeof setTimeout> | null = null;
+  // #932 durable fix: this attach cycle's own quiescence + clean-boundary
+  // gate for `outputFd` -- the same fd `statusBar` draws into. Scoped to
+  // this call (not module-level, unlike the wrapper's `wrapperPtyGate` in
+  // cli.ts) because a fresh `runAttachClient()` call is a fresh terminal
+  // parser state: nothing has been written to `outputFd` yet, so a new gate
+  // starting from "ground, never observed" is exactly right.
+  const ptyGate = new PtyQuiescenceGate();
 
   function writeOutput(text: string): void {
     if (outputBroken) return;
@@ -171,6 +179,13 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
     if (outputBroken) return;
     try {
       const buf = Buffer.from(base64Data, 'base64');
+      // #932 durable fix: feed the quiescence + clean-boundary gate with the
+      // exact bytes about to hit outputFd, BEFORE the write -- same
+      // ordering rationale as the wrapper's `observeLocalPtyOutput`
+      // (pty-session-setup.ts). When this chunk completes a bare ESC[r
+      // (DECSTBM full-screen reset), ask the bar to repaint immediately
+      // instead of leaving row N unprotected until the next tick.
+      if (ptyGate.observe(buf)) statusBar?.notifyScrollRegionReset();
       fs.writeSync(outputFd, buf);
     } catch (err) {
       outputBroken = true;
@@ -226,6 +241,9 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       }),
       isEnabled: () => latestStatus !== null,
       hasLiveQuestions: () => liveQuestionIds.size > 0,
+      // #932 durable fix: gate every paint on the same `ptyGate` `writeRawBytes` feeds.
+      isBoundaryClean: () => ptyGate.isBoundaryClean(),
+      isQuiescent: () => ptyGate.isQuiescent(),
       log: (msg) => process.stderr.write(`${msg}\n`),
     });
     statusBar.start();

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -177,15 +177,8 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
 
   function writeRawBytes(base64Data: string): void {
     if (outputBroken) return;
+    const buf = Buffer.from(base64Data, 'base64');
     try {
-      const buf = Buffer.from(base64Data, 'base64');
-      // #932 durable fix: feed the quiescence + clean-boundary gate with the
-      // exact bytes about to hit outputFd, BEFORE the write -- same
-      // ordering rationale as the wrapper's `observeLocalPtyOutput`
-      // (pty-session-setup.ts). When this chunk completes a bare ESC[r
-      // (DECSTBM full-screen reset), ask the bar to repaint immediately
-      // instead of leaving row N unprotected until the next tick.
-      if (ptyGate.observe(buf)) statusBar?.notifyScrollRegionReset();
       fs.writeSync(outputFd, buf);
     } catch (err) {
       outputBroken = true;
@@ -193,7 +186,19 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
       if (code !== 'EBADF' && code !== 'EPIPE') {
         process.stderr.write(`[remi] output write failed: ${code ?? err}\n`);
       }
+      return;
     }
+    // #932 durable fix (review finding 2): feed the quiescence +
+    // clean-boundary gate AFTER the real chunk has landed on the wire,
+    // never before -- and outside the write's own try/catch, so a throw
+    // from this callback (e.g. StatusBar's isBoundaryClean/isQuiescent/
+    // hasLiveQuestions predicates) is never misclassified as a write
+    // failure. Same ordering rationale as the wrapper's
+    // `observeLocalPtyOutput` (pty-session-setup.ts): observing before the
+    // write would put the bar's corrective DECSTBM-reasserting paint on
+    // the wire BEFORE the very ESC[r that triggered it, so the reset would
+    // immediately undo the correction instead of the other way around.
+    if (ptyGate.observe(buf)) statusBar?.notifyScrollRegionReset();
   }
 
   /**

--- a/packages/daemon/src/cli/pty-quiescence-gate.ts
+++ b/packages/daemon/src/cli/pty-quiescence-gate.ts
@@ -1,0 +1,195 @@
+/**
+ * PTY output quiescence + clean-boundary gate (#932 durable fix).
+ *
+ * remi's reserved-row status bar (`status-bar.ts`) and Claude's own PTY
+ * output are two writers on the same terminal fd. Both are synchronous
+ * `fs.writeSync` calls on the same thread, so byte-level interleaving
+ * WITHIN one write is impossible -- the actual hazard (see #932's
+ * corrected mechanism, recorded in status-bar.ts's module doc) is a bar
+ * paint landing BETWEEN two of Claude's own PTY-forwarding chunks, at a
+ * boundary that happens to split one of Claude's escape sequences. The
+ * terminal then parses the bar's bytes as the continuation of Claude's
+ * half-delivered sequence, garbling both ("mode 1").
+ *
+ * This module tracks, over the stream of chunks actually forwarded to one
+ * terminal fd, the two things a caller needs in order to decide whether a
+ * write right now is safe:
+ *
+ *   1. `isBoundaryClean()` -- HARD requirement. False while the last fed
+ *      chunk left the stream inside an unterminated ESC / CSI / OSC (etc.)
+ *      sequence. A write must NEVER happen while this is false -- that is
+ *      the structural fix for mode 1: a paint can no longer land at a
+ *      dirty boundary, full stop.
+ *   2. `isQuiescent()` -- SOFT requirement. False until at least
+ *      `QUIESCENCE_MS` has passed since the last fed chunk. This reduces
+ *      but does not eliminate "mode 2": a paint landing inside a Claude
+ *      ESC7...ESC8 save/restore pair that spans a quiet gap between
+ *      chunks -- closing that fully would require a full VT state model
+ *      of the child (a mini-multiplexer for one status row), which is
+ *      disproportionate; it is an accepted residual (see #932's
+ *      discussion). `QUIESCENCE_MS` is measured from a real capture, not
+ *      guessed -- see the constant's own doc.
+ *
+ * Deliberately NOT a VT emulator: no cursor position, no character
+ * rendition, no semantic state of any kind is tracked -- only "am I
+ * currently inside one of Claude's own escape sequences," the one
+ * question a caller needs answered before writing to the shared fd.
+ *
+ * Bonus signal: `observe()` also reports when a chunk completes a BARE
+ * `ESC[r` (DECSTBM full-screen scroll-region reset, confirmed present in
+ * the 2.1.220 `claude` binary) so a caller can force an immediate repaint
+ * rather than leaving row `N` unprotected until the next scheduled tick --
+ * see `StatusBar.notifyScrollRegionReset`.
+ */
+
+/** Scanner state machine positions. */
+type ScanState =
+  | 'ground'
+  | 'escape' // saw ESC (0x1b); haven't seen the next byte yet
+  | 'csi' // ESC [ ... collecting params/intermediates, awaiting a final byte (0x40-0x7E)
+  | 'string' // ESC ] | ESC P | ESC X | ESC ^ | ESC _ ... (OSC/DCS/SOS/PM/APC), awaiting ST or BEL
+  | 'string-esc'; // inside a 'string' sequence, just saw ESC -- checking for the ST-closing '\'
+
+/**
+ * #932: PTY output quiescence window, in ms. Measured from a real capture
+ * of the `claude` 2.1.220 binary's own PTY chunk timing, via Bun's native
+ * `Bun.spawn({ terminal })` API -- the exact mechanism `PTYSession` uses in
+ * production (packages/daemon/src/pty/pty-session.ts) -- across six real
+ * conversational turns (plain-text replies and tool-use turns: Read an
+ * existing file, Edit it, list a directory). 372 inter-chunk gaps were
+ * recorded; 364 landed inside an actively-streaming turn, the other 8 were
+ * the idle gap between turns (waiting on the next API round-trip). The two
+ * populations separated cleanly, with a ~10x gap between them:
+ *   - active-burst gaps: p50 84.9ms, p90 122.4ms, p99 239.5ms, MAX 416.55ms
+ *   - idle (between-turn) gaps: MIN 4099ms
+ * 500ms sits ~20% above the highest active-burst gap actually observed (so
+ * a routine, non-edge paint essentially never fires mid-burst -- the
+ * intended effect), and more than 8x below the lowest idle gap observed
+ * (so once Claude genuinely goes idle, quiescence is satisfied almost
+ * immediately -- well inside status-bar.ts's HEARTBEAT_MS, which still
+ * bounds the worst case regardless of this gate; see
+ * StatusBar.render()'s doc for how the two interact). Full capture
+ * methodology, raw histogram, and sample counts are recorded in the #932
+ * PR body so the choice is auditable.
+ */
+export const QUIESCENCE_MS = 500;
+
+/** Sequence-introducer bytes that start a "string" sequence (terminated by
+ *  ST or BEL rather than a single CSI final byte): OSC (]), DCS (P), SOS
+ *  (X), PM (^), APC (_). Treating all five identically is conservative for
+ *  a boundary detector -- worst case it treats a chunk as "still open" a
+ *  little longer than strictly necessary; it never does the reverse. */
+const STRING_INTRODUCERS = new Set<number>([0x5d, 0x50, 0x58, 0x5e, 0x5f]); // ] P X ^ _
+
+const ESC = 0x1b;
+const CSI_INTRODUCER = 0x5b; // '['
+const BEL = 0x07;
+const ST_FINAL = 0x5c; // '\' -- completes ST (ESC \) when it follows ESC in a 'string' sequence
+const DECSTBM_FINAL = 0x72; // 'r'
+
+/** CSI final bytes are 0x40-0x7E (ECMA-48). */
+function isCsiFinalByte(byte: number): boolean {
+  return byte >= 0x40 && byte <= 0x7e;
+}
+
+/** CSI parameter bytes are 0x30-0x3F (digits, `;`, `<`, `=`, `>`, `?`). */
+function isCsiParamByte(byte: number): boolean {
+  return byte >= 0x30 && byte <= 0x3f;
+}
+
+/** CSI intermediate bytes are 0x20-0x2F. */
+function isCsiIntermediateByte(byte: number): boolean {
+  return byte >= 0x20 && byte <= 0x2f;
+}
+
+export class PtyQuiescenceGate {
+  private state: ScanState = 'ground';
+  /** Parameter bytes seen so far in the current CSI sequence -- used only
+   *  to recognize a BARE `ESC[r` (no parameters, DECSTBM's full-screen
+   *  reset) as distinct from a parameterized region set like the bar's own
+   *  `ESC[1;Nr` paint (see buildBarSequence). */
+  private csiParamBytes = 0;
+  private lastObservedAtMs: number | null = null;
+  private readonly now: () => number;
+
+  constructor(now: () => number = () => Date.now()) {
+    this.now = now;
+  }
+
+  /**
+   * Feed one PTY chunk actually forwarded to the terminal this gate
+   * guards. Must be called, in order, for every such chunk -- the scanner
+   * has no other way to observe the stream. Returns true iff this chunk
+   * completed a bare `ESC[r` (DECSTBM full-screen scroll-region reset):
+   * the caller should treat that as an immediate-repaint trigger (see
+   * `StatusBar.notifyScrollRegionReset`).
+   */
+  observe(data: Uint8Array): boolean {
+    this.lastObservedAtMs = this.now();
+    let sawScrollRegionReset = false;
+    for (let i = 0; i < data.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: bounds checked by loop condition
+      const byte = data[i]!;
+      switch (this.state) {
+        case 'ground':
+          if (byte === ESC) this.state = 'escape';
+          break;
+        case 'escape':
+          if (byte === CSI_INTRODUCER) {
+            this.state = 'csi';
+            this.csiParamBytes = 0;
+          } else if (STRING_INTRODUCERS.has(byte)) {
+            this.state = 'string';
+          } else {
+            // Any other byte completes a two-byte escape sequence (ESC 7,
+            // ESC 8, ESC c, ESC =, ESC >, ...) -- back to ground.
+            this.state = 'ground';
+          }
+          break;
+        case 'csi':
+          if (isCsiFinalByte(byte)) {
+            if (byte === DECSTBM_FINAL && this.csiParamBytes === 0) {
+              sawScrollRegionReset = true;
+            }
+            this.state = 'ground';
+          } else if (isCsiParamByte(byte)) {
+            this.csiParamBytes++;
+          } else if (!isCsiIntermediateByte(byte)) {
+            // A byte that is not param/intermediate/final should not occur
+            // inside a well-formed CSI sequence. Rather than risk the
+            // scanner getting stuck reporting "dirty" forever on
+            // malformed input (which would silently disable every future
+            // paint), fail toward recovery: a fresh ESC restarts scanning,
+            // anything else is treated as having ended the sequence.
+            this.state = byte === ESC ? 'escape' : 'ground';
+          }
+          break;
+        case 'string':
+          if (byte === BEL) this.state = 'ground';
+          else if (byte === ESC) this.state = 'string-esc';
+          break;
+        case 'string-esc':
+          if (byte === ST_FINAL) this.state = 'ground';
+          else if (byte !== ESC) this.state = 'string';
+          // else: another ESC -- keep checking the next byte for ST_FINAL
+          break;
+      }
+    }
+    return sawScrollRegionReset;
+  }
+
+  /** Hard gate: true iff the stream is NOT currently inside an
+   *  unterminated Claude escape sequence -- see this module's doc for why
+   *  a write must never proceed while this is false. */
+  isBoundaryClean(): boolean {
+    return this.state === 'ground';
+  }
+
+  /** Soft gate: true iff at least `QUIESCENCE_MS` has passed since the
+   *  last observed chunk, or none has ever been observed (fail toward
+   *  paintable -- a fresh gate with no PTY history yet must not block the
+   *  bar's very first paint). */
+  isQuiescent(): boolean {
+    return this.lastObservedAtMs === null || this.now() - this.lastObservedAtMs >= QUIESCENCE_MS;
+  }
+}

--- a/packages/daemon/src/cli/pty-quiescence-gate.ts
+++ b/packages/daemon/src/cli/pty-quiescence-gate.ts
@@ -40,6 +40,21 @@
  * the 2.1.220 `claude` binary) so a caller can force an immediate repaint
  * rather than leaving row `N` unprotected until the next scheduled tick --
  * see `StatusBar.notifyScrollRegionReset`.
+ *
+ * Never-latch invariant: because `isBoundaryClean()` is a HARD gate with no
+ * exceptions (not even the heartbeat, see `StatusBar.render()`), a scanner
+ * state that can only be exited by a specific terminating byte is a
+ * liveness bug, not just a correctness one -- if that byte never arrives,
+ * the bar stops painting FOR THE REST OF THE SESSION, silently (nothing
+ * throws, so `MAX_RENDER_ERRORS` never trips). This is worse than the bug
+ * #932 exists to fix. Every non-ground state must therefore be reachable
+ * back to `ground` from ANY byte, not only the well-formed terminator --
+ * see the `csi` case's malformed-byte recovery and the `string`/
+ * `string-esc` cases' C0-control-abort + `MAX_STRING_RUN_BYTES` cap below,
+ * both added after a live capture confirmed Claude Code 2.1.220 emits OSC 8
+ * hyperlinks, OSC 52 clipboard, Kitty graphics APC, DCS, and other
+ * string-type sequences that a killed subprocess, a truncated tool-output
+ * stream, or binary passthrough could leave unterminated.
  */
 
 /** Scanner state machine positions. */
@@ -87,6 +102,37 @@ const BEL = 0x07;
 const ST_FINAL = 0x5c; // '\' -- completes ST (ESC \) when it follows ESC in a 'string' sequence
 const DECSTBM_FINAL = 0x72; // 'r'
 
+/**
+ * #932 review finding 1: length cap on a `string` (OSC/DCS/SOS/PM/APC)
+ * sequence that never sees its terminator (BEL or ST). Without this, a
+ * truncated stream -- reproduced empirically by feeding one unterminated
+ * `ESC ]` introducer followed by 1000 chunks of otherwise-normal output
+ * (plain text, complete CSI sequences, DECSC/DECRC pairs) -- left
+ * `isBoundaryClean()` false forever, because nothing in the `string` state
+ * could ever return to `ground` except the exact terminator byte. Real
+ * Claude Code string sequences (window titles, OSC 8 hyperlink URLs, OSC 52
+ * clipboard payloads, Kitty graphics APC image data) are the legitimate
+ * cost of this cap: tripping it early on one of those just means the gate
+ * treats the stream as clean a little sooner than strictly accurate,
+ * reopening a narrow slice of the ORIGINAL mode-1/mode-2 exposure for that
+ * one sequence -- a self-correcting, bounded cost, and strictly better than
+ * a permanent, silent latch (`MAX_RENDER_ERRORS` cannot trip here; nothing
+ * throws). 8192 bytes comfortably covers realistic titles/URLs/typical
+ * clipboard pastes while keeping worst-case exposure small. */
+const MAX_STRING_RUN_BYTES = 8192;
+
+/** Same fail-safe as `MAX_STRING_RUN_BYTES`, applied to `csi` for the same
+ *  never-latch reason -- even though the live capture that motivated this
+ *  file's review only reproduced the latch via the string family. A real
+ *  DECSTBM/SGR/cursor-move CSI sequence is a handful of bytes; 512 is
+ *  generous headroom that should never trip on legitimate output while
+ *  still bounding the worst case tightly (CSI's existing malformed-byte
+ *  recovery already handles a byte outside 0x20-0x7E; this additionally
+ *  bounds a run of otherwise-valid param/intermediate bytes that never
+ *  reaches a final byte -- corrupted/binary passthrough could produce
+ *  exactly that). */
+const MAX_CSI_RUN_BYTES = 512;
+
 /** CSI final bytes are 0x40-0x7E (ECMA-48). */
 function isCsiFinalByte(byte: number): boolean {
   return byte >= 0x40 && byte <= 0x7e;
@@ -109,6 +155,11 @@ export class PtyQuiescenceGate {
    *  reset) as distinct from a parameterized region set like the bar's own
    *  `ESC[1;Nr` paint (see buildBarSequence). */
   private csiParamBytes = 0;
+  /** Bytes consumed in the current `csi` run; see `MAX_CSI_RUN_BYTES`. */
+  private csiRunBytes = 0;
+  /** Bytes consumed in the current `string`/`string-esc` run; see
+   *  `MAX_STRING_RUN_BYTES`. */
+  private stringRunBytes = 0;
   private lastObservedAtMs: number | null = null;
   private readonly now: () => number;
 
@@ -130,6 +181,31 @@ export class PtyQuiescenceGate {
     for (let i = 0; i < data.length; i++) {
       // biome-ignore lint/style/noNonNullAssertion: bounds checked by loop condition
       const byte = data[i]!;
+      // #932 review finding 1: the never-latch safety net, checked BEFORE
+      // the per-state switch so a byte that trips it is reprocessed fresh
+      // from `ground` in the same iteration (see this module's doc for the
+      // empirical repro this closes: an unterminated OSC introducer
+      // followed by 1000 chunks of otherwise-normal output left
+      // `isBoundaryClean()` false forever, because nothing except the
+      // exact terminator byte could ever leave the `string` state).
+      if (this.state === 'csi') {
+        if (++this.csiRunBytes > MAX_CSI_RUN_BYTES) {
+          this.state = 'ground';
+          this.csiRunBytes = 0;
+        }
+      } else if (this.state === 'string' || this.state === 'string-esc') {
+        if (byte < 0x20 && byte !== BEL && byte !== ESC) {
+          // A C0 control other than BEL/ESC should not occur inside a
+          // well-formed string sequence -- same recovery discipline as
+          // the malformed-byte case in `csi` below: fail toward "boundary
+          // clean" rather than risk latching dirty forever.
+          this.state = 'ground';
+          this.stringRunBytes = 0;
+        } else if (++this.stringRunBytes > MAX_STRING_RUN_BYTES) {
+          this.state = 'ground';
+          this.stringRunBytes = 0;
+        }
+      }
       switch (this.state) {
         case 'ground':
           if (byte === ESC) this.state = 'escape';
@@ -138,8 +214,10 @@ export class PtyQuiescenceGate {
           if (byte === CSI_INTRODUCER) {
             this.state = 'csi';
             this.csiParamBytes = 0;
+            this.csiRunBytes = 0;
           } else if (STRING_INTRODUCERS.has(byte)) {
             this.state = 'string';
+            this.stringRunBytes = 0;
           } else {
             // Any other byte completes a two-byte escape sequence (ESC 7,
             // ESC 8, ESC c, ESC =, ESC >, ...) -- back to ground.

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -80,6 +80,21 @@ export interface PtySessionSetupDeps {
    * it. Absent => no-op (tests/old callers, or auto-approve disabled).
    */
   cancelAutoApproveForQuestion?: (sessionId: UUID, questionId: UUID, reason: string) => void;
+  /**
+   * #932 durable fix: observe every PTY chunk actually forwarded to the
+   * wrapper's own local terminal fd -- the exact same fd the reserved-row
+   * status bar draws into -- so a `PtyQuiescenceGate` can track whether a
+   * bar write right now would land inside one of Claude's own escape
+   * sequences. Fed with the raw bytes right before they are written to that
+   * fd (only when the wrapper is actually still attached: `passThrough &&
+   * stdoutFd !== null && !isWrapperDetached()`, the same condition guarding
+   * the write itself), never with the bar's own paint bytes -- those are
+   * self-terminating (see `buildBarSequence`) and do not need tracking.
+   * Absent => no gate wired (tests, older callers); `StatusBar`'s own
+   * `isBoundaryClean` / `isQuiescent` defaults then keep pre-durable-fix
+   * behavior (always paintable).
+   */
+  observeLocalPtyOutput?: (data: Uint8Array) => void;
 }
 
 /** Normalized sub-question texts to match a summary answer line against. */
@@ -213,6 +228,7 @@ export function createPtySessionForSession(
     exitProcess = (code: number) => process.exit(code),
     onQuestionResolved,
     cancelAutoApproveForQuestion,
+    observeLocalPtyOutput,
   } = deps;
   const { sessionId, workingDirectory, extraArgs, passThrough, reservedRows = 0 } = args;
 
@@ -242,6 +258,12 @@ export function createPtySessionForSession(
         // Write to the local terminal when wrapper is still attached.
         const stdoutFd = getPtyStdoutFd();
         if (passThrough && stdoutFd !== null && !isWrapperDetached()) {
+          // #932 durable fix: feed the quiescence + clean-boundary gate with
+          // the exact bytes about to hit this fd, BEFORE the write, so the
+          // gate's state reflects the stream up to and including this
+          // chunk by the time anything (a resize-triggered render(), the
+          // status bar's own timer) can observe it next.
+          observeLocalPtyOutput?.(data);
           try {
             fs.writeSync(stdoutFd, data);
           } catch (err) {

--- a/packages/daemon/src/cli/session-phases/pty-session-setup.ts
+++ b/packages/daemon/src/cli/session-phases/pty-session-setup.ts
@@ -85,14 +85,19 @@ export interface PtySessionSetupDeps {
    * wrapper's own local terminal fd -- the exact same fd the reserved-row
    * status bar draws into -- so a `PtyQuiescenceGate` can track whether a
    * bar write right now would land inside one of Claude's own escape
-   * sequences. Fed with the raw bytes right before they are written to that
-   * fd (only when the wrapper is actually still attached: `passThrough &&
+   * sequences. Fed with the raw bytes right AFTER they are successfully
+   * written to that fd (never before -- #932 review finding 2: this
+   * callback can synchronously trigger an immediate bar repaint when the
+   * chunk completes a bare ESC[r, and observing before the write would put
+   * that corrective paint on the wire before the very reset that
+   * triggered it, undoing the correction instead of the other way around),
+   * only when the wrapper is actually still attached (`passThrough &&
    * stdoutFd !== null && !isWrapperDetached()`, the same condition guarding
-   * the write itself), never with the bar's own paint bytes -- those are
-   * self-terminating (see `buildBarSequence`) and do not need tracking.
-   * Absent => no gate wired (tests, older callers); `StatusBar`'s own
-   * `isBoundaryClean` / `isQuiescent` defaults then keep pre-durable-fix
-   * behavior (always paintable).
+   * the write itself), and never with the bar's own paint bytes -- those
+   * are self-terminating (see `buildBarSequence`) and do not need
+   * tracking. Absent => no gate wired (tests, older callers); `StatusBar`'s
+   * own `isBoundaryClean` / `isQuiescent` defaults then keep
+   * pre-durable-fix behavior (always paintable).
    */
   observeLocalPtyOutput?: (data: Uint8Array) => void;
 }
@@ -258,14 +263,10 @@ export function createPtySessionForSession(
         // Write to the local terminal when wrapper is still attached.
         const stdoutFd = getPtyStdoutFd();
         if (passThrough && stdoutFd !== null && !isWrapperDetached()) {
-          // #932 durable fix: feed the quiescence + clean-boundary gate with
-          // the exact bytes about to hit this fd, BEFORE the write, so the
-          // gate's state reflects the stream up to and including this
-          // chunk by the time anything (a resize-triggered render(), the
-          // status bar's own timer) can observe it next.
-          observeLocalPtyOutput?.(data);
+          let wroteToLocalTerminal = false;
           try {
             fs.writeSync(stdoutFd, data);
+            wroteToLocalTerminal = true;
           } catch (err) {
             const code = (err as NodeJS.ErrnoException).code;
             setPtyStdoutFd(null);
@@ -288,6 +289,24 @@ export function createPtySessionForSession(
             process.stdin.removeAllListeners('data');
             process.stdin.unref();
           }
+          // #932 durable fix (review finding 2): feed the quiescence +
+          // clean-boundary gate AFTER the real chunk has landed on the
+          // wire, never before -- and outside the write's own try/catch,
+          // so a throw from this callback (e.g. a caller's isBoundaryClean/
+          // isQuiescent/hasLiveQuestions predicate) is never misclassified
+          // as a terminal write failure and does not trigger a spurious
+          // detach. `observeLocalPtyOutput` can synchronously trigger an
+          // immediate bar repaint (StatusBar.notifyScrollRegionReset, when
+          // this chunk completes a bare ESC[r) -- observing before the
+          // write would put that corrective DECSTBM-reasserting write on
+          // the wire BEFORE the very reset that triggered it, so the reset
+          // would immediately undo the correction instead of the other way
+          // around. Only fed on a successful write: a failed write means
+          // these bytes never reached the terminal, so the gate must not
+          // treat them as having done so (and `isWrapperDetached()` is now
+          // true anyway, so the bar cannot paint through this fd
+          // regardless).
+          if (wroteToLocalTerminal) observeLocalPtyOutput?.(data);
         }
 
         // Forward raw PTY bytes when at least one connection is attached

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -27,17 +27,14 @@
  * short to spare a row. A render error backs the bar off rather than crashing
  * the wrapper.
  *
- * Exposure reduction (#932): this bar and Claude's own PTY output are two
- * writers on the same fd, both synchronous `fs.writeSync` in the same
- * process and thread -- so byte-level interleaving WITHIN one write is not
- * the mechanism. The real hazard is a paint landing BETWEEN two PTY-
+ * Exposure reduction (#932, PR #933): this bar and Claude's own PTY output
+ * are two writers on the same fd, both synchronous `fs.writeSync` in the
+ * same process and thread -- so byte-level interleaving WITHIN one write is
+ * not the mechanism. The real hazard is a paint landing BETWEEN two PTY-
  * forwarding chunks, at a boundary that happens to split one of Claude's
  * own escape sequences (the DECSC/DECRC pair above shares Claude's own
- * cursor-save slot -- 166/421 occurrences in the installed binary). This
- * does not fix that (the durable fix is a quiescence + clean-boundary gate
- * on the PTY-forwarding side, tracked on #932 as its own follow-up -- NOT
- * a write queue, since same-process/same-thread writeSync calls have no
- * concurrency to serialize); it just cuts how often a paint is attempted:
+ * cursor-save slot -- 166/421 occurrences in the installed binary). PR #933
+ * did not fix that; it only cut how often a paint is attempted:
  *   1. `render()` no-ops while `hasLiveQuestions()` reports a pending
  *      question -- except for one fresh paint on the transition INTO that
  *      state (see `render()`'s `onset`), so the bar is current the moment
@@ -57,6 +54,23 @@
  * Protection 2 is also a restoration, not a new optimization: #565 specified
  * redraw "on: status change ... and on resize." The unconditional ~250ms
  * timer was added later, in #576, and exceeded that original design.
+ *
+ * The durable fix (#932 follow-up, this file's `isBoundaryClean` /
+ * `isQuiescent` deps): a quiescence + clean-boundary gate, backed by
+ * `PtyQuiescenceGate` (`pty-quiescence-gate.ts`), a small scanner over the
+ * PTY chunks actually forwarded to this fd. `isBoundaryClean()` is a HARD
+ * requirement checked before every write, with no exceptions -- a paint can
+ * no longer land at a boundary that splits one of Claude's own escape
+ * sequences, making that hazard ("mode 1") structurally impossible rather
+ * than just less frequent. `isQuiescent()` is a SOFT requirement that only
+ * gates a routine (non-edge, non-heartbeat) paint, reducing but not
+ * eliminating "mode 2" (a paint landing inside a save/restore pair that
+ * spans a quiet gap -- an accepted residual, see `pty-quiescence-gate.ts`).
+ * Both deps default to always-true (same fail-open pattern as
+ * `hasLiveQuestions`) so a caller that omits them -- tests, or a bar not
+ * wired to a PTY forwarder -- keeps pre-gate behavior. See `render()` for
+ * how the hard/soft split interacts with the heartbeat and the
+ * onset/resumed edges without weakening either.
  */
 
 import * as fs from 'node:fs';
@@ -85,7 +99,25 @@ export const MAX_RENDER_ERRORS = 3;
  *  user would notice as "the bar stopped updating," while still cutting the
  *  write rate roughly 8x versus the old unconditional 250ms cadence -- most
  *  of protection 2's exposure reduction. Not configurable: it exists to keep
- *  the dedup and the region invariant coupled, not to be tuned per caller. */
+ *  the dedup and the region invariant coupled, not to be tuned per caller.
+ *
+ *  #932 durable fix interaction: `render()`'s soft quiescence gate
+ *  (`isQuiescent`) is bypassed once this heartbeat is due, precisely so a
+ *  continuously streaming Claude session cannot defer this reassertion
+ *  indefinitely -- the heartbeat still fires within `HEARTBEAT_MS` of the
+ *  last write, unchanged from before the durable fix. The HARD boundary
+ *  gate (`isBoundaryClean`) is NOT bypassed for the heartbeat, and cannot
+ *  be: writing at a dirty boundary is the exact hazard the gate exists to
+ *  prevent, so weakening it here would defeat the fix it is coupled to. In
+ *  the realistic case this costs nothing -- an escape sequence completes
+ *  within the same or the very next PTY chunk, microseconds to
+ *  milliseconds, not a measurable fraction of 2000ms (see
+ *  `pty-quiescence-gate.ts`'s capture data). The only way the boundary gate
+ *  could delay a heartbeat past this window is a pathologically long
+ *  unterminated sequence -- effectively the same failure mode
+ *  `MAX_RENDER_ERRORS` and the config kill-switch already exist as escape
+ *  hatches for, and, like mode 2, an accepted residual rather than
+ *  something this gate can close without becoming a full VT emulator. */
 export const HEARTBEAT_MS = 2000;
 
 /**
@@ -216,6 +248,28 @@ export interface StatusBarDeps {
    *  not toward a precise per-agent freeze window -- see #932's PR
    *  discussion for the full reasoning on why that tradeoff was kept. */
   readonly hasLiveQuestions?: () => boolean;
+  /** #932 durable fix, HARD gate: true iff a write right now would NOT land
+   *  inside an unterminated Claude escape sequence -- backed by
+   *  `PtyQuiescenceGate.isBoundaryClean()` fed from the PTY chunks actually
+   *  forwarded to this fd (see `pty-quiescence-gate.ts`). `render()` checks
+   *  this before every write, with no exceptions -- not even for the
+   *  heartbeat or an onset/resumed edge paint -- because writing at a dirty
+   *  boundary is the exact hazard the gate exists to make structurally
+   *  impossible. Optional; defaults to always-true (same fail-open pattern
+   *  as `hasLiveQuestions`) so a caller that omits it -- tests, or a bar
+   *  not wired to a PTY forwarder -- keeps pre-gate behavior. */
+  readonly isBoundaryClean?: () => boolean;
+  /** #932 durable fix, SOFT gate: true iff the PTY has been quiet for at
+   *  least `QUIESCENCE_MS` (`pty-quiescence-gate.ts`). Unlike
+   *  `isBoundaryClean`, this gate has documented exceptions: a heartbeat-due
+   *  write, and the onset/resumed edge paints, all proceed as soon as
+   *  `isBoundaryClean()` allows even when this is false -- otherwise a
+   *  continuously streaming Claude session could starve the heartbeat's
+   *  DECSTBM reassertion or delay an onset/resumed capture past the moment
+   *  it is meant to capture. Only a routine (content-changed,
+   *  non-edge/non-heartbeat) paint waits on this. Optional; defaults to
+   *  always-true, same fail-open pattern as the other predicates here. */
+  readonly isQuiescent?: () => boolean;
   /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
   readonly writeToFd?: (fd: number, data: string) => void;
   /** Current epoch ms. Injectable for tests; defaults to Date.now. */
@@ -268,11 +322,20 @@ export class StatusBar {
    *  level) -- see `render()` for why each edge forces a fresh paint. Reset
    *  by `stop()` so a restart starts from "not live" again. */
   private wasQuestionLive = false;
+  /** Set by `notifyScrollRegionReset()`; cleared only once a write actually
+   *  lands. #932: the ESC[r bonus signal -- if `isBoundaryClean()` refuses
+   *  the immediate attempt (the reset chunk was followed by more bytes that
+   *  left the stream mid-sequence), this stays true so the very next
+   *  capable `render()` call -- the next tick, or the next chunk-triggered
+   *  notify -- retries rather than the intent being silently dropped. */
+  private forceRepaintPending = false;
   private readonly getStdoutFd: () => number | null;
   private readonly getStatus: () => Readonly<RemiStatus>;
   private readonly getSize: () => { cols: number; rows: number };
   private readonly isEnabled: () => boolean;
   private readonly hasLiveQuestions: () => boolean;
+  private readonly isBoundaryClean: () => boolean;
+  private readonly isQuiescent: () => boolean;
   private readonly writeToFd: (fd: number, data: string) => void;
   private readonly now: () => number;
   private readonly log: (msg: string) => void;
@@ -284,6 +347,8 @@ export class StatusBar {
     this.getSize = deps.getSize;
     this.isEnabled = deps.isEnabled;
     this.hasLiveQuestions = deps.hasLiveQuestions ?? (() => false);
+    this.isBoundaryClean = deps.isBoundaryClean ?? (() => true);
+    this.isQuiescent = deps.isQuiescent ?? (() => true);
     this.writeToFd = deps.writeToFd ?? ((fd, data) => fs.writeSync(fd, data));
     this.now = deps.now ?? (() => Date.now());
     this.log = deps.log;
@@ -315,29 +380,59 @@ export class StatusBar {
     this.lastRendered = null;
     this.lastWriteAtMs = null;
     this.wasQuestionLive = false;
+    this.forceRepaintPending = false;
+  }
+
+  /**
+   * #932 durable fix: notify the bar that the PTY-forwarding scanner just
+   * observed Claude emit a bare `ESC[r` (DECSTBM full-screen scroll-region
+   * reset) -- row N is unprotected until the region is re-asserted, so this
+   * attempts an immediate repaint rather than waiting out the normal tick
+   * or the up-to-`HEARTBEAT_MS` heartbeat window. Safe to call any time
+   * (same guards as `render()` apply); if `isBoundaryClean()` still refuses
+   * the attempt -- the reset chunk was followed by more bytes that left the
+   * stream mid-sequence -- the intent is not dropped: it stays pending for
+   * the next capable `render()` call (see `forceRepaintPending`'s doc).
+   */
+  notifyScrollRegionReset(): void {
+    this.forceRepaintPending = true;
+    this.render();
   }
 
   /** Paint the reserved row now. Safe no-op when disabled / detached / no
-   *  room. While a question is live (#932), paints once on the transition
-   *  into that state and freezes after; paints once more on the transition
-   *  back out, then resumes normal cadence -- see the `onset`/`resumed`
-   *  comment below for why both edges force a fresh paint. */
+   *  room / a dirty escape-sequence boundary. While a question is live
+   *  (#932), paints once on the transition into that state and freezes
+   *  after; paints once more on the transition back out, then resumes
+   *  normal cadence -- see the `onset`/`resumed` comment below for why both
+   *  edges force a fresh paint. */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
-    // fd/room checks come BEFORE hasLiveQuestions() is read and
-    // wasQuestionLive is mutated (#932 review fix): a transition landing on
-    // a tick where a paint isn't even possible must not be consumed. If it
-    // were, the flag would flip with no write to show for it, and the NEXT
-    // successful tick would compute onset/resumed against the
-    // already-flipped flag -- neither true -- and freeze on stale content
-    // for the rest of the window: the exact bug this whole mechanism exists
-    // to prevent, reintroduced through ordering. Same pattern
-    // `disabled`/`isEnabled()` above already use: return before touching
-    // any state a later, capable tick still needs to see as unconsumed.
+    // fd/room/boundary checks come BEFORE hasLiveQuestions() is read and
+    // wasQuestionLive is mutated (#932 review fix, preserved by the durable
+    // fix): a transition landing on a tick where a paint isn't even
+    // possible must not be consumed. If it were, the flag would flip with
+    // no write to show for it, and the NEXT successful tick would compute
+    // onset/resumed against the already-flipped flag -- neither true -- and
+    // freeze on stale content for the rest of the window: the exact bug
+    // this whole mechanism exists to prevent, reintroduced through
+    // ordering. Same pattern `disabled`/`isEnabled()` above already use:
+    // return before touching any state a later, capable tick still needs to
+    // see as unconsumed.
     const fd = this.getStdoutFd();
     if (fd === null) return;
     const { cols, rows } = this.getSize();
     if (rows < MIN_ROWS_FOR_BAR || cols < 1) return;
+    // #932 durable fix, HARD gate: a write can never land at a boundary
+    // that splits one of Claude's own escape sequences -- this belongs in
+    // the same "cannot physically paint" group as the fd/room checks above,
+    // for the identical ordering reason: it must run before
+    // hasLiveQuestions() so a question transition landing while the
+    // boundary is dirty is never consumed either. No exception exists for
+    // this gate -- not onset, not resumed, not the heartbeat -- because
+    // writing here is not merely undesirable, it is the exact hazard #932
+    // documents (a bar write parsed as the continuation of Claude's own
+    // half-delivered sequence).
+    if (!this.isBoundaryClean()) return;
     const questionLive = this.hasLiveQuestions();
     const wasLive = this.wasQuestionLive;
     this.wasQuestionLive = questionLive;
@@ -369,17 +464,31 @@ export class StatusBar {
       const nowMs = this.now();
       const heartbeatDue =
         this.lastWriteAtMs === null || nowMs - this.lastWriteAtMs >= HEARTBEAT_MS;
-      // #932 protection 2: skip the write when nothing changed since the last
-      // successful paint AND the heartbeat hasn't elapsed -- most ticks would
-      // otherwise rewrite identical bytes. The heartbeat still forces a write
-      // at least every HEARTBEAT_MS so buildBarSequence's DECSTBM
-      // re-assertion stays bounded (see that doc and HEARTBEAT_MS's). The
-      // question onset/resume paints always write regardless of either check
-      // -- each is a fresh capture (or recovery), not a routine repaint.
-      if (!onset && !resumed && sequence === this.lastRendered && !heartbeatDue) return;
+      // #932 durable fix: onset/resumed/heartbeat/an observed ESC[r all
+      // bypass the SOFT quiescence gate below (they still obey the HARD
+      // boundary gate above) -- each is either a correctness-critical
+      // instant capture (onset/resumed) or an explicit bound that must not
+      // be starved by continuous output (heartbeat's DECSTBM reassertion,
+      // the scroll-region-reset recovery). This is the documented answer to
+      // "what happens when the gate could defer a paint past the heartbeat
+      // window": it cannot -- the heartbeat is exempt from the soft gate,
+      // so it still fires within HEARTBEAT_MS of the last write regardless
+      // of how busy the PTY is, same as before this fix.
+      const bypassesQuiescence = onset || resumed || heartbeatDue || this.forceRepaintPending;
+      // #932 protection 2 (unchanged): skip the write when nothing changed
+      // since the last successful paint, UNLESS this is one of the forced
+      // paths above.
+      if (!bypassesQuiescence && sequence === this.lastRendered) return;
+      // #932 durable fix, SOFT gate: a routine paint (content changed, none
+      // of the forced reasons above) additionally waits for PTY quiescence
+      // -- reduces "mode 2" exposure (a paint landing inside a save/restore
+      // pair that spans a quiet gap). See `isQuiescent`'s doc for why this
+      // check does not apply to the forced paths.
+      if (!bypassesQuiescence && !this.isQuiescent()) return;
       this.writeToFd(fd, sequence);
       this.lastRendered = sequence;
       this.lastWriteAtMs = nowMs;
+      this.forceRepaintPending = false;
       this.consecutiveErrors = 0;
       this.errorLogged = false;
     } catch (err) {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -981,10 +981,24 @@ describe('runAttachClient', () => {
     });
 
     const output = readOutput();
-    const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
-    expect(bars.length).toBe(2);
-    expect(bars[0]).toContain('idle');
-    expect(bars[1]).toContain('thinking');
+    const barMatches = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)];
+    expect(barMatches.length).toBe(2);
+    expect(barMatches[0]?.[1]).toContain('idle');
+    expect(barMatches[1]?.[1]).toContain('thinking');
+
+    // #932 review finding 2: a paint count alone does not prove ordering --
+    // the immediate repaint is worthless (and actively harmful) if it lands
+    // on the wire BEFORE the ESC[r that triggered it, since the reset would
+    // then immediately undo the correction. The bar's own paints always
+    // include DECSTBM with explicit params (`\x1b[1;Nr`), so the first
+    // literal bare `\x1b[r` in the raw output can only be our injected
+    // reset chunk (the only other source, the teardown clear sequence,
+    // writes its own bare `\x1b[r` later still, on WS close).
+    const resetIndex = output.indexOf('\x1b[r');
+    expect(resetIndex).toBeGreaterThanOrEqual(0);
+    const secondBarIndex = barMatches[1]?.index;
+    expect(secondBarIndex).toBeDefined();
+    expect(secondBarIndex as number).toBeGreaterThan(resetIndex);
   });
 
   // #898: renderMessage's total-dispatch handler for raw_pty_output was

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -795,6 +795,198 @@ describe('runAttachClient', () => {
     expect(output).toContain('\x1b[7m'); // the bar started anyway, past the fallback bound
   });
 
+  // #932 durable fix: proves the REAL wiring end to end (real
+  // `PtyQuiescenceGate`, fed by real `raw_pty_output` messages through
+  // `writeRawBytes`), not just StatusBar in isolation. A chunk that leaves
+  // the stream mid-escape-sequence must suppress the bar until BOTH gates
+  // clear -- and the two checkpoints below prove they are two SEPARATE
+  // gates, not one: the boundary clears well before quiescence does, and a
+  // routine repaint still waits for both.
+  test('a raw_pty_output chunk ending mid-escape-sequence suppresses the bar until the boundary clears AND the PTY goes quiet', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    // A CSI introducer with no final byte -- the stream is left inside an
+    // unterminated escape sequence, exactly the #932 mode-1 hazard.
+    const dirtyChunk = Buffer.from([0x1b, 0x5b]).toString('base64'); // ESC [
+    const completingChunk = Buffer.from('31m', 'utf-8').toString('base64'); // ...31m
+
+    server = Bun.serve({
+      port: TEST_PORT + 15,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'idle' }),
+                  ),
+                ),
+              );
+            }, 50);
+            // Unblocks the deferred first paint -- status A ("idle"), painted.
+            setTimeout(() => {
+              ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [])));
+            }, 100);
+            // Leaves the boundary dirty from here on.
+            setTimeout(() => {
+              ws.send(serialize(createRawPtyOutput(dirtyChunk, targetSessionId as UUID)));
+            }, 150);
+            // A real status change, stored but must not paint while dirty.
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'thinking' }),
+                  ),
+                ),
+              );
+            }, 200);
+            // Completes the sequence: boundary clears here, but this same
+            // chunk also resets the quiescence window from this instant.
+            setTimeout(() => {
+              ws.send(serialize(createRawPtyOutput(completingChunk, targetSessionId as UUID)));
+            }, 550);
+            setTimeout(() => ws.close(), 1400);
+          }
+        },
+        close() {},
+      },
+    });
+
+    let atBoundaryDirty = '';
+    setTimeout(() => {
+      atBoundaryDirty = fs.readFileSync(outputPath, 'utf-8');
+    }, 500); // well after the status change at t=200, boundary still dirty
+
+    let afterBoundaryClearsButNotQuiescent = '';
+    setTimeout(() => {
+      afterBoundaryClearsButNotQuiescent = fs.readFileSync(outputPath, 'utf-8');
+    }, 750); // boundary cleared at t=550, but only 200ms of quiet (< QUIESCENCE_MS)
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 15,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+      statusBarEligible: true,
+    });
+
+    const barsIn = (text: string) =>
+      [...text.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
+
+    const dirtyBars = barsIn(atBoundaryDirty);
+    expect(dirtyBars.length).toBe(1); // only the onset paint; status change never landed
+    expect(dirtyBars[0]).toContain('idle');
+
+    const cleanNotQuietBars = barsIn(afterBoundaryClearsButNotQuiescent);
+    expect(cleanNotQuietBars.length).toBe(1); // boundary alone is not enough
+    expect(cleanNotQuietBars[0]).toContain('idle');
+
+    const output = readOutput();
+    const finalBars = barsIn(output);
+    // Once both the boundary is clean AND the PTY has been quiet for
+    // QUIESCENCE_MS, the routine repaint finally lands with the status
+    // change that was stored back at t=200.
+    expect(finalBars.length).toBe(2);
+    expect(finalBars[1]).toContain('thinking');
+  });
+
+  // #932 durable fix bonus signal: a bare ESC[r (DECSTBM full-screen
+  // scroll-region reset) must trigger an immediate repaint rather than
+  // waiting for the normal tick, the quiescence window, or the heartbeat --
+  // row N is unprotected until DECSTBM is re-asserted. Timed to land well
+  // before the bar's first regular timer tick (~250ms after start()) and
+  // far under QUIESCENCE_MS/HEARTBEAT_MS, so the only mechanism that can
+  // explain the second paint is the immediate trigger.
+  test('a bare ESC[r in raw_pty_output triggers an immediate repaint', async () => {
+    setupOutput();
+    const targetSessionId = generateId();
+    const resetChunk = Buffer.from([0x1b, 0x5b, 0x72]).toString('base64'); // ESC [ r
+
+    server = Bun.serve({
+      port: TEST_PORT + 16,
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: {} })) return;
+        return new Response('Not found', { status: 404 });
+      },
+      websocket: {
+        open() {},
+        message(ws, data) {
+          const text = typeof data === 'string' ? data : new TextDecoder().decode(data);
+          const msg = deserialize(text);
+          if (!msg) return;
+
+          if (msg.type === 'hello') {
+            ws.send(serialize(createHelloAck('1.0.0', targetSessionId as UUID)));
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'idle' }),
+                  ),
+                ),
+              );
+            }, 50);
+            // Unblocks the deferred first paint -- status A ("idle"), painted.
+            setTimeout(() => {
+              ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [])));
+            }, 100);
+            // A real status change, stored but not yet painted.
+            setTimeout(() => {
+              ws.send(
+                serialize(
+                  createRemiStatus(
+                    targetSessionId as UUID,
+                    mkRemiStatus(targetSessionId as UUID, { sessionStatus: 'thinking' }),
+                  ),
+                ),
+              );
+            }, 200);
+            // Sent well before the first regular ~250ms tick (start() was
+            // called at t=100, so the first regular tick lands at ~t=350).
+            setTimeout(() => {
+              ws.send(serialize(createRawPtyOutput(resetChunk, targetSessionId as UUID)));
+            }, 270);
+            // Closes before the first regular tick and far under both
+            // QUIESCENCE_MS (500) and HEARTBEAT_MS (2000).
+            setTimeout(() => ws.close(), 320);
+          }
+        },
+        close() {},
+      },
+    });
+
+    await runAttachClient({
+      host: 'localhost',
+      port: TEST_PORT + 16,
+      sessionId: targetSessionId,
+      timeout: 3000,
+      outputFd,
+      statusBarEligible: true,
+    });
+
+    const output = readOutput();
+    const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
+    expect(bars.length).toBe(2);
+    expect(bars[0]).toContain('idle');
+    expect(bars[1]).toContain('thinking');
+  });
+
   // #898: renderMessage's total-dispatch handler for raw_pty_output was
   // exercised only indirectly before (nothing asserted on decoded bytes).
   test('renders decoded raw_pty_output bytes to output', async () => {

--- a/packages/daemon/tests/cli/pty-quiescence-gate.test.ts
+++ b/packages/daemon/tests/cli/pty-quiescence-gate.test.ts
@@ -134,6 +134,122 @@ describe('PtyQuiescenceGate.isBoundaryClean', () => {
   });
 });
 
+// #932 review finding 1: `isBoundaryClean()` is a HARD gate with no
+// exceptions (status-bar.ts's render() checks it before onset/resumed/
+// heartbeat), so a scanner state reachable only via its well-formed
+// terminator is a liveness bug -- if that terminator never arrives, the bar
+// stops painting for the rest of the session, silently (nothing throws).
+// These reproduce the exact class of input that latched the scanner before
+// the fix, and prove recovery.
+describe('PtyQuiescenceGate — never-latch safety net', () => {
+  test('an unterminated OSC introducer followed by many chunks of normal output eventually recovers to clean', () => {
+    // Direct reproduction of the review finding: one unterminated ESC ]
+    // introducer, then 1000 chunks of entirely normal output -- plain
+    // text, complete CSI sequences, DECSC/DECRC pairs -- none containing
+    // BEL or ESC \. Before the fix, isBoundaryClean() stayed false through
+    // all 1000 chunks.
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']')); // unterminated OSC introducer
+    expect(gate.isBoundaryClean()).toBe(false);
+
+    const normalChunks = [
+      'hello world, this is normal output ',
+      '\x1b[32mgreen text\x1b[0m ',
+      '\x1b7\x1b8 ', // DECSC/DECRC pair
+      'more plain text without any BEL or ST terminator ',
+    ];
+    let recovered = false;
+    for (let i = 0; i < 1000; i++) {
+      gate.observe(bytes(normalChunks[i % normalChunks.length] as string));
+      if (gate.isBoundaryClean()) {
+        recovered = true;
+        break;
+      }
+    }
+    expect(recovered).toBe(true);
+    // And the gate keeps working normally afterward -- not just "clean
+    // once," but genuinely recovered, not wedged in some other state.
+    expect(gate.observe(bytes([ESC], '[31m'))).toBe(false);
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a stray C0 control other than BEL/ESC inside a string sequence aborts it back to ground', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;some title'));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes([0x0a])); // a stray LF -- never a valid OSC byte
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a stray C0 control aborts DCS/SOS/PM/APC string sequences too', () => {
+    for (const introducer of ['P', 'X', '^', '_']) {
+      const gate = new PtyQuiescenceGate();
+      gate.observe(bytes([ESC], introducer, 'payload'));
+      expect(gate.isBoundaryClean()).toBe(false);
+      gate.observe(bytes([0x18])); // CAN
+      expect(gate.isBoundaryClean()).toBe(true);
+    }
+  });
+
+  test('a stray C0 control inside string-esc (after an ESC that was not ST) also recovers', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;t', [ESC])); // ESC that might be starting ST
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes([0x0a])); // LF instead of '\' -- abort, not resume
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a legitimate OSC well under the length cap is unaffected', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;a normal window title', [0x07]));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('an OSC sequence that never terminates recovers once the length cap is exceeded', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']52;c;')); // OSC 52 clipboard introducer
+    expect(gate.isBoundaryClean()).toBe(false);
+    // Feed printable, non-control bytes only (a plausible base64 payload
+    // stand-in) well past any realistic OSC 52 payload, with no BEL/ST.
+    const payloadChunk = 'A'.repeat(1000);
+    let recovered = false;
+    for (let i = 0; i < 20; i++) {
+      gate.observe(bytes(payloadChunk));
+      if (gate.isBoundaryClean()) {
+        recovered = true;
+        break;
+      }
+    }
+    expect(recovered).toBe(true);
+  });
+
+  test('a CSI sequence that never reaches a final byte eventually recovers (defense in depth)', () => {
+    // CSI already has malformed-byte recovery for a byte outside its
+    // grammar; this covers the narrower case of a long run of otherwise-
+    // valid param bytes (e.g. corrupted/binary passthrough) that never
+    // reaches a final byte in 0x40-0x7E.
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '['));
+    expect(gate.isBoundaryClean()).toBe(false);
+    const paramRun = '0123456789;'.repeat(100); // all valid CSI param bytes
+    let recovered = false;
+    for (let i = 0; i < 10; i++) {
+      gate.observe(bytes(paramRun));
+      if (gate.isBoundaryClean()) {
+        recovered = true;
+        break;
+      }
+    }
+    expect(recovered).toBe(true);
+  });
+
+  test('a legitimate short CSI sequence is unaffected by the run cap', () => {
+    const gate = new PtyQuiescenceGate();
+    expect(gate.observe(bytes([ESC], '[38;2;255;100;50m'))).toBe(false); // 24-bit color SGR
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+});
+
 describe('PtyQuiescenceGate.observe scroll-region-reset detection (ESC[r)', () => {
   test('a bare ESC[r in one chunk is reported', () => {
     const gate = new PtyQuiescenceGate();

--- a/packages/daemon/tests/cli/pty-quiescence-gate.test.ts
+++ b/packages/daemon/tests/cli/pty-quiescence-gate.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'bun:test';
+import { PtyQuiescenceGate, QUIESCENCE_MS } from '../../src/cli/pty-quiescence-gate.ts';
+
+function bytes(...parts: (string | number[])[]): Uint8Array {
+  const chunks: number[] = [];
+  for (const part of parts) {
+    if (typeof part === 'string') {
+      for (let i = 0; i < part.length; i++) chunks.push(part.charCodeAt(i));
+    } else {
+      chunks.push(...part);
+    }
+  }
+  return new Uint8Array(chunks);
+}
+
+const ESC = 0x1b;
+
+describe('PtyQuiescenceGate.isBoundaryClean', () => {
+  test('a fresh gate with no observed chunks is clean', () => {
+    const gate = new PtyQuiescenceGate();
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('plain text with no escape sequences stays clean', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes('hello world\r\n'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a complete CSI sequence in one chunk is clean afterward', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '[31m'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a CSI sequence split across two chunks is dirty until the final byte arrives', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '[3'));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes('1m'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a CSI sequence split right after the introducer is dirty until the final byte arrives', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '['));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes('31m'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a two-byte escape sequence (e.g. DECSC / DECRC) is clean immediately after its one byte', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '7')); // DECSC
+    expect(gate.isBoundaryClean()).toBe(true);
+    gate.observe(bytes([ESC], '8')); // DECRC
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a bare ESC leaves the boundary dirty until the next byte resolves it', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC]));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes('7'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('an OSC sequence terminated by BEL in one chunk is clean afterward', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;title', [0x07]));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('an OSC sequence split before the BEL terminator is dirty until it arrives', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;title'));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes([0x07]));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('an OSC sequence terminated by ST (ESC \\) is clean afterward, including split across chunks', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;title'));
+    expect(gate.isBoundaryClean()).toBe(false);
+    gate.observe(bytes([ESC]));
+    expect(gate.isBoundaryClean()).toBe(false); // still dirty: could be ST or a literal ESC in the payload
+    gate.observe(bytes('\\'));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a stray ESC inside an OSC string that is not followed by backslash resumes the string, not ground', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], ']0;t'));
+    gate.observe(bytes([ESC])); // could be starting ST...
+    gate.observe(bytes('x')); // ...but it wasn't -- back to consuming the OSC body
+    expect(gate.isBoundaryClean()).toBe(false); // OSC is still open
+    gate.observe(bytes([0x07]));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('DCS/SOS/PM/APC introducers are treated as string sequences too', () => {
+    for (const introducer of ['P', 'X', '^', '_']) {
+      const gate = new PtyQuiescenceGate();
+      gate.observe(bytes([ESC], introducer, 'payload'));
+      expect(gate.isBoundaryClean()).toBe(false);
+      gate.observe(bytes([0x07]));
+      expect(gate.isBoundaryClean()).toBe(true);
+    }
+  });
+
+  test('an out-of-range byte inside a CSI sequence recovers to ground rather than sticking dirty forever', () => {
+    const gate = new PtyQuiescenceGate();
+    // 0x01 (SOH) is not a valid CSI param/intermediate/final byte.
+    gate.observe(bytes([ESC], '[', [0x01]));
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('an ESC inside a CSI sequence restarts scanning from escape rather than sticking dirty', () => {
+    const gate = new PtyQuiescenceGate();
+    gate.observe(bytes([ESC], '[3', [ESC], '7'));
+    // The abandoned CSI never got a final byte, but the ESC 7 that interrupted
+    // it is a complete two-byte sequence, so the boundary is clean again.
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('consecutive independent sequences across many small chunks all resolve clean', () => {
+    const gate = new PtyQuiescenceGate();
+    const fullSequence = '\x1b[2K\x1b[7m hi \x1b[0m\x1b7\x1b8';
+    for (const ch of fullSequence) {
+      gate.observe(bytes(ch));
+    }
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+});
+
+describe('PtyQuiescenceGate.observe scroll-region-reset detection (ESC[r)', () => {
+  test('a bare ESC[r in one chunk is reported', () => {
+    const gate = new PtyQuiescenceGate();
+    const sawReset = gate.observe(bytes([ESC], '[r'));
+    expect(sawReset).toBe(true);
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('a bare ESC[r split across two chunks is reported only once complete', () => {
+    const gate = new PtyQuiescenceGate();
+    const first = gate.observe(bytes([ESC], '['));
+    expect(first).toBe(false);
+    expect(gate.isBoundaryClean()).toBe(false);
+    const second = gate.observe(bytes('r'));
+    expect(second).toBe(true);
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test("a parameterized region set (the bar's own ESC[1;Nr) is NOT reported as a bare reset", () => {
+    const gate = new PtyQuiescenceGate();
+    const sawReset = gate.observe(bytes([ESC], '[1;39r'));
+    expect(sawReset).toBe(false);
+    expect(gate.isBoundaryClean()).toBe(true);
+  });
+
+  test('other CSI final bytes are never reported as a scroll-region reset', () => {
+    const gate = new PtyQuiescenceGate();
+    expect(gate.observe(bytes([ESC], '[2K'))).toBe(false); // erase line
+    expect(gate.observe(bytes([ESC], '[7m'))).toBe(false); // reverse video
+    expect(gate.observe(bytes([ESC], '[H'))).toBe(false); // cursor home
+  });
+
+  test('a bare ESC[r followed by more bytes in the same chunk still reports the reset', () => {
+    const gate = new PtyQuiescenceGate();
+    const sawReset = gate.observe(bytes([ESC], '[r', 'hello'));
+    expect(sawReset).toBe(true);
+  });
+
+  test('multiple bare ESC[r occurrences in one chunk still report true (not miscounted)', () => {
+    const gate = new PtyQuiescenceGate();
+    const sawReset = gate.observe(bytes([ESC], '[r', [ESC], '[r'));
+    expect(sawReset).toBe(true);
+  });
+});
+
+describe('PtyQuiescenceGate.isQuiescent', () => {
+  test('a fresh gate with no observed chunks is quiescent (fail toward paintable)', () => {
+    const gate = new PtyQuiescenceGate();
+    expect(gate.isQuiescent()).toBe(true);
+  });
+
+  test('is not quiescent immediately after a chunk, becomes quiescent once QUIESCENCE_MS has elapsed', () => {
+    let nowMs = 1_000_000;
+    const gate = new PtyQuiescenceGate(() => nowMs);
+    gate.observe(bytes('hello'));
+    expect(gate.isQuiescent()).toBe(false);
+    nowMs += QUIESCENCE_MS - 1;
+    expect(gate.isQuiescent()).toBe(false);
+    nowMs += 1;
+    expect(gate.isQuiescent()).toBe(true);
+  });
+
+  test('a later chunk resets the quiescence window from its own timestamp', () => {
+    let nowMs = 1_000_000;
+    const gate = new PtyQuiescenceGate(() => nowMs);
+    gate.observe(bytes('a'));
+    nowMs += QUIESCENCE_MS; // now quiescent
+    expect(gate.isQuiescent()).toBe(true);
+    gate.observe(bytes('b')); // resets the window
+    expect(gate.isQuiescent()).toBe(false);
+    nowMs += QUIESCENCE_MS - 1;
+    expect(gate.isQuiescent()).toBe(false);
+    nowMs += 1;
+    expect(gate.isQuiescent()).toBe(true);
+  });
+});

--- a/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/pty-session-setup.test.ts
@@ -10,7 +10,11 @@ import {
   createPtySessionForSession,
   detectAuqTerminalAnswers,
 } from '../../../src/cli/session-phases/pty-session-setup.ts';
-import { __resetWrapperStateForTests } from '../../../src/cli/wrapper-state.ts';
+import {
+  __resetWrapperStateForTests,
+  setPtyStdoutFd,
+  setWrapperDetached,
+} from '../../../src/cli/wrapper-state.ts';
 import { clearAuqRunActive, markAuqRunActive } from '../../../src/hooks/auq-active-runs.ts';
 import { OutputProcessor } from '../../../src/parser/output-processor.ts';
 import { appendPtyOutput, clearPtyOutput } from '../../../src/pty/output-buffer.ts';
@@ -254,6 +258,188 @@ describe('createPtySessionForSession', () => {
         /* already exited */
       }
     }
+  });
+});
+
+// #932 review finding 3: the wrapper's onRawData wiring (observeLocalPtyOutput)
+// does NOT require spawning a real `claude` to test -- createPtySessionForSession
+// never calls .start() (PTYSession's constructor only stores config; Bun.spawn
+// happens in start(), see the "returns a PTYSession whose sessionState starts in
+// created" test above), so the `events` object passed to `new PTYSession(...)`
+// is fully populated and reachable: TypeScript's `private` is compile-time only,
+// not a runtime guarantee, so a cast reaches it directly, exactly as the review
+// did in its own 16ms counter-example.
+describe('createPtySessionForSession onRawData wiring (#932)', () => {
+  let tmpDir: string;
+  let sessionRegistry: SessionRegistry;
+  let sessionStore: SessionStore;
+  let liveSessionsRegistry: SessionRegistryFile;
+  let outputProcessor: OutputProcessor;
+  let outPath: string;
+  let outFd: number;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-pty-rawdata-'));
+    sessionRegistry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    sessionStore = new SessionStore(path.join(tmpDir, 'sessions.json'));
+    liveSessionsRegistry = new SessionRegistryFile(path.join(tmpDir, 'live-sessions'));
+    outputProcessor = new OutputProcessor(
+      { sessionId: SID, streamStatusOnly: true },
+      { onMessage: () => {}, onQuestion: () => {}, onStatusChange: () => {} },
+    );
+    configureLogger({ writeLog: () => {} });
+    outPath = path.join(tmpDir, 'local-terminal-out');
+    fs.writeFileSync(outPath, '');
+    outFd = fs.openSync(outPath, 'w');
+    setPtyStdoutFd(outFd);
+    setWrapperDetached(false);
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    __resetWrapperStateForTests();
+    await sessionRegistry.shutdown();
+    try {
+      fs.closeSync(outFd);
+    } catch {
+      // may already be closed by a test that exercises the write-failure path
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Reach the real onRawData callback without starting a PTY (no `claude`
+   *  spawned) -- see this describe block's doc comment. */
+  function rawDataHandlerOf(pty: ReturnType<typeof createPtySessionForSession>) {
+    const events = (pty as unknown as { events: { onRawData?: (d: Uint8Array) => void } }).events;
+    const handler = events.onRawData;
+    if (!handler) throw new Error('onRawData was not wired');
+    return handler;
+  }
+
+  /** Invoke onRawData the way `PTYSession.handleData` actually does in
+   *  production -- wrapped in a try/catch that routes any throw to
+   *  `onError` (pty-session.ts) rather than letting it escape. The write-
+   *  failure path's stdin cleanup (`process.stdin.unref()` etc.) assumes a
+   *  real interactive terminal that this test runner's stdin does not
+   *  provide; production never calls onRawData bare either, so this
+   *  matches the real invocation context rather than papering over it. */
+  function invokeOnRawData(
+    pty: ReturnType<typeof createPtySessionForSession>,
+    data: Uint8Array,
+  ): void {
+    try {
+      rawDataHandlerOf(pty)(data);
+    } catch {
+      // See doc comment: mirrors PTYSession.handleData's own onError routing.
+    }
+  }
+
+  test('onRawData writes the real chunk to the local terminal and calls observeLocalPtyOutput with the exact bytes', () => {
+    const observedChunks: Uint8Array[] = [];
+    const pty = createPtySessionForSession(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        outputProcessor,
+        wsPort: 9999,
+        sendMessage: () => {},
+        cleanup: async () => {},
+        observeLocalPtyOutput: (data) => observedChunks.push(data),
+      },
+      { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: true },
+    );
+
+    const chunk = new TextEncoder().encode('hello from claude');
+    invokeOnRawData(pty, chunk);
+
+    expect(fs.readFileSync(outPath, 'utf-8')).toBe('hello from claude');
+    expect(observedChunks).toHaveLength(1);
+    expect(observedChunks[0]).toEqual(chunk);
+  });
+
+  // #932 review finding 2, proven at the wrapper level (the review noted this
+  // test would have caught it directly): the real chunk must land on the wire
+  // BEFORE anything observeLocalPtyOutput itself writes to the same fd, never
+  // after -- an immediate bar repaint triggered by an observed ESC[r would
+  // otherwise be undone by the very reset that triggered it.
+  test('observeLocalPtyOutput fires strictly AFTER the real chunk is written to the same fd', () => {
+    const pty = createPtySessionForSession(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        outputProcessor,
+        wsPort: 9999,
+        sendMessage: () => {},
+        cleanup: async () => {},
+        observeLocalPtyOutput: () => {
+          // Simulate StatusBar.notifyScrollRegionReset's synchronous write
+          // to the SAME shared fd.
+          fs.writeSync(outFd, 'MARKER');
+        },
+      },
+      { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: true },
+    );
+
+    invokeOnRawData(pty, new TextEncoder().encode('\x1b[r'));
+
+    const written = fs.readFileSync(outPath, 'utf-8');
+    const chunkIndex = written.indexOf('\x1b[r');
+    const markerIndex = written.indexOf('MARKER');
+    expect(chunkIndex).toBe(0); // the real chunk is written first, at offset 0
+    expect(markerIndex).toBeGreaterThan(chunkIndex);
+  });
+
+  test('observeLocalPtyOutput is NOT called when the local write fails', () => {
+    // Close the writable fd and reopen the same path read-only so the write
+    // throws EBADF -- a real, not simulated, write failure.
+    fs.closeSync(outFd);
+    outFd = fs.openSync(outPath, 'r');
+    setPtyStdoutFd(outFd);
+
+    let observed = false;
+    const pty = createPtySessionForSession(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        outputProcessor,
+        wsPort: 9999,
+        sendMessage: () => {},
+        cleanup: async () => {},
+        observeLocalPtyOutput: () => {
+          observed = true;
+        },
+      },
+      { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: true },
+    );
+
+    invokeOnRawData(pty, new TextEncoder().encode('data that cannot be written'));
+
+    expect(observed).toBe(false);
+  });
+
+  test('onRawData does not write or observe when passThrough is false', () => {
+    const observedChunks: Uint8Array[] = [];
+    const pty = createPtySessionForSession(
+      {
+        sessionRegistry,
+        sessionStore,
+        liveSessionsRegistry,
+        outputProcessor,
+        wsPort: 9999,
+        sendMessage: () => {},
+        cleanup: async () => {},
+        observeLocalPtyOutput: (data) => observedChunks.push(data),
+      },
+      { sessionId: SID, workingDirectory: tmpDir, extraArgs: [], passThrough: false },
+    );
+
+    invokeOnRawData(pty, new TextEncoder().encode('daemon-mode chunk'));
+
+    expect(fs.readFileSync(outPath, 'utf-8')).toBe('');
+    expect(observedChunks).toHaveLength(0);
   });
 });
 

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -343,20 +343,36 @@ describe('StatusBar', () => {
   });
 
   test('repaints are suppressed while a question stays live, after the onset paint', () => {
-    const { bar, writes } = harness({ hasLiveQuestions: () => true });
+    // #932 review finding 4: status content must vary DURING the freeze, or
+    // this can't distinguish "the suppression guard held" from "nothing
+    // changed so the dedup check alone produced the same write count" --
+    // neutering `if (questionLive && !onset) return;` previously left this
+    // green because mkStatus() never changed between calls.
+    let connections = 0;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      getStatus: () => mkStatus({ connections: connections++ }),
+    });
     bar.render(); // onset: paints once
     expect(writes).toHaveLength(1);
-    bar.render(); // still live: frozen
-    bar.render(); // still live: frozen
+    bar.render(); // still live: frozen, despite connections having changed
+    bar.render(); // still live: frozen again
     expect(writes).toHaveLength(1);
   });
 
   test('repaints resume once the question resolves', () => {
+    // Same fix as above: content changes on every getStatus() read so a
+    // neutered suppression guard would produce an extra write during the
+    // freeze, not just the same count by coincidence.
     let live = true;
-    const { bar, writes } = harness({ hasLiveQuestions: () => live });
+    let connections = 0;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => live,
+      getStatus: () => mkStatus({ connections: connections++ }),
+    });
     bar.render(); // onset paint
     expect(writes).toHaveLength(1);
-    bar.render(); // frozen
+    bar.render(); // frozen, despite connections having changed
     expect(writes).toHaveLength(1);
     live = false;
     bar.render(); // resumes

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -442,3 +442,198 @@ describe('StatusBar', () => {
     expect(writes).toHaveLength(1);
   });
 });
+
+// #932 durable fix: the quiescence + clean-boundary gate. `isBoundaryClean`
+// and `isQuiescent` default to always-true in the harness (matching
+// StatusBar's own fail-open defaults), so every test below opts in
+// explicitly -- proving these tests actually exercise the new guards rather
+// than merely coinciding with the pre-gate behavior every other test above
+// already covers.
+describe('StatusBar — #932 durable fix (quiescence + clean-boundary gate)', () => {
+  function harness(overrides: Partial<StatusBarDeps> = {}) {
+    const writes: string[] = [];
+    const logs: string[] = [];
+    const deps: StatusBarDeps = {
+      getStdoutFd: () => 1,
+      getStatus: () => mkStatus(),
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => NOW_MS,
+      log: (m) => logs.push(m),
+      intervalMs: 5,
+      ...overrides,
+    };
+    return { bar: new StatusBar(deps), writes, logs };
+  }
+
+  test('render refuses to write while isBoundaryClean is false', () => {
+    const { bar, writes } = harness({ isBoundaryClean: () => false });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('render writes once the boundary becomes clean', () => {
+    let clean = false;
+    const { bar, writes } = harness({ isBoundaryClean: () => clean });
+    bar.render();
+    expect(writes).toHaveLength(0);
+    clean = true;
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('a routine (content-changed) paint is refused while not quiescent, then happens once quiescent', () => {
+    // The very first render() is itself heartbeat-due (lastWriteAtMs is
+    // still null), so it bypasses quiescence like any other forced paint --
+    // same as before this fix. The gate under test here is a SECOND paint
+    // triggered only by a content change, well inside HEARTBEAT_MS.
+    let quiescent = false;
+    let connections = 0;
+    const { bar, writes } = harness({
+      isQuiescent: () => quiescent,
+      getStatus: () => mkStatus({ connections: connections++ }),
+    });
+    bar.render(); // first-ever paint: heartbeat-due, bypasses quiescence
+    expect(writes).toHaveLength(1);
+    bar.render(); // content changed again, but not quiescent: refused
+    expect(writes).toHaveLength(1);
+    quiescent = true;
+    bar.render(); // now quiescent: the routine paint proceeds
+    expect(writes).toHaveLength(2);
+    // Content keeps changing but quiescence drops again: refused once more.
+    quiescent = false;
+    bar.render();
+    expect(writes).toHaveLength(2);
+  });
+
+  test('an unchanged status still does not write a second time even when quiescent (dedup unaffected)', () => {
+    const { bar, writes } = harness({ isQuiescent: () => true });
+    bar.render();
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('the onset paint bypasses the quiescence gate but still honors the boundary gate', () => {
+    // Onset must fire the instant a question goes live, even mid-burst --
+    // see status-bar.ts's HEARTBEAT_MS doc for why the soft gate has
+    // documented exceptions.
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      isQuiescent: () => false,
+      isBoundaryClean: () => true,
+    });
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('the onset paint does NOT bypass the boundary gate', () => {
+    // The hard gate has no exceptions -- not even onset. Regression guard:
+    // if someone "simplifies" render() by exempting onset from the boundary
+    // check too, this must go red.
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      isQuiescent: () => true,
+      isBoundaryClean: () => false,
+    });
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('the resumed paint bypasses the quiescence gate but still honors the boundary gate', () => {
+    let live = true;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => live,
+      isQuiescent: () => false,
+      isBoundaryClean: () => true,
+    });
+    bar.render(); // onset
+    expect(writes).toHaveLength(1);
+    live = false;
+    bar.render(); // resumed, still not quiescent
+    expect(writes).toHaveLength(2);
+  });
+
+  test('a heartbeat repaint bypasses the quiescence gate but still honors the boundary gate', () => {
+    let nowMs = NOW_MS;
+    const { bar, writes } = harness({ now: () => nowMs, isQuiescent: () => false });
+    bar.render();
+    expect(writes).toHaveLength(1);
+    nowMs += HEARTBEAT_MS; // heartbeat due; PTY still "active" (not quiescent)
+    bar.render();
+    expect(writes).toHaveLength(2);
+  });
+
+  test('a heartbeat repaint does NOT bypass the boundary gate', () => {
+    // Regression guard for the interaction called out in HEARTBEAT_MS's doc:
+    // the heartbeat must never force a write at a dirty boundary, even
+    // though it is exempt from the (safe) quiescence gate.
+    let nowMs = NOW_MS;
+    const { bar, writes } = harness({ now: () => nowMs, isBoundaryClean: () => false });
+    bar.render();
+    expect(writes).toHaveLength(0);
+    nowMs += HEARTBEAT_MS;
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('notifyScrollRegionReset paints immediately, bypassing the quiescence gate', () => {
+    const { bar, writes } = harness({ isQuiescent: () => false, isBoundaryClean: () => true });
+    bar.notifyScrollRegionReset();
+    expect(writes).toHaveLength(1);
+  });
+
+  test('notifyScrollRegionReset stays pending and retries once the boundary clears', () => {
+    let clean = true;
+    let quiescent = true;
+    const { bar, writes } = harness({
+      isQuiescent: () => quiescent,
+      isBoundaryClean: () => clean,
+    });
+    // Get an ordinary first paint in so lastWriteAtMs is set -- otherwise
+    // every following render() would ALSO be "heartbeat due" (lastWriteAtMs
+    // still null) regardless of forceRepaintPending, and the test below
+    // would not actually prove the pending flag is what triggers the write.
+    bar.render();
+    expect(writes).toHaveLength(1);
+    // Now block both the boundary and quiescence, and go dirty; the
+    // immediate attempt inside notifyScrollRegionReset must be refused.
+    clean = false;
+    quiescent = false;
+    bar.notifyScrollRegionReset();
+    expect(writes).toHaveLength(1);
+    bar.render(); // still dirty, still not quiescent, unchanged content: no write
+    expect(writes).toHaveLength(1);
+    // Boundary clears, but quiescence and content still would not justify a
+    // routine write on their own (unchanged status, heartbeat not due,
+    // still not quiescent) -- only the pending flag can explain a write now.
+    clean = true;
+    bar.render();
+    expect(writes).toHaveLength(2);
+  });
+
+  test('a transition during a dirty-boundary window still paints once the boundary clears', () => {
+    // Mirrors the room-too-short guard-ordering test: the boundary gate must
+    // sit in the same "cannot physically paint" group as the fd/room checks,
+    // BEFORE hasLiveQuestions() is read -- otherwise a question transition
+    // landing while the boundary is dirty gets consumed with no write to
+    // show for it, and the bar freezes on stale content once the boundary
+    // clears (the exact bug the ordering exists to prevent).
+    let clean = false;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      isBoundaryClean: () => clean,
+    });
+    bar.render(); // question already live, but boundary dirty: no paint, no consumption
+    expect(writes).toHaveLength(0);
+    clean = true;
+    bar.render(); // onset must still fire now
+    expect(writes).toHaveLength(1);
+  });
+
+  test('omitting isBoundaryClean/isQuiescent keeps pre-durable-fix behavior (always paintable)', () => {
+    const { bar, writes } = harness({});
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #932. Builds on PR #933 (mitigation: suppression, dedup, heartbeat,
edge-triggered paints) with the durable fix the issue's correction comment
calls for: a **quiescence + clean-boundary gate**, not a write queue (that
was considered and explicitly withdrawn on #932 -- both writers are
synchronous `fs.writeSync` on one thread, so there is no concurrency to
serialize).

- `PtyQuiescenceGate` (`packages/daemon/src/cli/pty-quiescence-gate.ts`): a
  small state-machine scanner over PTY chunks actually forwarded to a
  terminal fd. Tracks two things:
  - `isBoundaryClean()` -- HARD gate. False while the last chunk left the
    stream inside an unterminated ESC/CSI/OSC(DCS/SOS/PM/APC) sequence.
  - `isQuiescent()` -- SOFT gate. False until `QUIESCENCE_MS` (500ms,
    measured -- see below) has passed since the last chunk.
  - `observe()` also reports a completed **bare** `ESC[r` (DECSTBM
    full-screen scroll-region reset, confirmed in the 2.1.220 binary) so
    the caller can force an immediate repaint.
- `StatusBar.render()` (`status-bar.ts`) now checks `isBoundaryClean()`
  unconditionally, before `hasLiveQuestions()` is even read -- same "cannot
  physically paint" group as the existing fd/room guards, same ordering
  reason (a transition landing on an unpaintable tick must never be
  consumed). No exception exists for this gate: not onset, not resumed, not
  the heartbeat.
  `isQuiescent()` gates only a *routine* (content-changed, non-edge,
  non-heartbeat) paint. Onset, resumed, the heartbeat, and a new
  `notifyScrollRegionReset()` call all bypass it (documented in
  `HEARTBEAT_MS`'s doc: the heartbeat still fires within `HEARTBEAT_MS`
  regardless of how busy the PTY is, so it can never be starved by this
  gate).
- Both PTY-forwarding call sites feed the gate and wire it into their own
  `StatusBar`:
  - wrapper: `pty-session-setup.ts`'s `onRawData` -> new
    `observeLocalPtyOutput` dep -> `cli.ts`'s module-level `wrapperPtyGate`.
  - attach client: `attach-client.ts`'s `writeRawBytes` -> its own
    per-attach-cycle `ptyGate`.

Makes mode 1 (paint landing at a boundary that splits one of Claude's own
escape sequences) **structurally impossible**, and drives mode 2 (landing
inside a save/restore pair that spans a quiet gap) to negligible, per the
issue's corrected mechanism. The residual (mode 2 not fully closed without
a full VT state model) is documented as accepted, same as #932's write-up.

## T = 500ms, measured

The issue is explicit that T must come from a real capture, not a guess.
Instrumented the actual forwarding mechanism: spawned the real `claude`
2.1.220 binary under Bun's native `Bun.spawn({ terminal })` API -- the
exact API `PTYSession` uses in production -- and recorded the wall-clock
arrival time of every PTY data chunk across six real conversational turns
(plain-text replies at `--model haiku --effort low` for speed, plus
tool-use turns: Read an existing file, Edit it, list a directory).

- 372 inter-chunk gaps recorded total.
- 364 landed inside an actively-streaming turn ("active"); 8 were the idle
  gap between turns waiting on the next API round-trip ("idle").
- The two populations separate cleanly, roughly 10x apart:
  - active-burst gaps (ms): min 0.00, p50 84.9, p75 110.6, p90 122.4,
    p95 209.2, p99 239.5, p99.5 334.5, **max 416.55**
  - idle (between-turn) gaps (ms): **min 4099**, up to 5093
- Histogram (ms buckets, all 372 gaps): (0,5]=78, (5,10]=6, (10,20]=18,
  (20,30]=15, (30,50]=31, (50,75]=31, (75,100]=28, (100,150]=133,
  (150,200]=4, (200,300]=18, (300,400]=1, (400,500]=1, (500,750]=0,
  (750,1000]=0, (1000,inf)=8.

`QUIESCENCE_MS = 500` sits ~20% above the highest active-burst gap actually
observed (416.55ms) -- so a routine paint essentially never fires
mid-burst, the intended effect -- and more than 8x below the lowest idle
gap observed (4099ms) -- so once Claude genuinely goes idle, quiescence is
satisfied almost immediately, well inside the existing 2000ms heartbeat
bound. Full methodology and the constant's rationale are in
`pty-quiescence-gate.ts`'s doc comment on `QUIESCENCE_MS`.

Sample size caveat, stated plainly: six turns, one model/effort
combination, one machine, one account. Real Claude Code output could differ
under other models/effort levels or heavier redraw patterns (e.g. very
large diffs) not captured here. The measurement is grounded in genuine
binary chunk timing, not guessed, and the ~10x separation between the two
populations gives comfortable margin in both directions even accounting for
that uncertainty.

## Mutation evidence

Every new guard was neutered, confirmed red for the right reason, restored,
confirmed green:

| Guard | Neutered | Tests gone red | Restored |
|---|---|---|---|
| `StatusBar` hard boundary gate | `if (!this.isBoundaryClean())` -> always false condition | 6 (status-bar.test.ts) | yes, 71/71 green |
| `StatusBar` soft quiescence gate | `if (!bypassesQuiescence && !this.isQuiescent())` -> always false condition | 2 (status-bar.test.ts + attach-client.test.ts) | yes, 71/71 green |
| `StatusBar.notifyScrollRegionReset()` | made a no-op | 3, including the real end-to-end attach-client test | yes, 71/71 green |
| attach-client wiring line (`if (ptyGate.observe(buf)) statusBar?.notifyScrollRegionReset()`) | dropped the trigger, kept `observe()` | exactly 1 (only the targeted ESC[r test; the boundary-suppression test stayed green, proving specificity) | yes, 20/20 green |
| Guard ordering (boundary check moved after `hasLiveQuestions()`/`wasQuestionLive`) | reordered | 1 (the guard-ordering regression test) | yes, 71/71 green |
| `PtyQuiescenceGate` bare-`ESC[r` detection (`&& this.csiParamBytes === 0`) | dropped the params check | 1 (pty-quiescence-gate.test.ts) | yes, 24/24 green |
| `PtyQuiescenceGate.isQuiescent()` | hardcoded `true` | 2 (pty-quiescence-gate.test.ts) | yes, 24/24 green |

No leftover mutation artifacts (`grep -rn "MUTATION-TEST" packages/daemon/src/` is clean).

**Scope note on the wrapper's own wiring** (`cli.ts` / `pty-session-setup.ts`):
`pty-session-setup.test.ts`'s own module doc already disclaims runtime PTY
callback testing ("Runtime callback behavior is exercised by the Docker
integration suite... where a real shell stands in for Claude") since
exercising it would require spawning a real `claude` process. I kept that
boundary rather than refactoring working, reviewed code to make it
independently unit-testable. Confidence in the wrapper wiring instead comes
from: (a) `PtyQuiescenceGate` and `StatusBar`'s gate logic are both
thoroughly unit- and mutation-tested in isolation, (b) the attach client's
wiring is structurally identical (same `observe()` -> `notifyScrollRegionReset()`
-> `isBoundaryClean`/`isQuiescent` pattern) and is proven end-to-end against
the real `StatusBar`/`PtyQuiescenceGate` classes over a real WebSocket, and
(c) a manual read-through of the wrapper diff.

## Interactions preserved (all from PR #933)

- **Heartbeat coupling to the scroll region**: the heartbeat is exempt from
  the soft quiescence gate (documented in `HEARTBEAT_MS`'s doc) but NOT
  from the hard boundary gate -- it still fires within `HEARTBEAT_MS`
  regardless of PTY activity; the only way it could be delayed further is a
  pathologically long unterminated sequence, an accepted residual alongside
  mode 2 (same escape hatches: `MAX_RENDER_ERRORS`, the config kill-switch).
- **Edge-triggered onset/resumed paints** still fire on a question going
  live/resolving, and still bypass quiescence (not the boundary gate --
  that has no exceptions). Existing #933 tests for these are unchanged and
  green.
- **Guard ordering**: fd-null and room-too-short checks (and now the new
  boundary check) all run before `hasLiveQuestions()` is read and
  `wasQuestionLive` is mutated. New regression test proves this
  specifically for the boundary gate.
- Both call sites wired: wrapper (`cli.ts`) and attach client
  (`attach-client.ts`).

## Explicitly not built

A write queue -- considered and withdrawn on #932: no concurrency exists to
serialize (both writers are synchronous on one thread), so it would add
latency machinery that fixes neither the chunk-boundary hazard nor the
cursor-slot collision.

## Test plan

- [x] `bunx biome check` (foreground, clean -- pre-existing unrelated
      `noNonNullAssertion` warnings only, none in touched files)
- [x] `bun run typecheck` (foreground, clean)
- [x] `bun test packages/daemon/tests/cli/` (foreground): 1070 pass, 0 fail
- [x] New tests: a paint refused mid-sequence then allowed once clean; a
      paint refused during active output then allowed once quiescent; a
      bare `ESC[r` triggers an immediate repaint; heartbeat/onset/resumed
      bypass quiescence but not the boundary gate; guard ordering preserved
      for the new gate
- [x] Mutation-proven (see table above)
- [x] Existing #933 tests (heartbeat, onset/resumed, guard ordering,
      suppression) still pass unmodified
