### PR TITLE
Filter Claude Code-injected entries from user chat bubbles

### DIFF
--- a/packages/daemon/src/auto-approve/authority.ts
+++ b/packages/daemon/src/auto-approve/authority.ts
@@ -17,11 +17,12 @@
  * OUTPUT (the same shape the transcript's `<local-command-stdout>` entries
  * show)? Nobody has captured this live yet. Because the premise is
  * unverified, `hook-bridge-setup.ts`'s `UserPromptSubmit` listener also runs
- * `isWrappedNonHumanText` (below) over `input.prompt` before recording it —
- * DEFENSE IN DEPTH, not confirmation. If the premise holds, that check is a
- * permanent no-op costing one substring scan on a human-paced event. If the
- * premise is wrong, it is the thing that catches the wrapped-string shape of
- * the failure (though NOT an output shape with no wrapper tag at all, which
+ * `isWrappedNonHumanText` (`transcript/user-entry-provenance.ts`, imported
+ * below) over `input.prompt` before recording it — DEFENSE IN DEPTH, not
+ * confirmation. If the premise holds, that check is a permanent no-op
+ * costing one substring scan on a human-paced event. If the premise is
+ * wrong, it is the thing that catches the wrapped-string shape of the
+ * failure (though NOT an output shape with no wrapper tag at all, which
  * would need #938's answer to even know exists). Do not read the presence of
  * that filter as evidence the premise was checked.
  *
@@ -30,60 +31,18 @@
  *
  * The transcript JSONL is the FALLBACK, load-bearing for a session the
  * daemon attached to mid-conversation (a resume): its prior turns exist only
- * in the transcript, because `UserPromptSubmit` never fired for them. Measured
- * across real transcripts under `~/.claude/projects/...` (#893 issue thread;
- * corrected after an audit caught a first-pass miscount), a `role: "user"`
- * entry is NOT reliably a human-typed prompt:
- *
- *   | shape                                              | count |
- *   |------------------------------------------------------|-------|
- *   | content: [ {type: tool_result} ]                     | 5,518 |
- *   | content: <string>, isMeta absent -> genuinely typed  |   703 |
- *   | content: <string>, isMeta: true                      |    88 |
- *   | content: <string> starting <command-name>            |    36 |
- *   | content: <string> starting <local-command-stdout>    |    34 |
- *
- * The `isMeta: true` row breaks down as: 47 "Another Claude session sent a
- * message: <agent-message from=\"...\">..." (a SUBAGENT's own authored text,
- * delivered in a plain "user"-role string entry), 35 `<local-command-caveat>`
- * notices, 5 scheduled/heartbeat task prompts, and 2 `<system-reminder>`.
- *
- * TWO SEPARATE MECHANISMS handle this, because ONE discriminator does not
- * cover both hazards:
- *
- * 1. **`tool_result`** is excluded structurally by shape: it is array-shaped
- *    and carries no top-level `text` block (`extractUserEntryText` below,
- *    mirroring `transcript-message-bridge.ts`'s `extractTextContent`). No
- *    flag needed.
- * 2. **The `isMeta: true` cohort** (agent messages, local-command-caveat,
- *    scheduled tasks, system-reminders) IS structurally separable — Claude
- *    Code stamps every one of these `isMeta: true` at the entry's top level
- *    (`transcript/types.ts`). This is the important one to get right: an
- *    `<agent-message>` entry is a SUBAGENT's own words in a user envelope —
- *    filtering ONLY on `role === "user"` + `typeof content === "string"`
- *    would let a subagent write its own authority, a more direct injection
- *    than anything requiring human action. `extractUserEntryText` checks
- *    `entry.isMeta` FIRST, before any content-shape logic, specifically so
- *    this cohort can never slip through by content shape alone.
- * 3. **`<command-name>` and `<local-command-stdout>`** (confirmed: 0 of 36
- *    and 0 of 34 sampled entries carry `isMeta`) are NOT structurally
- *    separable from a genuine prompt at all — same role, same type
- *    (`string`), same shape, no flag. Only the textual wrapper distinguishes
- *    them. `isWrappedNonHumanText` below is a DENYLIST for exactly this
- *    residual case, and denylists fail open: a wrapper tag Claude Code adds
- *    tomorrow sails straight through until someone notices and adds it here.
- *    Whether `<local-command-stdout>` is reachable via a `!`-prefixed bash-
- *    mode command specifically is UNCONFIRMED — the only two samples actually
- *    inspected for this issue ("Goodbye!", "Set model to Fable 5...") are
- *    slash-command output (`/exit`, `/model`), not `!` bash-mode; the general
- *    hazard (this content is Claude-influenceable, not necessarily
- *    human-authored) stands on the samples themselves regardless of exactly
- *    which channel produces it.
- *
- * That asymmetry (isMeta catches one cohort structurally, a denylist catches
- * the other only until it doesn't) is precisely why the hook is the PRIMARY
- * source and this filter only guards the fallback path — see
- * `resolveAuthority`.
+ * in the transcript, because `UserPromptSubmit` never fired for them.
+ * `extractUserEntryText` below is what makes that fallback safe — a
+ * transcript `role: "user"` entry is NOT reliably a human-typed prompt. The
+ * measured breakdown, and the two-mechanism `isMeta` + `isWrappedNonHumanText`
+ * design that handles it, now live in `transcript/user-entry-provenance.ts`'s
+ * module doc — the single source of truth, since the same provenance
+ * question also applies to what `transcript-message-bridge.ts` renders as a
+ * chat message and what `transcript-discovery.ts` shows as a session-list
+ * preview (#936). That asymmetry (isMeta catches one cohort structurally, a
+ * denylist catches the other only until it doesn't) is precisely why the
+ * hook is the PRIMARY source and this filter only guards the fallback path —
+ * see `resolveAuthority`.
  *
  * ## The trust boundary
  *
@@ -100,6 +59,7 @@
  */
 
 import type { ContentBlock, UserEntry } from '../transcript/types.ts';
+import { isWrappedNonHumanText } from '../transcript/user-entry-provenance.ts';
 import { matchSubstringPattern } from './pattern-matcher.ts';
 
 /** Hard caps so a very long session's authority block cannot balloon the
@@ -160,53 +120,16 @@ export class AuthorityStore {
 }
 
 /**
- * Wrapper-tag prefixes that mark a transcript "user"-role STRING entry as
- * something other than genuine human-typed text, for the residual cohort
- * that does NOT carry `isMeta` (confirmed: 0 of 36 `<command-name>` and 0 of
- * 34 `<local-command-stdout>` sampled entries do — see the module doc). A
- * DENYLIST — see the module doc for why that is an accepted, explicitly-named
- * risk here rather than an oversight. `<local-command-caveat>` and
- * `<system-reminder>` are ALSO listed here for defense in depth even though
- * both were observed carrying `isMeta: true` in the sampled data (the
- * `isMeta` check below already excludes them) — belt and suspenders in case
- * a future Claude Code version stops stamping the flag on one of them.
- *
- * `'Another Claude session sent a message:'` is a DIFFERENT shape than the
- * rest of this list: the real captured samples (module doc) put a
- * human-readable preamble sentence BEFORE the `<agent-message from="...">`
- * tag, so the entry does not start with a tag at all — a plain prefix match
- * against `<agent-message` would miss it. This entry matters MORE than the
- * others on the PRIMARY (hook) path specifically: `UserPromptSubmitHookInput`
- * (`hook-types.ts`) carries no `isMeta` field at all — that flag exists only
- * on transcript entries — so if a cross-session agent message is EVER
- * delivered through `UserPromptSubmit.prompt` (unconfirmed; same epistemic
- * status as the `!`-bash-mode question, #938), this literal-sentence prefix
- * is the ONLY defense available on that path. On the transcript fallback it
- * is pure redundancy on top of the `isMeta` check.
+ * `isWrappedNonHumanText` used to be defined here; moved to
+ * `transcript/user-entry-provenance.ts` (#936 review) because it is
+ * fundamentally a transcript user-envelope provenance concern — consumed by
+ * `transcript-message-bridge.ts` and `transcript-discovery.ts` too, neither
+ * of which should depend on the auto-approve policy layer to get it.
+ * Re-exported here (rather than just imported) so existing consumers of
+ * `auto-approve/index.ts` are unaffected. See that module's doc for the
+ * full denylist rationale and the measured breakdown behind it.
  */
-const NON_HUMAN_WRAPPER_PREFIXES: readonly string[] = [
-  '<command-name>',
-  '<command-message>',
-  '<local-command-stdout>',
-  '<local-command-caveat>',
-  '<system-reminder>',
-  'Another Claude session sent a message:',
-];
-
-/** True if a user-role string entry is a wrapped non-human artifact (slash
- *  command echo, `!`-command output, injected reminder) rather than something
- *  the human actually typed.
- *
- *  Also imported directly by `transcript/transcript-message-bridge.ts` and
- *  `transcript/transcript-discovery.ts` (#936) — the same display-provenance
- *  hazard applies to what renders as a user chat bubble and what surfaces as
- *  a session-list preview, not just to the auto-approve authority block.
- *  Import from here rather than redefining the list elsewhere, so all three
- *  call sites can never drift into different denylists. */
-export function isWrappedNonHumanText(text: string): boolean {
-  const trimmed = text.trimStart();
-  return NON_HUMAN_WRAPPER_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
-}
+export { isWrappedNonHumanText } from '../transcript/user-entry-provenance.ts';
 
 /**
  * Extract genuine human-typed text from one transcript user entry, or null
@@ -226,8 +149,9 @@ export function isWrappedNonHumanText(text: string): boolean {
  *    block (Claude's own tool output riding a user envelope) is never
  *    text-typed and so is dropped by construction, not by an extra check.
  * 3. String content -> excluded when wrapper-tagged (the RESIDUAL cohort
- *    `isMeta` does not cover — see `NON_HUMAN_WRAPPER_PREFIXES`); otherwise
- *    it is exactly what a human typed.
+ *    `isMeta` does not cover — see `transcript/user-entry-provenance.ts`'s
+ *    `NON_HUMAN_WRAPPER_PREFIXES`); otherwise it is exactly what a human
+ *    typed.
  */
 export function extractUserEntryText(entry: UserEntry): string | null {
   if (entry.isMeta === true) return null;

--- a/packages/daemon/src/auto-approve/authority.ts
+++ b/packages/daemon/src/auto-approve/authority.ts
@@ -195,7 +195,14 @@ const NON_HUMAN_WRAPPER_PREFIXES: readonly string[] = [
 
 /** True if a user-role string entry is a wrapped non-human artifact (slash
  *  command echo, `!`-command output, injected reminder) rather than something
- *  the human actually typed. */
+ *  the human actually typed.
+ *
+ *  Also imported directly by `transcript/transcript-message-bridge.ts` and
+ *  `transcript/transcript-discovery.ts` (#936) — the same display-provenance
+ *  hazard applies to what renders as a user chat bubble and what surfaces as
+ *  a session-list preview, not just to the auto-approve authority block.
+ *  Import from here rather than redefining the list elsewhere, so all three
+ *  call sites can never drift into different denylists. */
 export function isWrappedNonHumanText(text: string): boolean {
   const trimmed = text.trimStart();
   return NON_HUMAN_WRAPPER_PREFIXES.some((prefix) => trimmed.startsWith(prefix));

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -11,6 +11,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { DiscoverableSession } from '@remi/shared';
+import { isWrappedNonHumanText } from '../auto-approve/authority.ts';
 import type {
   AssistantEntry,
   ContentBlock,
@@ -294,17 +295,28 @@ export class TranscriptDiscovery {
 
           if (entry.type === 'user') {
             const userEntry = entry as UserEntry;
-            let msgContent: string;
-            if (typeof userEntry.message.content === 'string') {
-              msgContent = userEntry.message.content;
-            } else if (Array.isArray(userEntry.message.content)) {
-              const textBlocks = userEntry.message.content.filter(isTextBlock);
-              msgContent = textBlocks[0]?.text || '';
-            } else {
-              msgContent = '';
-            }
-            if (msgContent) {
-              lastMessage = msgContent.length > 100 ? `${msgContent.slice(0, 97)}...` : msgContent;
+            // #936: never surface a Claude Code-injected entry (isMeta:
+            // true — e.g. a subagent's `<agent-message from="...">` report)
+            // or the residual non-isMeta wrapper cohort (`<command-name>`,
+            // `<local-command-stdout>`) as the session-list preview. Same
+            // filter as `TranscriptMessageBridge.handleUserEntry`, imported
+            // from `auto-approve/authority.ts` so both stay in lockstep.
+            if (userEntry.isMeta !== true) {
+              let msgContent: string;
+              if (typeof userEntry.message.content === 'string') {
+                msgContent = isWrappedNonHumanText(userEntry.message.content)
+                  ? ''
+                  : userEntry.message.content;
+              } else if (Array.isArray(userEntry.message.content)) {
+                const textBlocks = userEntry.message.content.filter(isTextBlock);
+                msgContent = textBlocks[0]?.text || '';
+              } else {
+                msgContent = '';
+              }
+              if (msgContent) {
+                lastMessage =
+                  msgContent.length > 100 ? `${msgContent.slice(0, 97)}...` : msgContent;
+              }
             }
           }
         } catch {

--- a/packages/daemon/src/transcript/transcript-discovery.ts
+++ b/packages/daemon/src/transcript/transcript-discovery.ts
@@ -11,7 +11,6 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { DiscoverableSession } from '@remi/shared';
-import { isWrappedNonHumanText } from '../auto-approve/authority.ts';
 import type {
   AssistantEntry,
   ContentBlock,
@@ -19,6 +18,7 @@ import type {
   TranscriptEntry,
   UserEntry,
 } from './types.ts';
+import { isWrappedNonHumanText } from './user-entry-provenance.ts';
 
 /** Type predicate for TextBlock content blocks */
 function isTextBlock(block: ContentBlock): block is TextBlock {
@@ -300,7 +300,7 @@ export class TranscriptDiscovery {
             // or the residual non-isMeta wrapper cohort (`<command-name>`,
             // `<local-command-stdout>`) as the session-list preview. Same
             // filter as `TranscriptMessageBridge.handleUserEntry`, imported
-            // from `auto-approve/authority.ts` so both stay in lockstep.
+            // from `./user-entry-provenance.ts` so both stay in lockstep.
             if (userEntry.isMeta !== true) {
               let msgContent: string;
               if (typeof userEntry.message.content === 'string') {

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -12,8 +12,8 @@
 import type { Message, TranscriptContentBlock, TranscriptContentMessage, UUID } from '@remi/shared';
 import { createTranscriptContent, generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
-import { isWrappedNonHumanText } from '../auto-approve/authority.ts';
 import type { AssistantEntry, ContentBlock, UserEntry } from './types.ts';
+import { isWrappedNonHumanText } from './user-entry-provenance.ts';
 
 /** Configuration for TranscriptMessageBridge */
 export interface TranscriptMessageBridgeConfig {
@@ -138,14 +138,15 @@ export class TranscriptMessageBridge {
    * `<agent-message from="...">` text in an agent-team session, which
    * otherwise renders in the chat view as a message the human sent (measured
    * across real transcripts: 47 of 88 `isMeta: true` entries were exactly
-   * this shape — see `auto-approve/authority.ts`'s module doc for the full
-   * breakdown). This mirrors that module's `extractUserEntryText`: `isMeta`
-   * is checked FIRST and unconditionally, before any content-shape logic,
-   * then the residual `isWrappedNonHumanText` denylist catches the cohort
+   * this shape — see `user-entry-provenance.ts`'s module doc for the full
+   * breakdown). This mirrors that module's design (also used by
+   * `auto-approve/authority.ts`'s `extractUserEntryText`): `isMeta` is
+   * checked FIRST and unconditionally, before any content-shape logic, then
+   * the residual `isWrappedNonHumanText` denylist catches the cohort
    * (`<command-name>`, `<local-command-stdout>`) that is NOT stamped
-   * `isMeta` at all. `isWrappedNonHumanText` is imported from `authority.ts`
-   * rather than redefined here so the two call sites can never drift into
-   * two different denylists.
+   * `isMeta` at all. `isWrappedNonHumanText` is imported from
+   * `user-entry-provenance.ts` rather than redefined here so all call sites
+   * can never drift into different denylists.
    *
    * SKIP, not tag: an excluded entry is dropped outright (marked processed,
    * no message emitted) rather than shipped with a provenance flag for

--- a/packages/daemon/src/transcript/transcript-message-bridge.ts
+++ b/packages/daemon/src/transcript/transcript-message-bridge.ts
@@ -12,6 +12,7 @@
 import type { Message, TranscriptContentBlock, TranscriptContentMessage, UUID } from '@remi/shared';
 import { createTranscriptContent, generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../api/message-api.ts';
+import { isWrappedNonHumanText } from '../auto-approve/authority.ts';
 import type { AssistantEntry, ContentBlock, UserEntry } from './types.ts';
 
 /** Configuration for TranscriptMessageBridge */
@@ -130,6 +131,31 @@ export class TranscriptMessageBridge {
   /**
    * Handle a user entry from TranscriptWatcher.
    * Emits a TranscriptContentMessage for user messages.
+   *
+   * Provenance filtering (#936): Claude Code stamps `isMeta: true` at the
+   * entry's top level on "user"-role entries IT injected rather than
+   * something the human typed — most consequentially a subagent's own
+   * `<agent-message from="...">` text in an agent-team session, which
+   * otherwise renders in the chat view as a message the human sent (measured
+   * across real transcripts: 47 of 88 `isMeta: true` entries were exactly
+   * this shape — see `auto-approve/authority.ts`'s module doc for the full
+   * breakdown). This mirrors that module's `extractUserEntryText`: `isMeta`
+   * is checked FIRST and unconditionally, before any content-shape logic,
+   * then the residual `isWrappedNonHumanText` denylist catches the cohort
+   * (`<command-name>`, `<local-command-stdout>`) that is NOT stamped
+   * `isMeta` at all. `isWrappedNonHumanText` is imported from `authority.ts`
+   * rather than redefined here so the two call sites can never drift into
+   * two different denylists.
+   *
+   * SKIP, not tag: an excluded entry is dropped outright (marked processed,
+   * no message emitted) rather than shipped with a provenance flag for
+   * clients to render specially. This matches what the web client already
+   * does for the six pre-existing wrapper tags — `stripProtocolTags` removes
+   * tag and content, and the caller (`App.tsx`) drops the message entirely
+   * when nothing is left — so there is no "render it differently" case being
+   * lost: a rendered bubble was never the intended outcome for this cohort.
+   * Filtering here also fixes every client at once (macOS, iOS, web), not
+   * just the one that happens to run `stripProtocolTags`.
    */
   handleUserEntry(entry: UserEntry): void {
     if (this.processedEntryUuids.has(entry.uuid)) {
@@ -140,13 +166,26 @@ export class TranscriptMessageBridge {
       this.transcriptSessionId = entry.sessionId;
     }
 
+    // Primary defense: see doc comment above.
+    if (entry.isMeta === true) {
+      this.processedEntryUuids.add(entry.uuid);
+      return;
+    }
+
+    const rawContent = entry.message.content;
     const content =
-      typeof entry.message.content === 'string'
-        ? entry.message.content
-        : this.extractTextContent(entry.message.content as readonly ContentBlock[]);
+      typeof rawContent === 'string'
+        ? rawContent
+        : this.extractTextContent(rawContent as readonly ContentBlock[]);
 
     // Skip user entries with no text content (tool_result entries)
     if (!content) {
+      this.processedEntryUuids.add(entry.uuid);
+      return;
+    }
+
+    // Residual defense for the non-isMeta wrapper cohort; see doc above.
+    if (typeof rawContent === 'string' && isWrappedNonHumanText(rawContent)) {
       this.processedEntryUuids.add(entry.uuid);
       return;
     }

--- a/packages/daemon/src/transcript/user-entry-provenance.ts
+++ b/packages/daemon/src/transcript/user-entry-provenance.ts
@@ -1,0 +1,127 @@
+/**
+ * User-envelope provenance — is a transcript "user"-role entry something the
+ * human actually typed, or something Claude Code (or a subagent) put in that
+ * role instead?
+ *
+ * This is a TRANSCRIPT concern, not an auto-approve one: `UserEntry`
+ * (`types.ts`) is structurally identical whether a human typed it or Claude
+ * Code injected it — same `role: "user"`, same `content: string`. This
+ * module is what makes the two distinguishable at all, and it is consumed by
+ * every layer that has its own reason to care:
+ *
+ *  - `transcript-message-bridge.ts`'s `handleUserEntry` — must not render an
+ *    injected entry as a message the human sent (#936).
+ *  - `transcript-discovery.ts` — must not surface an injected entry as a
+ *    session-list preview (#936).
+ *  - `auto-approve/authority.ts`'s `extractUserEntryText` — must not let an
+ *    injected entry (especially a subagent's own words) become "authority"
+ *    the auto-approve prompt trusts as the human's own instruction (#893).
+ *
+ * That last consumer is a POLICY layer built on top of this one, not the
+ * other way round — import direction matters here specifically because a
+ * change to (or removal of) the auto-approve module must never be able to
+ * break transcript ingestion. Originally this lived inside `authority.ts`
+ * and was imported backwards into the transcript module for #936; moved
+ * here on review (same day) once that inversion was noticed.
+ *
+ * Measured across real transcripts under `~/.claude/projects/...` (#893
+ * issue thread; corrected after an audit caught a first-pass miscount), a
+ * `role: "user"` entry is NOT reliably human-typed:
+ *
+ *   | shape                                              | count |
+ *   |------------------------------------------------------|-------|
+ *   | content: [ {type: tool_result} ]                     | 5,518 |
+ *   | content: <string>, isMeta absent -> genuinely typed  |   703 |
+ *   | content: <string>, isMeta: true                      |    88 |
+ *   | content: <string> starting <command-name>            |    36 |
+ *   | content: <string> starting <local-command-stdout>    |    34 |
+ *
+ * The `isMeta: true` row breaks down as: 47 "Another Claude session sent a
+ * message: <agent-message from=\"...\">..." (a SUBAGENT's own authored text,
+ * delivered in a plain "user"-role string entry), 35 `<local-command-caveat>`
+ * notices, 5 scheduled/heartbeat task prompts, and 2 `<system-reminder>`.
+ *
+ * TWO SEPARATE MECHANISMS handle this, because ONE discriminator does not
+ * cover both hazards:
+ *
+ * 1. **`tool_result`** is excluded structurally by shape: it is array-shaped
+ *    and carries no top-level `text` block. No flag needed — every consumer
+ *    above filters to `text`-typed blocks only.
+ * 2. **The `isMeta: true` cohort** (agent messages, local-command-caveat,
+ *    scheduled tasks, system-reminders) IS structurally separable — Claude
+ *    Code stamps every one of these `isMeta: true` at the entry's top level
+ *    (`types.ts`). This is the important one to get right: an
+ *    `<agent-message>` entry is a SUBAGENT's own words in a user envelope —
+ *    filtering ONLY on `role === "user"` + `typeof content === "string"`
+ *    would let a subagent's report render as the human's own chat message,
+ *    or worse, write its own auto-approve authority. Every consumer checks
+ *    `entry.isMeta` FIRST, before any content-shape logic, specifically so
+ *    this cohort can never slip through by content shape alone.
+ * 3. **`<command-name>` and `<local-command-stdout>`** (confirmed: 0 of 36
+ *    and 0 of 34 sampled entries carry `isMeta`) are NOT structurally
+ *    separable from a genuine prompt at all — same role, same type
+ *    (`string`), same shape, no flag. Only the textual wrapper distinguishes
+ *    them. `isWrappedNonHumanText` below is a DENYLIST for exactly this
+ *    residual case, and denylists fail open: a wrapper tag Claude Code adds
+ *    tomorrow sails straight through until someone notices and adds it here.
+ *    Whether `<local-command-stdout>` is reachable via a `!`-prefixed bash-
+ *    mode command specifically is UNCONFIRMED — the only two samples actually
+ *    inspected for this issue ("Goodbye!", "Set model to Fable 5...") are
+ *    slash-command output (`/exit`, `/model`), not `!` bash-mode; the general
+ *    hazard (this content is Claude-influenceable, not necessarily
+ *    human-authored) stands on the samples themselves regardless of exactly
+ *    which channel produces it.
+ *
+ * That asymmetry (isMeta catches one cohort structurally, a denylist catches
+ * the other only until it doesn't) is why `isMeta` is the PRIMARY
+ * discriminator at every call site, with this denylist as a residual /
+ * defense-in-depth layer on top — never the reverse.
+ */
+
+/**
+ * Wrapper-tag prefixes that mark a transcript "user"-role STRING entry as
+ * something other than genuine human-typed text, for the residual cohort
+ * that does NOT carry `isMeta` (confirmed: 0 of 36 `<command-name>` and 0 of
+ * 34 `<local-command-stdout>` sampled entries do — see the module doc). A
+ * DENYLIST — see the module doc for why that is an accepted, explicitly-named
+ * risk here rather than an oversight. `<local-command-caveat>` and
+ * `<system-reminder>` are ALSO listed here for defense in depth even though
+ * both were observed carrying `isMeta: true` in the sampled data (each call
+ * site's `isMeta` check already excludes them) — belt and suspenders in case
+ * a future Claude Code version stops stamping the flag on one of them.
+ *
+ * `'Another Claude session sent a message:'` is a DIFFERENT shape than the
+ * rest of this list: the real captured samples (module doc) put a
+ * human-readable preamble sentence BEFORE the `<agent-message from="...">`
+ * tag, so the entry does not start with a tag at all — a plain prefix match
+ * against `<agent-message` would miss it. This entry matters MORE than the
+ * others on `auto-approve/authority.ts`'s PRIMARY (hook) path specifically:
+ * `UserPromptSubmitHookInput` (`hook-types.ts`) carries no `isMeta` field at
+ * all — that flag exists only on transcript entries — so if a cross-session
+ * agent message is EVER delivered through `UserPromptSubmit.prompt`
+ * (unconfirmed; same epistemic status as the `!`-bash-mode question, #938),
+ * this literal-sentence prefix is the ONLY defense available on that path.
+ * On every other call site here it is pure redundancy on top of the
+ * `isMeta` check.
+ */
+const NON_HUMAN_WRAPPER_PREFIXES: readonly string[] = [
+  '<command-name>',
+  '<command-message>',
+  '<local-command-stdout>',
+  '<local-command-caveat>',
+  '<system-reminder>',
+  'Another Claude session sent a message:',
+];
+
+/** True if a user-role string entry is a wrapped non-human artifact (slash
+ *  command echo, `!`-command output, injected reminder) rather than something
+ *  the human actually typed.
+ *
+ *  Consumed by `transcript-message-bridge.ts`, `transcript-discovery.ts`
+ *  (#936), and `auto-approve/authority.ts` (#893) — import from here rather
+ *  than redefining the list elsewhere, so all three call sites can never
+ *  drift into different denylists. */
+export function isWrappedNonHumanText(text: string): boolean {
+  const trimmed = text.trimStart();
+  return NON_HUMAN_WRAPPER_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}

--- a/packages/daemon/tests/transcript/user-entry-provenance.test.ts
+++ b/packages/daemon/tests/transcript/user-entry-provenance.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for #936: daemon-side provenance filtering of "user"-role transcript
+ * entries Claude Code injected rather than the human actually typing.
+ *
+ * Two call sites are covered:
+ *  - TranscriptMessageBridge.handleUserEntry — the chat-bubble path.
+ *  - TranscriptDiscovery's session-list preview extraction.
+ *
+ * Both must:
+ *  - Drop entries carrying `isMeta: true` (e.g. a subagent's own
+ *    `<agent-message from="...">` report).
+ *  - Drop the residual non-`isMeta` wrapper cohort (`<command-name>`,
+ *    `<local-command-stdout>`, ...) via the SAME `isWrappedNonHumanText`
+ *    denylist `auto-approve/authority.ts` uses, imported rather than
+ *    reimplemented.
+ *  - NEVER drop a genuine, unflagged human prompt. That regression (losing
+ *    the user's own message with no signal) is worse than the bug being
+ *    fixed here, so it gets equal test weight.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { generateId } from '@remi/shared';
+import type { TranscriptContentMessage } from '@remi/shared';
+import { MessageAPI } from '../../src/api/message-api.ts';
+import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
+import { TranscriptMessageBridge } from '../../src/transcript/transcript-message-bridge.ts';
+import type { UserEntry } from '../../src/transcript/types.ts';
+
+function createBridge() {
+  const sid = generateId();
+  const messageApi = new MessageAPI({ sessionId: sid });
+  const transcriptMessages: TranscriptContentMessage[] = [];
+
+  const bridge = new TranscriptMessageBridge({ sessionId: sid }, messageApi, {
+    onTranscriptContent: (msg) => transcriptMessages.push(msg),
+  });
+
+  return { bridge, transcriptMessages };
+}
+
+function makeUserEntry(overrides?: Partial<UserEntry>): UserEntry {
+  return {
+    uuid: overrides?.uuid ?? generateId(),
+    parentUuid: null,
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    type: 'user',
+    message: {
+      role: 'user',
+      content: overrides?.message?.content ?? 'Hello from user',
+    },
+    ...overrides,
+  };
+}
+
+const AGENT_MESSAGE_CONTENT =
+  'Another Claude session sent a message:\n<agent-message from="builder-534"> PR #727 is open and ready for review.';
+
+describe('TranscriptMessageBridge.handleUserEntry provenance filtering (#936)', () => {
+  test('an isMeta: true agent-message entry does not render as a user message', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      isMeta: true,
+      message: { role: 'user', content: AGENT_MESSAGE_CONTENT },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(0);
+    expect(bridge.processedCount).toBe(1); // still marked processed, not re-evaluated
+  });
+
+  test('a genuinely typed prompt (no isMeta) still renders normally', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      message: { role: 'user', content: 'please fix the login bug' },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(1);
+    expect(transcriptMessages[0]?.role).toBe('user');
+    expect(transcriptMessages[0]?.content).toBe('please fix the login bug');
+  });
+
+  test('a genuinely typed prompt with isMeta explicitly false still renders', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      isMeta: false,
+      message: { role: 'user', content: 'what does this function do?' },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(1);
+    expect(transcriptMessages[0]?.content).toBe('what does this function do?');
+  });
+
+  test('a <local-command-caveat> entry (isMeta: true in real samples) is handled', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      isMeta: true,
+      message: {
+        role: 'user',
+        content:
+          '<local-command-caveat>Caveat: this output is not visible to the user</local-command-caveat>',
+      },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(0);
+  });
+
+  test('a <command-name> entry (never carries isMeta) is handled via the residual denylist', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      message: { role: 'user', content: '<command-name>/review-pr</command-name>' },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(0);
+  });
+
+  test('a <local-command-stdout> entry (never carries isMeta) is handled via the residual denylist', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      message: { role: 'user', content: '<local-command-stdout>Goodbye!</local-command-stdout>' },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(0);
+  });
+
+  test('isMeta is checked before content shape, so an isMeta array-content entry is also dropped', () => {
+    const { bridge, transcriptMessages } = createBridge();
+    const entry = makeUserEntry({
+      isMeta: true,
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'scheduled task prompt' }],
+      },
+    });
+
+    bridge.handleUserEntry(entry);
+
+    expect(transcriptMessages.length).toBe(0);
+  });
+});
+
+describe('TranscriptDiscovery session preview provenance filtering (#936)', () => {
+  const TEMP_DIR = path.join(os.tmpdir(), 'remi-test-discovery-provenance');
+
+  function makeProjectDir(): string {
+    const dir = path.join(TEMP_DIR, '-Users-test-project');
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function writeTranscript(dir: string, sessionId: string, entries: object[]): string {
+    const filePath = path.join(dir, `${sessionId}.jsonl`);
+    const content = `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`;
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  function jsonlUserEntry(content: string, isMeta?: boolean): object {
+    return {
+      type: 'user',
+      uuid: crypto.randomUUID(),
+      parentUuid: null,
+      sessionId: 'test',
+      timestamp: new Date().toISOString(),
+      ...(isMeta !== undefined && { isMeta }),
+      message: { role: 'user', content },
+    };
+  }
+
+  function jsonlAssistantEntry(text: string): object {
+    return {
+      type: 'assistant',
+      uuid: crypto.randomUUID(),
+      parentUuid: null,
+      sessionId: 'test',
+      timestamp: new Date().toISOString(),
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    };
+  }
+
+  beforeEach(() => {
+    fs.mkdirSync(TEMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+  });
+
+  test('does not surface an isMeta agent-message entry as the last-message preview', () => {
+    const projectDir = makeProjectDir();
+    writeTranscript(projectDir, 'dead-team-session', [
+      jsonlAssistantEntry('starting the review'),
+      jsonlUserEntry(AGENT_MESSAGE_CONTENT, true),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.lastMessage).not.toContain('agent-message');
+    expect(sessions[0]?.lastMessage).not.toContain('Another Claude session sent a message');
+    // Falls back to the last non-meta entry instead of surfacing nothing useful.
+    expect(sessions[0]?.lastMessage).toBe('starting the review');
+  });
+
+  test('a genuinely typed final prompt still becomes the preview', () => {
+    const projectDir = makeProjectDir();
+    writeTranscript(projectDir, 'live-session', [
+      jsonlAssistantEntry('done with the first task'),
+      jsonlUserEntry('now fix the second bug please'),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]?.lastMessage).toBe('now fix the second bug please');
+  });
+
+  test('an isMeta scheduled-task entry with no wrapper markup does not surface as the preview', () => {
+    // Isolates the isMeta guard from the residual isWrappedNonHumanText
+    // denylist: unlike the agent-message/command-name cases above, this
+    // content carries no recognizable wrapper prefix at all, so only the
+    // isMeta check can catch it.
+    const projectDir = makeProjectDir();
+    writeTranscript(projectDir, 'scheduled-task-session', [
+      jsonlAssistantEntry('acknowledged, standing by'),
+      jsonlUserEntry('Check on the deploy status and report back', true),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]?.lastMessage).toBe('acknowledged, standing by');
+  });
+
+  test('a <command-name> final entry (no isMeta) does not surface as the preview', () => {
+    const projectDir = makeProjectDir();
+    writeTranscript(projectDir, 'slash-command-session', [
+      jsonlAssistantEntry('sure, running it now'),
+      jsonlUserEntry('<command-name>/review-pr</command-name>'),
+    ]);
+
+    const discovery = new TranscriptDiscovery({ projectsDir: TEMP_DIR });
+    const sessions = discovery.discoverSessions();
+
+    expect(sessions[0]?.lastMessage).toBe('sure, running it now');
+  });
+});

--- a/packages/web/src/lib/message-filter.ts
+++ b/packages/web/src/lib/message-filter.ts
@@ -63,6 +63,21 @@ const xmlTagPatterns = [
   /<command-message>.*?<\/command-message>/gs,
   /<command-args>.*?<\/command-args>/gs,
   /<system-reminder>.*?<\/system-reminder>/gs,
+  // COMPATIBILITY LAYER, not the primary defense (#936). The daemon now
+  // filters `isMeta: true` entries — including a subagent's own
+  // `<agent-message from="...">` report — before they ever reach a client
+  // (`TranscriptMessageBridge.handleUserEntry`). This pattern only matters
+  // when talking to an older daemon that still ships that entry as a raw
+  // string. Real captured samples put a human-readable preamble sentence
+  // BEFORE the tag ("Another Claude session sent a message:\n<agent-message
+  // from=\"...\">..."), so the entry does not start with the tag at all — a
+  // bare `<agent-message` prefix match would miss every real sample. Match
+  // the preamble sentence instead, same convention (and the same literal
+  // string) as `auto-approve/authority.ts`'s `NON_HUMAN_WRAPPER_PREFIXES` on
+  // the daemon side, so the two never drift apart. Strips to the end of the
+  // string rather than requiring a closing `</agent-message>` tag, because
+  // whether one is ever present is unconfirmed (#936 "Not verified").
+  /Another Claude session sent a message:[\s\S]*$/g,
 ];
 
 /**


### PR DESCRIPTION
## Summary

- `TranscriptMessageBridge.handleUserEntry` now skips `isMeta: true` transcript entries outright before they ever become a `sender: 'user'` message, plus the residual non-`isMeta` wrapper cohort (`<command-name>`, `<local-command-stdout>`) via the same `isWrappedNonHumanText` denylist. This is the daemon-side fix — it protects every client (web, macOS, iOS), not just the one running the web denylist.
- `TranscriptDiscovery`'s session-list preview extraction gets the identical filter, so a dead agent-team session no longer shows "Another Claude session sent a message: ..." as its summary.
- `packages/web/src/lib/message-filter.ts` gets a compatibility-layer pattern for `agent-message`, explicitly documented as belt-and-braces for older daemons, not the primary defense. Real `<agent-message>` entries carry a preamble sentence *before* the tag (`Another Claude session sent a message:\n<agent-message from="...">`), so it matches that literal sentence rather than a bare tag prefix that would miss every real sample, and strips to end-of-string since whether a closing tag exists is unconfirmed.
- `isWrappedNonHumanText` / `NON_HUMAN_WRAPPER_PREFIXES` live in **`packages/daemon/src/transcript/user-entry-provenance.ts`** (moved there mid-review — see below), imported by all three call sites (`handleUserEntry`, `TranscriptDiscovery`, `auto-approve/authority.ts`'s `extractUserEntryText`) so the denylist can never fork into two conventions.

## Skip vs. tag decision

Chose **skip**, not tag. Justification (documented in the code):
- Matches what the web client already does for the six pre-existing wrapper tags: `stripProtocolTags` removes tag+content, and the caller drops the whole message when nothing is left. A rendered bubble was never the intended outcome for this cohort, so there's no "render it differently" case being lost.
- Tagging would require a new protocol field and a new client-side rendering path for content nobody asked to see, for zero behavioral payoff today.
- Skipping fixes every client at once (daemon is the single point all clients read from), which is the whole point of moving this out of a client-side denylist.

## Review fix: dependency direction

First pass imported `isWrappedNonHumanText` from `auto-approve/authority.ts` into the transcript module — reused the existing denylist instead of duplicating it, which was the right instinct, but pointed the dependency the wrong way. Transcript parsing is a lower-level data-ingestion concern; auto-approve is a policy layer built on top of it. As written, a change to (or removal of) auto-approve could break transcript ingestion, and the function lived somewhere a reader looking at `UserEntry` would never think to check.

Fixed by moving `isWrappedNonHumanText` and `NON_HUMAN_WRAPPER_PREFIXES` into `transcript/user-entry-provenance.ts` (alongside `types.ts`, matching the test file already named for that concept). `authority.ts` now imports from there and re-exports the name so its existing consumers (`auto-approve/index.ts`, `hook-bridge-setup.ts`) are unaffected — mechanical move, no behavior change. Re-ran all six mutation scenarios below after the move; every one reproduced the identical pass/fail split.

## Pattern: a test that could not fail

Worth stating explicitly, separate from the fix itself, because the pattern is more useful to the next reader than this instance is: the first `TranscriptDiscovery` `isMeta` mutation produced **0/11 red**, not the expected failure. The sample content I'd used for that test also matched the residual `isWrappedNonHumanText` check, so the test could not distinguish the guard it was named for from the guard behind it — a passing test that was structurally unable to fail for the reason its name claimed. I only found this by mutating *after* writing the test, not by inspecting it or trusting the earlier green run. Fixed by adding an isolating case (an `isMeta` entry with no wrapper markup at all — a plain "scheduled task" style string), which then failed correctly when the guard was neutered.

This repo's `AGENTS.md` ("Verify before you describe") already tracks this failure mode for security *claims*; this is the same shape applied to test *coverage claims*. A test whose assertion happens to pass regardless of the mechanism it names is a claim about coverage that isn't true, and the only way to catch it is to break the thing on purpose and watch what actually goes red.

The over-fire mutations (forcing each guard to fire on a genuine, unflagged prompt, confirming the regression tests catch it) are the same habit pointed the other direction: silently dropping something the human typed is worse than the original bug, and those tests are what prove it cannot happen. Both directions — can the guard fail to protect, and can the guard over-protect — needed an actual red run, not an inspection.

## Mutation evidence

For both `handleUserEntry` and `TranscriptDiscovery`'s preview extraction, each guard was independently neutered, confirmed red for the right specific test(s), then restored and confirmed green. Re-run identically after the dependency-direction fix above, with the same results both times:

- **isMeta guard neutered** (bridge): only the array-content isMeta test went red (1/11) — the string-content isMeta tests are also caught by the residual `isWrappedNonHumanText` check, confirming real defense-in-depth overlap, not redundant no-op code.
- **residual `isWrappedNonHumanText` guard neutered** (bridge): exactly the `<command-name>` and `<local-command-stdout>` tests went red (2/11).
- **isMeta guard forced to over-fire** (bridge, unconditional skip): both "genuinely typed prompt" regression tests went red (2/11) — proves the regression tests actually catch an over-reaching guard, not just a no-op assertion.
- **isMeta guard neutered** (discovery): initially 0/11 red (see "Pattern: a test that could not fail" above) — after adding the isolating test, 1/11 red, for the isolating test specifically.
- **residual `isWrappedNonHumanText` guard neutered** (discovery): the `<command-name>` preview test went red (1/11).
- **isMeta guard forced to over-fire** (discovery, unconditional skip): the genuine-prompt preview test went red (1/11), falling back to a stale earlier message instead of the live one.

All mutations were reverted; final state is 11/11 in the new test file, 84/84 across `packages/daemon/tests/transcript/`.

## Test plan

- [x] `bunx biome check .` — 0 errors (48 pre-existing warnings unrelated, confirmed identical on `develop` baseline)
- [x] `bun run typecheck` — clean
- [x] `bun test packages/daemon/tests/transcript/` — 84 pass, 0 fail
- [x] `bun test packages/daemon/tests/transcript-message-bridge.test.ts packages/daemon/tests/transcript-discovery.test.ts packages/daemon/tests/auto-approve/authority.test.ts packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` — 196 pass, 0 fail (no regressions in existing suites touching the same shared `isWrappedNonHumanText`)
- [x] `cd packages/web && bun run build` — succeeds
- [x] `cd packages/web && bun run lint` — same 3 pre-existing errors/2 warnings as `develop` baseline, none in `message-filter.ts`'s changed lines

Fixes #936.
