### PR TITLE
Unregister SessionStart hook, never dispatched

### DIFF
--- a/docs/claude-code-hook-contract.md
+++ b/docs/claude-code-hook-contract.md
@@ -125,9 +125,12 @@ it can proceed with that action — a stale or slow daemon can make Claude Code
 unable to submit a prompt, create a worktree, or finish a session, purely
 because a hook nobody needed a decision from is still gating the action
 (#203). This is why `HOOK_EVENT_NAMES` (31, type-complete as of this PR) and
-`REMI_REGISTERED_HOOK_EVENTS` (11 when this document landed; **14 since #889**
-added `PermissionDenied`, `Elicitation` and `ElicitationResult`) are and must
-stay two different lists.
+`REMI_REGISTERED_HOOK_EVENTS` (11 when this document landed; 14 after #889
+added `PermissionDenied`, `Elicitation`, `ElicitationResult`; 15 after #893
+added `UserPromptSubmit`; **14 again since #930 unregistered `SessionStart`**
+— Claude Code hard-discards `http`-type hooks for it before dispatch, so
+remi's registration never gated anything and never even reached the wire;
+see "Corpus status" below) are and must stay two different lists.
 
 ### Axis 2: semantic power — varies from zero to full override, per event
 
@@ -208,7 +211,7 @@ above for what it does).
 | `InstructionsLoaded` | — | `file_path, memory_type, load_reason, globs?, trigger_file_path?, parent_file_path?` | — | [B] was typed `source: string`, which **does not exist** in the binary at all |
 | `MessageDisplay` | — | `turn_id, message_id, index, final?, delta?` | Y (`displayContent`, can replace on-screen text) | [B] new type this PR |
 | `Notification` | Y | `message, title?, notification_type` (8-value enum, widened this PR — see below) | Y (context only) | [B][D] |
-| `SessionStart` | Y | `source?, model?, agent_type?, session_title?` | Y | [B][D] `model` was wrongly required; docs explicitly say "not guaranteed to be present." `agent_type`/`session_title` were untyped |
+| `SessionStart` | **N (#930)** | `source?, model?, agent_type?, session_title?` | Y | [B][D] `model` was wrongly required; docs explicitly say "not guaranteed to be present." `agent_type`/`session_title` were untyped. **[B] http-discarded**: Claude Code hard-discards `http`-type hook registrations for `SessionStart`/`Setup` before dispatch — confirmed by binary extraction against 2.1.220, independently corroborated by 5,000+ captured events with zero `SessionStart` records. remi registered it from #886 onward but unregistered it in #930 once this was confirmed; see "Corpus status" below for the full writeup |
 | `Setup` | — | `trigger` | Y (context only) | [B] new type this PR |
 | `SubagentStart` | Y | `agent_type` | Y (context only) | [B] matches pre-existing type |
 | `SessionEnd` | Y | `reason` | — | [B] matches pre-existing type |
@@ -387,10 +390,30 @@ is not evidence about that event. Fixtures for `UserPromptSubmit` (#893),
 `MessageDisplay` (#892) and the task/teammate events cannot exist until their
 registrations land — the drift test grows WITH the epic; it does not precede it.
 
-`SessionStart` is a special case: it is registered and still has zero captures,
+`SessionStart` was a special case worth recording even after the fix: it was
+registered from #886 onward and had zero captures across 5,000+ real events,
 because Claude Code **hard-discards `http`-type registrations for
-`SessionStart`/`Setup`** before dispatch (#930, verified against 2.1.220). Its
-absence is expected, not a gap — do not fabricate a fixture for it.
+`SessionStart`/`Setup`** before dispatch (#930, verified against 2.1.220 by
+binary extraction — exactly one `hook.type==="http"` filter site, gated on
+`r==="SessionStart"||r==="Setup"`, in the generic matched-hooks pipeline
+every event traverses). The registration cost remi nothing at runtime
+(Claude strips the entry before ever making the HTTP call — no roundtrip,
+unlike every other registered event, which DOES gate Claude on a real one);
+the cost was purely epistemic, a registration that read as coverage while
+never firing, which billed real hours in the #886 investigation. remi
+unregistered `SessionStart` in #930 rather than build a `command`-type hook
+to recover it (considered and rejected: a shell string in
+`settings.local.json`, a process spawn per session start, and a second
+registration mechanism, for an instant-vs-dir-poll latency difference on a
+rare path). Session identity never depended on it — the pre-assigned
+`--session-id` (`claude-binding.ts`, ADR 0001) plus the binder's
+`feedSyntheticRotation` no-hooks mirror (#452/#453) were already the
+designed signal — so `SessionStart` simply dropped out of
+`REMI_REGISTERED_HOOK_EVENTS` and, with it, out of `contract-spec.ts`'s
+`EVENT_SPECS`/`EVENTS_WITHOUT_FIXTURES`: its absence from the corpus needs no
+special case anymore, the same as any other never-registered event. It
+remains in `HOOK_EVENT_NAMES` (Claude Code still defines the event; remi
+just declines to pay for a registration it discards).
 
 `PermissionDenied` / `Elicitation` / `ElicitationResult` (registered in #926)
 have no captures yet because each needs a precondition that has not occurred.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -62,14 +62,27 @@
  *
  * This listener block IS the per-session hook router (admit-then-fan-out); a
  * formal HookRouter class is deferred to a later refactor (#470). The function
- * registers 14 hookServer `.on()` listeners — the original 6 (SessionStart,
- * PreToolUse, PostToolUse, Notification, Stop, SessionEnd; PermissionRequest
+ * registers 13 hookServer `.on()` listeners — the original 5 still standing
+ * (PreToolUse, PostToolUse, Notification, Stop, SessionEnd; PermissionRequest
  * is installed separately via `setPermissionResolver`, not `.on()`) plus the 4
  * wired in phase 4 (StopFailure, PostToolUseFailure, SubagentStart, SubagentStop)
  * plus the 3 wired for Q4 (#889: PermissionDenied, Elicitation,
  * ElicitationResult) plus the 1 wired for Q9 (#893: UserPromptSubmit) — and
  * returns void. It runs once per session at createNewSession time, only when
  * a hookServer is configured.
+ *
+ * #930 REMOVES the `SessionStart` listener that used to make this 14 (the
+ * "original 6"): Claude Code hard-discards `http`-type hook registrations for
+ * `SessionStart`/`Setup` before dispatch, confirmed by binary extraction
+ * against 2.1.220 and independently by 5,000+ captured events containing zero
+ * `SessionStart` records, so the listener never ran. Its three legs were each
+ * already covered elsewhere: the restart pre-empt has a designed no-hooks
+ * mirror (`TranscriptBinder.feedSyntheticRotation`, #452/#453), every other
+ * listener below already calls `binder.onHookEvent` as its first line, and
+ * the subagent-context reset + `onSessionInfo` leg (`HookEventBridge.
+ * handleSessionStart`) was deleted outright -- `onSessionInfo` was wired to a
+ * literal no-op regardless. `TranscriptBinder.preemptOnSessionStart` itself
+ * is KEPT; `feedSyntheticRotation` is its only remaining caller.
  *
  * The inline session-binding path this file used to also carry (pre-#453) and
  * the shadow-mode differential wiring (#453 phase 3, commit 3) were deleted in
@@ -542,12 +555,6 @@ export function setupHookBridge(
         messageApi.handleQuestion(question);
       }
     },
-    // The binder's onHookEvent (fired from the SessionStart listener) already
-    // subsumes the bind/rotation this callback used to perform inline (#470).
-    // The bridge still fires it (status/subagent tracking lives on
-    // handlers.onSessionStart), but the binding control plane is the binder's
-    // alone, so there is nothing left to do here.
-    onSessionInfo: () => {},
   });
 
   const handlers = hookBridge.hookHandlers();
@@ -717,7 +724,7 @@ export function setupHookBridge(
   // transcript, so session-id filtering cannot distinguish them.
   //
   // Split policy:
-  //   - `PreToolUse` / `PostToolUse` / `SessionStart`: STATUS updates and
+  //   - `PreToolUse` / `PostToolUse`: STATUS updates and
   //     Task-tool tracking are dropped here so they stay scoped to the main
   //     interactive session. #799: Pre/PostToolUse additionally call
   //     `autoApproveGate.cancelExternallyResolved` (agent-scoped) before
@@ -812,14 +819,6 @@ export function setupHookBridge(
       `[Binder] No pre-assigned claudeSessionId for ${sessionId.slice(0, 8)}; fallback poll + dir-watch not armed`,
     );
   }
-
-  hookServer.on('SessionStart', (input) => {
-    // The binder owns the pre-empt + bind. Pre-empt (flip its own
-    // mainSessionEnded) BEFORE onHookEvent, mirroring the pre-#453 order.
-    binder.preemptOnSessionStart(input);
-    binder.onHookEvent(input);
-    handlers.onSessionStart?.(input);
-  });
 
   hookServer.on('PreToolUse', (input) => {
     binder.onHookEvent(input);

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -39,7 +39,6 @@ import type {
   PostToolUseHookInput,
   PreToolUseHookInput,
   SessionEndHookInput,
-  SessionStartHookInput,
   StopFailureHookInput,
   StopHookInput,
   SubagentStartHookInput,
@@ -51,7 +50,6 @@ import { extractToolQuestion } from './tool-question.ts';
 export interface HookBridgeEvents {
   onStatusChange: (status: AgentStatus, context?: string) => void;
   onQuestion: (question: Question) => void;
-  onSessionInfo: (claudeSessionId: string, transcriptPath: string) => void;
 }
 
 /** Honest Yes/No fallback options (#718): used when a PermissionRequest
@@ -312,7 +310,6 @@ export class HookEventBridge {
       onPostToolUse: (input) => this.handlePostToolUse(input),
       onNotification: (input) => this.handleNotification(input),
       onStop: (input) => this.handleStop(input),
-      onSessionStart: (input) => this.handleSessionStart(input),
       onPermissionRequest: (input) => this.handlePermissionRequest(input),
       onPostToolUseFailure: (input) => this.handlePostToolUseFailure(input),
       onSubagentStart: (input) => this.handleSubagentStart(input),
@@ -401,18 +398,6 @@ export class HookEventBridge {
       // PostToolUse(Task) can't permanently block the user's permission prompts.
       this.subagentContext.reset();
     }
-  }
-
-  handleSessionStart(input: SessionStartHookInput): void {
-    if (!input.session_id || !input.transcript_path) {
-      console.warn(
-        `[HookEventBridge] SessionStart missing required fields: session_id=${input.session_id}, transcript_path=${input.transcript_path}`,
-      );
-      return;
-    }
-    // Reset tracker for a fresh session (also covers daemon restart mid-Task).
-    this.subagentContext.reset();
-    this.events.onSessionInfo(input.session_id, input.transcript_path);
   }
 
   /**

--- a/packages/daemon/src/hooks/hook-types.ts
+++ b/packages/daemon/src/hooks/hook-types.ts
@@ -687,13 +687,36 @@ export type HookEventName = (typeof HOOK_EVENT_NAMES)[number];
  * because responding is free. Anything heavier (an LLM call, a file read, a
  * network hop) must move off the listener — the way `PermissionRequest` does
  * with its hold/park design — before its event is added to this list.
+ *
+ * #930 REMOVES one: `SessionStart` was part of "the original 6" (see the
+ * Q4 comment above) but is deliberately NOT registered as of this issue.
+ * Binary extraction against the installed Claude Code 2.1.220 found exactly
+ * one `hook.type==="http"` filter site, gated on
+ * `r==="SessionStart"||r==="Setup"`, sitting in the generic matched-hooks
+ * pipeline every event traverses -- Claude Code hard-discards `http`-type
+ * hook registrations for these two events before dispatch. Independently
+ * corroborated: 5,000+ captured events (`~/.remi/hook-diag.jsonl`) contain
+ * zero `SessionStart` records. The registration cost remi NOTHING at
+ * runtime (Claude strips the entry before ever making the HTTP call, so no
+ * roundtrip happened, unlike every other event in this list which DOES gate
+ * Claude on a real round trip) -- the entire cost was epistemic: a
+ * registration that reads as coverage while never firing, which billed real
+ * hours in the #886 investigation before anyone checked. Nothing depended on
+ * it: session identity is pre-assigned (`claude-binding.ts`, `--session-id`
+ * at spawn, ADR 0001), and the one live behavior riding the dead listener
+ * (the restart pre-empt, `TranscriptBinder.preemptOnSessionStart`) already
+ * has a designed no-hooks mirror in `feedSyntheticRotation` (#452/#453) that
+ * remains the sole caller going forward. `SessionStart` stays in
+ * `HOOK_EVENT_NAMES` above (Claude Code still defines the event; remi just
+ * declines to pay for a registration it discards) -- see
+ * `docs/claude-code-hook-contract.md` for the full contract-reference
+ * writeup.
  */
 export const REMI_REGISTERED_HOOK_EVENTS = [
   'PreToolUse',
   'PostToolUse',
   'Notification',
   'Stop',
-  'SessionStart',
   'PermissionRequest',
   'PostToolUseFailure',
   'SubagentStart',

--- a/packages/daemon/tests/api/question-identity.test.ts
+++ b/packages/daemon/tests/api/question-identity.test.ts
@@ -155,7 +155,6 @@ function buildPipeline(
         tracker.recordPendingHook(q);
       }
     },
-    onSessionInfo: () => {},
   });
 
   const gate = new AutoApproveGate(

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -391,14 +391,17 @@ describe('setupHookBridge', () => {
     return { tracker, messageApi: localMessageApi };
   }
 
-  test('registers 14 .on() listeners + the synchronous PermissionRequest resolver (#496)', () => {
+  test('registers 13 .on() listeners + the synchronous PermissionRequest resolver (#496)', () => {
     build();
     const events = new Set(hookServer.listeners.keys());
     // PermissionRequest is NO LONGER a .on() listener — it is the synchronous
-    // resolver (#496), installed via setPermissionResolver.
+    // resolver (#496), installed via setPermissionResolver. SessionStart
+    // dropped from 14 to 13 (#930): Claude Code hard-discards http-type hook
+    // registrations for SessionStart/Setup before dispatch, so remi's
+    // registration never fired -- confirmed by 5,000+ captured events with
+    // zero SessionStart records.
     expect(events).toEqual(
       new Set([
-        'SessionStart',
         'PreToolUse',
         'PostToolUse',
         'Notification',
@@ -422,10 +425,18 @@ describe('setupHookBridge', () => {
 
   describe('Q9 (#893): UserPromptSubmit -> authority', () => {
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 
@@ -636,12 +647,20 @@ describe('setupHookBridge', () => {
   });
 
   describe('phase 4 (#453): the 4 previously-dropped events', () => {
-    /** Fire a SessionStart so the bridge locks onto `id` (admit gate then passes). */
+    /** Fire a neutral Notification so the bridge locks onto `id` (admit gate then passes; #930). */
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 
@@ -737,10 +756,12 @@ describe('setupHookBridge', () => {
     // parked record later pairs with a real render.
     const { tracker } = build({ autoApprove: true, autoApproveDecision: 'approve' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-123',
       transcript_path: path.join(tmpDir, 'sub.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // PTY rendered the subagent's prompt on the user's screen.
@@ -774,10 +795,12 @@ describe('setupHookBridge', () => {
     // no agent_id would inject into the parent agent's PTY input.
     build({ autoApprove: true, autoApproveDecision: 'approve' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-nested-1',
       transcript_path: path.join(tmpDir, 'nested.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // Engage nested-Task subagent context (no agent_id, just Task spawn).
@@ -820,10 +843,12 @@ describe('setupHookBridge', () => {
     const bridge = bridgeHandles[bridgeHandles.length - 1]?.bridge;
     if (!bridge) throw new Error('test setup: no bridge handle');
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-leak-1',
       transcript_path: path.join(tmpDir, 'leak.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PreToolUse', {
@@ -854,12 +879,14 @@ describe('setupHookBridge', () => {
   test('PermissionRequest with auto-approve APPROVE returns "allow" (no inject) (#496)', async () => {
     build({ autoApprove: true });
 
-    // Fire SessionStart first so claudeSessionId locks; subsequent events
-    // pass filterBySession.
-    hookServer.fire('SessionStart', {
+    // Fire a neutral Notification first so claudeSessionId locks (#930);
+    // subsequent events pass filterBySession.
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-123',
       transcript_path: path.join(tmpDir, 'does-not-matter.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     const decision = await hookServer.firePermission({
@@ -898,10 +925,12 @@ describe('setupHookBridge', () => {
     // claude-A; events are deferred to the mtime fallback. PreToolUse during
     // this window must also be filtered out (the headline #321 symptom: no
     // [AutoApprove], no status updates).
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-A',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
     expect(transcriptWatchers.has(SID)).toBe(false);
 
@@ -920,10 +949,12 @@ describe('setupHookBridge', () => {
     // Next hook event must now lock onto claude-A and start the watcher.
     // Pre-#321-fix: the cached `hasSiblingInDir=true` from the first call
     // permanently blocked init even after the sibling was gone.
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-A',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
     expect(transcriptWatchers.has(SID)).toBe(true);
 
@@ -944,10 +975,12 @@ describe('setupHookBridge', () => {
     build();
 
     // Acquire the lock cleanly with no siblings present.
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-A',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
     expect(transcriptWatchers.has(SID)).toBe(true);
 
@@ -1273,51 +1306,17 @@ describe('setupHookBridge', () => {
     });
   });
 
-  test('SessionStart with source=clear pre-empts classifier and tears down watcher', () => {
-    build();
-
-    // First lock onto claude-A via a normal SessionStart.
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    // Simulate a live transcript watcher so teardown has something to act on.
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-
-    // Fire SessionStart with source=clear and a DIFFERENT session id.
-    // This pre-empts the classifier into 'restart', tearing down the watcher
-    // and resetting claudeSessionId so the new claude-B can lock.
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-B',
-      transcript_path: path.join(tmpDir, 'b.jsonl'),
-      hook_event_name: 'SessionStart',
-      source: 'clear',
-    });
-
-    // teardown side effects: old watcher stopped, messageApi reset. A new
-    // watcher MAY be registered immediately after (for claude-B), so we
-    // assert only the tear-down signals, not the final map state.
-    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
-    expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
-  });
-
   test('restart (/clear) broadcasts question_resolved for each pending question and clears them (#585 P7)', () => {
     const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
     build({ broadcastResolvedLog });
 
     // Lock onto claude-A.
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-A',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // A question was pushed before the restart (held-hook or hook+PTY path).
@@ -1335,185 +1334,30 @@ describe('setupHookBridge', () => {
     expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
 
     // /clear: a new session_id rotates the binding (restart classification).
-    hookServer.fire('SessionStart', {
+    // #930: SessionStart's own pre-empt is unreachable via hooks now (Claude
+    // Code never sends it), so the rotation here is driven the way it
+    // actually happens post-#930: a real SessionEnd for the OLD id flips
+    // `mainSessionEnded` (`TranscriptBinder.onSessionEnd`), then any
+    // registered event for the NEW id classifies as 'restart'. This is
+    // real production behavior (SessionEnd genuinely fires on a clean exit),
+    // not a synthetic-only substitute.
+    hookServer.fire('SessionEnd', {
+      session_id: 'claude-A',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+    hookServer.fire('Notification', {
       session_id: 'claude-B',
       transcript_path: path.join(tmpDir, 'b.jsonl'),
-      hook_event_name: 'SessionStart',
-      source: 'clear',
+      hook_event_name: 'Notification',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // The pending card is dismissed on every client (broadcast) AND dropped from
     // the registry, so nothing lingers across the rotation.
     expect(broadcastResolvedLog).toEqual([{ questionId: QID, reason: 'cancelled' }]);
     expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
-  });
-
-  // SessionStart restart pre-empt is source-agnostic: any rotation of
-  // session_id while PTY is running fires it. These tests cover the new-
-  // source, undefined-source, same-session_id (must NOT fire), missing
-  // session_id (defensive), and subagent (agent_id set, must NOT fire) axes.
-
-  test('SessionStart with unknown source AND new session_id pre-empts classifier (issue #416)', () => {
-    build();
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-B',
-      transcript_path: path.join(tmpDir, 'b.jsonl'),
-      hook_event_name: 'SessionStart',
-      source: 'switch_chat_future_value',
-    });
-
-    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
-    expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
-
-    hookServer.fire('PreToolUse', {
-      session_id: 'claude-B',
-      tool_name: 'Bash',
-      tool_input: { command: 'ls' },
-    });
-    expect(messageApiLog.statusCalls).toContain('executing');
-  });
-
-  test('SessionStart with undefined source AND new session_id pre-empts classifier (issue #416)', () => {
-    // Some Claude Code versions omit `source` entirely on session transitions.
-    build();
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-B',
-      transcript_path: path.join(tmpDir, 'b.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
-    expect(messageApiLog.resetCalls.n).toBeGreaterThanOrEqual(1);
-
-    hookServer.fire('PreToolUse', {
-      session_id: 'claude-B',
-      tool_name: 'Bash',
-      tool_input: { command: 'ls' },
-    });
-    expect(messageApiLog.statusCalls).toContain('executing');
-  });
-
-  test('SessionStart with same session_id does NOT pre-empt (issue #416)', () => {
-    // Locks the `input.session_id !== claudeSessionId` guard against silent
-    // refactor regression: a duplicate SessionStart for the same session
-    // (e.g. SDK reconnect, source=startup repeat) must be a no-op.
-    build();
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-    const resetsBefore = messageApiLog.resetCalls.n;
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-      source: 'startup',
-    });
-
-    expect(stopCalls.length).toBe(0);
-    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
-  });
-
-  test('SessionStart with missing session_id does NOT pre-empt (issue #416)', () => {
-    // Defensive: malformed/incomplete event must be inert, not tear down.
-    build();
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-    const resetsBefore = messageApiLog.resetCalls.n;
-
-    hookServer.fire('SessionStart', {
-      hook_event_name: 'SessionStart',
-      transcript_path: path.join(tmpDir, 'b.jsonl'),
-    });
-
-    expect(stopCalls.length).toBe(0);
-    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
-  });
-
-  test('SessionStart with agent_id set does NOT pre-empt even on session_id mismatch (issue #416)', () => {
-    // isSubagentEvent guard: a subagent firing SessionStart with its own
-    // session_id (hypothetical future Claude Code shape) must not tear down
-    // main's watcher. Closes the gap the pre-PR narrow `source` gate covered
-    // by accident.
-    build();
-
-    hookServer.fire('SessionStart', {
-      session_id: 'claude-A',
-      transcript_path: path.join(tmpDir, 'a.jsonl'),
-      hook_event_name: 'SessionStart',
-    });
-
-    const stopCalls: number[] = [];
-    transcriptWatchers.set(SID, {
-      filePath: path.join(tmpDir, 'a.jsonl'),
-      stop: () => {
-        stopCalls.push(1);
-      },
-    } as never);
-    const resetsBefore = messageApiLog.resetCalls.n;
-
-    hookServer.fire('SessionStart', {
-      session_id: 'subagent-B',
-      transcript_path: path.join(tmpDir, 'b.jsonl'),
-      hook_event_name: 'SessionStart',
-      agent_id: 'subagent-id-xyz',
-    });
-
-    expect(stopCalls.length).toBe(0);
-    expect(messageApiLog.resetCalls.n).toBe(resetsBefore);
   });
 
   // -------------------------------------------------------------------------
@@ -1536,12 +1380,12 @@ describe('setupHookBridge', () => {
     // labels onto unrelated future PTY prompts.
     const { tracker } = build({ realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-wire-1',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'wire.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1571,12 +1415,12 @@ describe('setupHookBridge', () => {
     // prompt. Two reviewers flagged this on PR #423.
     const { tracker } = build({ realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-restart-A',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'a.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1588,15 +1432,23 @@ describe('setupHookBridge', () => {
 
     expect(tracker.hasPendingForTest()).toBe(true);
 
-    // Restart fires (e.g. user typed /clear). Classifier returns
-    // 'restart' because session_id mismatch + source is treated as
-    // restart-evidence by phase 1.
-    hookServer.fire('SessionStart', {
+    // Restart fires (e.g. user typed /clear). #930: SessionStart's own
+    // pre-empt is unreachable via hooks now, so the rotation is driven the
+    // way it actually happens post-#930: a real SessionEnd for the OLD id
+    // flips `mainSessionEnded`, then any registered event for the NEW id
+    // classifies as 'restart' (see the (#585 P7) test above for the same
+    // substitution and its rationale).
+    hookServer.fire('SessionEnd', {
+      session_id: 'claude-restart-A',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    });
+    hookServer.fire('Notification', {
       session_id: 'claude-restart-B',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'b.jsonl'),
-      source: 'clear',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     expect(tracker.hasPendingForTest()).toBe(false);
@@ -1614,12 +1466,12 @@ describe('setupHookBridge', () => {
       realTracker: true,
     });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-cancel',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'c.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1643,12 +1495,12 @@ describe('setupHookBridge', () => {
     // pending slot, or a final PTY echo could fire a spurious push.
     const { tracker } = build({ realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-late-1',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'late.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('SessionEnd', {
@@ -1679,12 +1531,12 @@ describe('setupHookBridge', () => {
       autoApprovePickIndex: 2,
     });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-pick',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'pick.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1736,12 +1588,12 @@ describe('setupHookBridge', () => {
       ),
     );
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-mixed',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'mixed.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // No auto-approve: the listener falls through to escalateToUser,
@@ -1817,12 +1669,12 @@ describe('setupHookBridge', () => {
       ),
     );
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-A',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subA.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1892,12 +1744,12 @@ describe('setupHookBridge', () => {
       ),
     );
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-B',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subB.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PermissionRequest', {
@@ -1953,12 +1805,12 @@ describe('setupHookBridge', () => {
     // PermissionRequest leaves the tracker with nothing pending at all.
     const { tracker } = build({ realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-N',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subN.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('Notification', {
@@ -1990,12 +1842,12 @@ describe('setupHookBridge', () => {
       orphanDebounceMs: 5,
     });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-890-unpaired',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'unpaired.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // No PermissionRequest -- this is the unpaired case by construction.
@@ -2050,12 +1902,12 @@ describe('setupHookBridge', () => {
     // stores the question and waits for a render, it does not push.
     build({ autoApprove: true, autoApproveDecision: 'approve', realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-AA',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subAA.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     const decision = await hookServer.firePermission({
@@ -2084,12 +1936,12 @@ describe('setupHookBridge', () => {
     // render, via the parked record.
     const { tracker } = build({ autoApprove: true, autoApproveDecision: 'approve' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-hot',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subhot.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // PTY rendered the subagent's prompt on the user's screen.
@@ -2122,12 +1974,12 @@ describe('setupHookBridge', () => {
     // the approve case above.
     build({ autoApprove: true, autoApproveDecision: 'deny', realTracker: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-deny',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subdeny.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     const decision = await hookServer.firePermission({
@@ -2147,12 +1999,12 @@ describe('setupHookBridge', () => {
   test('#807: a PTY-visible prompt does not make a subagent deny either', async () => {
     const { tracker } = build({ autoApprove: true, autoApproveDecision: 'deny' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-sub-deny-hot',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'subdenyhot.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     tracker.onPTYPromptVisible({
@@ -2189,12 +2041,12 @@ describe('setupHookBridge', () => {
     // silent main-agent deny. The bridge resets the tracker and escalates as main.
     build({ autoApprove: true, autoApproveDecision: 'escalate' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-esc-task',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'esctask.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     // Open a synchronous Task context.
@@ -2223,12 +2075,12 @@ describe('setupHookBridge', () => {
     // Mirrors the escalate case above for the eval-error (.catch) branch.
     build({ autoApprove: true, autoApproveThrows: true });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-throws-task',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'throws-task.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PreToolUse', {
@@ -2254,12 +2106,12 @@ describe('setupHookBridge', () => {
     // Mirrors the escalate case above for the no-service branch.
     build(); // no autoApprove
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-noaa-task',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'noaatask.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PreToolUse', {
@@ -2290,12 +2142,12 @@ describe('setupHookBridge', () => {
     // only if Claude's native prompt renders on the PTY.
     build({ autoApprove: true, autoApproveDecision: 'escalate' });
 
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-esc-task-tagged',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'esctask-tagged.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
 
     hookServer.fire('PreToolUse', {
@@ -2335,12 +2187,12 @@ describe('setupHookBridge', () => {
     // PreToolUse must not abort it (that dropped decisions about to approve).
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-pre',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     hookServer.fire('PreToolUse', {
       session_id: 'claude-locked-pre',
@@ -2354,12 +2206,12 @@ describe('setupHookBridge', () => {
   test('#537: PostToolUse does NOT cancel the in-flight auto-approve eval', () => {
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-post',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     hookServer.fire('PostToolUse', {
       session_id: 'claude-locked-post',
@@ -2380,12 +2232,12 @@ describe('setupHookBridge', () => {
     // runs, the eval is already tracked as in-flight and main-tagged.
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-stop',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     void hookServer.firePermission({
       session_id: 'claude-locked-stop',
@@ -2407,12 +2259,12 @@ describe('setupHookBridge', () => {
     // not because nothing was in flight.
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-stop-sub',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test-sub.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     void hookServer.firePermission({
       session_id: 'claude-locked-stop-sub',
@@ -2433,12 +2285,12 @@ describe('setupHookBridge', () => {
   test('SessionEnd cancels stale auto-approve LLM eval', () => {
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-end',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     hookServer.fire('SessionEnd', {
       session_id: 'claude-locked-end',
@@ -2453,12 +2305,12 @@ describe('setupHookBridge', () => {
     // cancelling here would defeat auto-approve for slow LLMs.
     const cancelLog: string[] = [];
     build({ autoApprove: true, cancelLog });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-idle',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     hookServer.fire('Notification', {
       session_id: 'claude-locked-idle',
@@ -2476,12 +2328,12 @@ describe('setupHookBridge', () => {
       autoApprove: true,
       autoApproveDecision: 'cancelled',
     });
-    hookServer.fire('SessionStart', {
+    hookServer.fire('Notification', {
       session_id: 'claude-locked-cancel',
-      hook_event_name: 'SessionStart',
+      hook_event_name: 'Notification',
       transcript_path: path.join(tmpDir, 'cancel-test.jsonl'),
-      source: 'startup',
-      model: 'test',
+      notification_type: 'auth_success',
+      message: '',
     });
     hookServer.fire('PermissionRequest', {
       session_id: 'claude-locked-cancel',
@@ -2507,10 +2359,18 @@ describe('setupHookBridge', () => {
   // ---------------------------------------------------------------------------
   describe('#799: subagent question purge', () => {
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 
@@ -2750,10 +2610,18 @@ describe('setupHookBridge', () => {
   // ---------------------------------------------------------------------------
   describe('#889 (Q4): PermissionDenied external resolution', () => {
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 
@@ -2938,10 +2806,18 @@ describe('setupHookBridge', () => {
   // ---------------------------------------------------------------------------
   describe('#889 (Q4): Elicitation / ElicitationResult (real MessageAPI, ADR 0014)', () => {
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 
@@ -3100,262 +2976,7 @@ describe('setupHookBridge', () => {
     });
   });
 
-  describe('session_rotated emission on rotation (#430 #438)', () => {
-    /**
-     * Set up a hook bridge that captures every protocol message it tries
-     * to send. We can't use the shared `build` helper because that swallows
-     * sendAndRecord; rotation emission is the whole point we need to assert
-     * on.
-     */
-    function buildWithCapture(): { sent: import('@remi/shared').ProtocolMessage[] } {
-      const sent: import('@remi/shared').ProtocolMessage[] = [];
-      const tracker = new PassthroughTracker((q) => {
-        messageApiLog.questionCalls += 1;
-        const _ = q;
-      });
-      const handle = setupHookBridge(
-        {
-          sessionRegistry,
-          bindingStore,
-          liveSessionsRegistry,
-          transcriptWatchers: transcriptWatchers as unknown as Map<
-            UUID,
-            import('../../../src/transcript/transcript-watcher.ts').TranscriptWatcher
-          >,
-          transcriptFallbackTimers,
-          autoApproveService: null,
-          currentPort: () => 8765,
-          transcriptDiscovery: new TranscriptDiscovery(),
-        },
-        {
-          hookServer: hookServer as unknown as HookServer,
-          sessionId: SID,
-          workingDirectory: tmpDir,
-          messageApi: {
-            handleMessage: () => {},
-            handleQuestion: () => {},
-            handleStatusChange: () => {},
-            reset: () => {
-              messageApiLog.resetCalls.n += 1;
-            },
-          } as unknown as import('../../../src/api/message-api.ts').MessageAPI,
-          sendAndRecord: (msg) => sent.push(msg),
-          tracker: tracker as unknown as QuestionPresenceTracker,
-        },
-      );
-      bridgeHandles.push(handle);
-      return { sent };
-    }
-
-    test('first-init does NOT emit (no rotation, only hello_ack covers initial)', () => {
-      const { sent } = buildWithCapture();
-
-      // Register the session so the bridge proceeds past hasSession() checks.
-      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
-        handleMessage: () => {},
-        handleQuestion: () => {},
-        handleStatusChange: () => {},
-        reset: () => {},
-      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
-
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-first-id',
-        transcript_path: path.join(tmpDir, 'first.jsonl'),
-        hook_event_name: 'SessionStart',
-      });
-
-      expect(sent.filter((m) => m.type === 'session_rotated')).toHaveLength(0);
-    });
-
-    test('second SessionStart with a different id emits one session_rotated', () => {
-      const { sent } = buildWithCapture();
-      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
-        handleMessage: () => {},
-        handleQuestion: () => {},
-        handleStatusChange: () => {},
-        reset: () => {},
-      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
-
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-first-id',
-        transcript_path: path.join(tmpDir, 'first.jsonl'),
-        hook_event_name: 'SessionStart',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-second-id',
-        transcript_path: path.join(tmpDir, 'second.jsonl'),
-        hook_event_name: 'SessionStart',
-      });
-
-      const events = sent.filter((m) => m.type === 'session_rotated') as Array<{
-        sessionId: string;
-        oldClaudeSessionId?: string;
-        newClaudeSessionId: string;
-        newTranscriptPath: string;
-        reason: string;
-      }>;
-      expect(events).toHaveLength(1);
-      expect(events[0]?.sessionId).toBe(SID);
-      expect(events[0]?.oldClaudeSessionId).toBe('claude-first-id');
-      expect(events[0]?.newClaudeSessionId).toBe('claude-second-id');
-      expect(events[0]?.newTranscriptPath).toBe(path.join(tmpDir, 'second.jsonl'));
-      expect(events[0]?.reason).toBe('restart');
-    });
-
-    // Epic #453 phase 0 characterization. The #430/#433 hazard: the
-    // transcript-fallback writes the NEW claudeSessionId to sessionStore
-    // BEFORE the hook event for it arrives, so adoptLockFromStore pulls the
-    // new id and classifySessionEvent sees currentLock === incoming = 'match'.
-    // The bug-regression + Codex critics flagged that this exact race is
-    // untested. This pins TODAY's behavior so the TranscriptBinder refactor
-    // (phase 3) cannot change it unnoticed: when the store has already raced
-    // to the new id, the early-return at hook-bridge-setup.ts:370 is hit and
-    // NO session_rotated is emitted (the snapshot's isRotation is computed but
-    // never reaches the restart/adopt announce). Reconnect reconcile then
-    // relies on the store-binding + hello_ack decoration, not a replayed
-    // session_rotated. The binder must consciously preserve OR fix this.
-    test('store raced to the new id before SessionStart: characterize session_rotated', () => {
-      const { sent } = buildWithCapture();
-      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
-        handleMessage: () => {},
-        handleQuestion: () => {},
-        handleStatusChange: () => {},
-        reset: () => {},
-      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
-
-      // Establish the lock on claude-A.
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-A',
-        transcript_path: path.join(tmpDir, 'a.jsonl'),
-        hook_event_name: 'SessionStart',
-      });
-
-      // Fallback races the store to claude-B BEFORE the SessionStart for B.
-      sessionStore.save({
-        remiSessionId: SID,
-        claudeSessionId: 'claude-B',
-        projectPath: tmpDir,
-        port: 8765,
-        pid: process.pid,
-        startedAt: new Date().toISOString(),
-        exitedAt: null,
-        exitCode: null,
-      });
-
-      // SessionStart for B arrives; adoptLockFromStore pulls B -> 'match'.
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-B',
-        transcript_path: path.join(tmpDir, 'b.jsonl'),
-        hook_event_name: 'SessionStart',
-      });
-
-      // Baseline: the store-raced case does NOT re-emit session_rotated.
-      expect(sent.filter((m) => m.type === 'session_rotated')).toHaveLength(0);
-      // But the binding DID advance to B (store + lock), so a reconnect still
-      // reconciles via the store, not via a replayed rotation event.
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-B');
-    });
-
-    // Epic #453 phase 0: golden-master / differential baseline. A
-    // representative multi-rotation session lifecycle (fresh -> /clear ->
-    // /clear) replayed through the CURRENT path, capturing the control-plane
-    // contract: the ordered session_rotated sequence + the final durable
-    // binding. Phase 3's TranscriptBinder must reproduce this exactly
-    // (shadow-mode diffs against it). Deterministic (synchronous control
-    // plane only; async transcript content is out of scope here).
-    test('golden master: multi-rotation control-plane sequence + final binding', () => {
-      const { sent } = buildWithCapture();
-      sessionRegistry.registerSession(SID, tmpDir, fakePTY([]), {
-        handleMessage: () => {},
-        handleQuestion: () => {},
-        handleStatusChange: () => {},
-        reset: () => {},
-      } as unknown as import('../../../src/api/message-api.ts').MessageAPI);
-
-      // Pre-spawn binding (createNewSession writes this before spawn).
-      sessionStore.save({
-        remiSessionId: SID,
-        claudeSessionId: 'claude-1',
-        projectPath: tmpDir,
-        port: 8765,
-        pid: process.pid,
-        startedAt: new Date().toISOString(),
-        exitedAt: null,
-        exitCode: null,
-      });
-
-      const t1 = path.join(tmpDir, 'm1.jsonl');
-      const t2 = path.join(tmpDir, 'm2.jsonl');
-      const t3 = path.join(tmpDir, 'm3.jsonl');
-
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-1',
-        transcript_path: t1,
-        hook_event_name: 'SessionStart',
-        source: 'startup',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-2',
-        transcript_path: t2,
-        hook_event_name: 'SessionStart',
-        source: 'clear',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: 'claude-3',
-        transcript_path: t3,
-        hook_event_name: 'SessionStart',
-        source: 'clear',
-      });
-
-      const rotations = sent
-        .filter((m) => m.type === 'session_rotated')
-        .map((m) => {
-          const r = m as unknown as {
-            oldClaudeSessionId?: string;
-            newClaudeSessionId: string;
-            newTranscriptPath: string;
-            reason: string;
-          };
-          return {
-            old: r.oldClaudeSessionId,
-            new: r.newClaudeSessionId,
-            path: r.newTranscriptPath,
-            reason: r.reason,
-          };
-        });
-
-      // THE GOLDEN MASTER — phase 3 must reproduce this byte-for-byte.
-      expect(rotations).toEqual([
-        { old: 'claude-1', new: 'claude-2', path: t2, reason: 'restart' },
-        { old: 'claude-2', new: 'claude-3', path: t3, reason: 'restart' },
-      ]);
-      expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe('claude-3');
-    });
-  });
-
   describe('child-liveness + port-ownership rotation (#451)', () => {
-    /** Write a co-located sibling registry entry. `child` controls how its
-     *  Claude liveness is recorded: alive pid, a dead pid, or none (legacy). */
-    function writeSibling(
-      name: string,
-      child: { claudeChildPid?: number; claudeChildExited?: boolean } = {},
-    ): void {
-      fs.mkdirSync(liveSessionsRegistry.dirPath, { recursive: true });
-      fs.writeFileSync(
-        path.join(liveSessionsRegistry.dirPath, name),
-        JSON.stringify({
-          sessionId: `sib-${name}`,
-          pid: process.pid, // sibling DAEMON is alive
-          wsPort: 18999,
-          hookPort: 18001,
-          projectPath: tmpDir,
-          name: 'sibling',
-          startedAt: new Date().toISOString(),
-          ...child,
-        }),
-      );
-    }
-
     /** Write a transcript whose head optionally carries the remi:<port> marker. */
     function writeTranscript(claudeId: string, ownerPort: number | null): string {
       const p = path.join(tmpDir, `${claudeId}.jsonl`);
@@ -3400,165 +3021,24 @@ describe('setupHookBridge', () => {
     }
 
     const CLAUDE_A = 'aaaaaaaa-1111-1111-1111-111111111111';
-    const CLAUDE_B = 'bbbbbbbb-2222-2222-2222-222222222222';
 
-    test('zombie sibling (dead Claude child) no longer wedges our rotation', async () => {
-      // The exact bug: a leftover daemon (process alive, Claude dead) shares
-      // the dir. Pre-fix it permanently deferred rotation handling. The
-      // rotated transcript here carries NO port marker, proving the zombie is
-      // fully ignored rather than relying on the ownership signal.
-      const deadProc = Bun.spawn(['true'], { stdout: 'ignore', stderr: 'ignore' });
-      await deadProc.exited;
-      writeSibling('zombie.json', { claudeChildPid: deadProc.pid });
-      seedLock(CLAUDE_A);
-      writeTranscript(CLAUDE_A, null);
-      const pathB = writeTranscript(CLAUDE_B, null);
-
-      build();
-      // Event 1: establish lock=CLAUDE_A from the store.
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_A,
-        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
-        hook_event_name: 'SessionStart',
-      });
-      // Event 2: in-process rotation to CLAUDE_B.
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_B,
-        transcript_path: pathB,
-        hook_event_name: 'SessionStart',
-      });
-
-      try {
-        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
-        expect(transcriptWatchers.has(SID)).toBe(true);
-      } finally {
-        stopWatchers();
-      }
-    });
-
-    test('genuine live sibling: our own rotation adopts via the remi:<port> marker', async () => {
-      // A real second daemon (live Claude child) shares the dir. Our rotation
-      // must still rebind because the new transcript carries OUR port marker.
-      writeSibling('live.json', { claudeChildPid: process.pid }); // alive
-      seedLock(CLAUDE_A);
-      writeTranscript(CLAUDE_A, 8765);
-      const pathB = writeTranscript(CLAUDE_B, 8765); // ours
-
-      build();
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_A,
-        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
-        hook_event_name: 'SessionStart',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_B,
-        transcript_path: pathB,
-        hook_event_name: 'SessionStart',
-      });
-
-      try {
-        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
-        expect(transcriptWatchers.has(SID)).toBe(true);
-      } finally {
-        stopWatchers();
-      }
-    });
-
-    test("genuine live sibling: the SIBLING's rotation is NOT adopted (no latching)", () => {
-      // Mirror of the above, but the rotating transcript carries the SIBLING's
-      // port. We must not overwrite our binding or start a watcher on it.
-      writeSibling('live2.json', { claudeChildPid: process.pid });
-      seedLock(CLAUDE_A);
-      writeTranscript(CLAUDE_A, 8765);
-      const siblingId = 'cccccccc-3333-3333-3333-333333333333';
-      const pathSib = writeTranscript(siblingId, 18999); // sibling's port
-
-      build();
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_A,
-        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
-        hook_event_name: 'SessionStart',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: siblingId,
-        transcript_path: pathSib,
-        hook_event_name: 'SessionStart',
-      });
-
-      try {
-        // Binding unchanged: the sibling's rotation never overwrote ours.
-        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_A);
-        // Our watcher (started for CLAUDE_A on event 1) is still intact and was
-        // never torn down or re-pointed at the sibling's transcript.
-        expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
-        expect(transcriptWatchers.get(SID)?.filePath).not.toBe(pathSib);
-      } finally {
-        stopWatchers();
-      }
-    });
-
-    test('live sibling + rotation with NO port marker is not adopted', () => {
-      // Guards the &&-not-|| shape of the ownership check: with a live sibling
-      // present and a rotated transcript carrying no remi:<port> marker, we
-      // cannot prove ownership, so we must defer rather than latch.
-      writeSibling('live-nomarker.json', { claudeChildPid: process.pid });
-      seedLock(CLAUDE_A);
-      writeTranscript(CLAUDE_A, 8765); // ours, lets event 1 lock cleanly
-      const pathB = writeTranscript(CLAUDE_B, null); // rotation, unmarked
-
-      build();
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_A,
-        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
-        hook_event_name: 'SessionStart',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_B,
-        transcript_path: pathB,
-        hook_event_name: 'SessionStart',
-      });
-
-      try {
-        // Unproven rotation deferred: binding stays, watcher stays on CLAUDE_A.
-        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_A);
-        expect(transcriptWatchers.get(SID)?.filePath).toBe(path.join(tmpDir, `${CLAUDE_A}.jsonl`));
-      } finally {
-        stopWatchers();
-      }
-    });
-
-    test('sibling explicitly flagged claudeChildExited is ignored (recycle-proof)', () => {
-      // The recycle-proof tombstone path: an entry that went alive -> exited via
-      // markClaudeChildExited must not count as a sibling even though its pid is
-      // alive. Rotation proceeds with no port marker, as in the zombie case.
-      writeSibling('flagged-exited.json', {
-        claudeChildPid: process.pid, // alive pid...
-        claudeChildExited: true, // ...but explicitly tombstoned
-      });
-      seedLock(CLAUDE_A);
-      writeTranscript(CLAUDE_A, null);
-      const pathB = writeTranscript(CLAUDE_B, null);
-
-      build();
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_A,
-        transcript_path: path.join(tmpDir, `${CLAUDE_A}.jsonl`),
-        hook_event_name: 'SessionStart',
-      });
-      hookServer.fire('SessionStart', {
-        session_id: CLAUDE_B,
-        transcript_path: pathB,
-        hook_event_name: 'SessionStart',
-      });
-
-      try {
-        expect(sessionStore.findByRemiSessionId(SID)?.claudeSessionId).toBe(CLAUDE_B);
-        expect(transcriptWatchers.has(SID)).toBe(true);
-      } finally {
-        stopWatchers();
-      }
-    });
-
+    // #930: the sibling/zombie/port-marker ROTATION scenarios that used to
+    // live in this describe block (fired two SessionStarts to simulate a
+    // live-PTY restart) relied on the SessionStart hookServer listener
+    // calling `binder.preemptOnSessionStart` before `binder.onHookEvent` --
+    // the ONLY way this integration layer could flip `mainSessionEnded` on a
+    // live PTY without an intervening SessionEnd. That listener is deleted
+    // (Claude Code hard-discards http-type hooks for SessionStart, so it
+    // never fired in production either -- see hook-types.ts's
+    // REMI_REGISTERED_HOOK_EVENTS doc comment). The underlying binder logic
+    // (`preemptOnSessionStart`, `incomingReclaimsViaMarker`, zombie-sibling
+    // handling) is unit-tested directly against `TranscriptBinder` in
+    // `tests/transcript/transcript-binder.test.ts` (see its own "#451" and
+    // "zombie sibling" cases), which calls `preemptOnSessionStart` +
+    // `onHookEvent` directly rather than through this deleted wiring. Only
+    // the ONE test below survives here: it locks via the store-adoption path
+    // (`seedLock` + a single PreToolUse), which never depended on
+    // SessionStart at all.
     test('self-heals the watcher when locked-from-store but the fallback gave up', () => {
       // The osa case: single daemon, no sibling. The lock is adopted from the
       // store (deterministic pre-spawn binding), but no watcher exists because
@@ -3599,12 +3079,12 @@ describe('setupHookBridge', () => {
     test('two-step push: a hook stashes pending WITHOUT pushing; only PTY presence fires the push', () => {
       const { tracker } = build({ realTracker: true });
 
-      hookServer.fire('SessionStart', {
+      hookServer.fire('Notification', {
         session_id: 'claude-twostep',
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
         transcript_path: path.join(tmpDir, 'twostep.jsonl'),
-        source: 'startup',
-        model: 'test',
+        notification_type: 'auth_success',
+        message: '',
       });
 
       hookServer.fire('PermissionRequest', {
@@ -3647,12 +3127,12 @@ describe('setupHookBridge', () => {
       // A small eval delay guarantees onEvalStart fires before onHandled.
       build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 10, sendLog });
 
-      hookServer.fire('SessionStart', {
+      hookServer.fire('Notification', {
         session_id: 'claude-aa-status',
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
         transcript_path: path.join(tmpDir, 'aa-status.jsonl'),
-        source: 'startup',
-        model: 'test',
+        notification_type: 'auth_success',
+        message: '',
       });
 
       const decision = await hookServer.firePermission({
@@ -3679,12 +3159,12 @@ describe('setupHookBridge', () => {
         sendLog,
       });
 
-      hookServer.fire('SessionStart', {
+      hookServer.fire('Notification', {
         session_id: 'claude-aa-esc',
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
         transcript_path: path.join(tmpDir, 'aa-esc.jsonl'),
-        source: 'startup',
-        model: 'test',
+        notification_type: 'auth_success',
+        message: '',
       });
 
       await hookServer.firePermission({
@@ -3706,12 +3186,12 @@ describe('setupHookBridge', () => {
       const sendLog: ProtocolMessage[] = [];
       build({ autoApprove: true, autoApproveDecision: 'approve', autoApproveDelayMs: 10, sendLog });
 
-      hookServer.fire('SessionStart', {
+      hookServer.fire('Notification', {
         session_id: 'claude-aa-subagent',
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
         transcript_path: path.join(tmpDir, 'aa-subagent.jsonl'),
-        source: 'startup',
-        model: 'test',
+        notification_type: 'auth_success',
+        message: '',
       });
 
       const decision = await hookServer.firePermission({
@@ -3780,12 +3260,12 @@ describe('setupHookBridge', () => {
         ),
       );
 
-      freshHook.fire('SessionStart', {
+      freshHook.fire('Notification', {
         session_id: 'claude-throw-broadcast',
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
         transcript_path: path.join(tmpDir, 'throw-bc.jsonl'),
-        source: 'startup',
-        model: 'test',
+        notification_type: 'auth_success',
+        message: '',
       });
 
       // The decision must still resolve to 'allow' despite the throwing sender.
@@ -3802,12 +3282,20 @@ describe('setupHookBridge', () => {
   });
 
   describe('#891: free-win hook field consumption', () => {
-    /** Fire a SessionStart so the bridge locks onto `id` (admit gate then passes). */
+    /** Fire a neutral Notification so the bridge locks onto `id` (admit gate then passes; #930). */
     function lock(id: string): void {
-      hookServer.fire('SessionStart', {
+      // #930: SessionStart is no longer a registered/dispatched hook
+      // event (Claude Code discards http-type hooks for it). Notification
+      // with a neutral type locks the binder via the same onHookEvent()
+      // first-adopt path with zero downstream side effects (handleNotification
+      // no-ops for anything outside permission_prompt/idle_prompt/
+      // elicitation_dialog).
+      hookServer.fire('Notification', {
         session_id: id,
         transcript_path: path.join(tmpDir, `${id}.jsonl`),
-        hook_event_name: 'SessionStart',
+        hook_event_name: 'Notification',
+        notification_type: 'auth_success',
+        message: '',
       });
     }
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -3030,14 +3030,37 @@ describe('setupHookBridge', () => {
     // live PTY without an intervening SessionEnd. That listener is deleted
     // (Claude Code hard-discards http-type hooks for SessionStart, so it
     // never fired in production either -- see hook-types.ts's
-    // REMI_REGISTERED_HOOK_EVENTS doc comment). The underlying binder logic
-    // (`preemptOnSessionStart`, `incomingReclaimsViaMarker`, zombie-sibling
-    // handling) is unit-tested directly against `TranscriptBinder` in
-    // `tests/transcript/transcript-binder.test.ts` (see its own "#451" and
-    // "zombie sibling" cases), which calls `preemptOnSessionStart` +
-    // `onHookEvent` directly rather than through this deleted wiring. Only
-    // the ONE test below survives here: it locks via the store-adoption path
-    // (`seedLock` + a single PreToolUse), which never depended on
+    // REMI_REGISTERED_HOOK_EVENTS doc comment).
+    //
+    // Deleted rather than "covered elsewhere": the scenarios these tests
+    // exercised hinged on `preemptOnSessionStart`'s sibling/ownership guard
+    // (`!this.hasSiblingInDir() || this.ownsTranscript(event.transcript_path)`,
+    // `transcript-binder.ts:480`) taking its `!hasSiblingInDir()` branch --
+    // i.e. a rotation event arriving with an UNMARKED or foreign-port
+    // transcript (`ownsTranscript()` false) while a sibling is present. That
+    // branch is now unreachable through `preemptOnSessionStart`'s only
+    // production caller: `feedSyntheticRotation`'s candidate loop
+    // (`transcript-binder.ts:~1117`) already drops any candidate whose
+    // `ownerPort !== currentPort()` BEFORE it ever calls
+    // `preemptOnSessionStart`, so `ownsTranscript()` is guaranteed true by
+    // the time it runs -- the `!hasSiblingInDir()` side of the OR never
+    // gets to matter. The deleted tests were not testing dead-but-parallel
+    // coverage; they were testing a guard configuration that can no longer
+    // occur.
+    //
+    // This is NOT a matched set against `transcript-binder.test.ts`: that
+    // file has exactly ONE `#451`-labeled test (`#451: restart with a live
+    // sibling + unmarked transcript defers`, line 496) and ONE zombie test
+    // (`a zombie sibling (claude child exited) does not by itself block
+    // reclaim, but staleness does`, line 1702) -- and the zombie test's
+    // single `admitted === false` assertion cannot on its own distinguish
+    // "zombie correctly ignored, staleness alone blocks" from "zombie
+    // incorrectly blocks" (its setup combines a zombie sibling AND a stale
+    // transcript, per its own title). Cited as the one surviving analog, not
+    // as a parallel set proving the deleted scenarios stayed covered.
+    //
+    // Only the ONE test below survives here: it locks via the store-adoption
+    // path (`seedLock` + a single PreToolUse), which never depended on
     // SessionStart at all.
     test('self-heals the watcher when locked-from-store but the fallback gave up', () => {
       // The osa case: single daemon, no sibling. The lock is adopted from the

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
@@ -273,12 +273,36 @@ describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
     return result;
   }
 
+  // #930: SessionStart is no longer a registered/dispatched hook event
+  // (Claude Code hard-discards http-type hooks for it; see hook-types.ts's
+  // REMI_REGISTERED_HOOK_EVENTS doc comment). Streams below lock via a
+  // neutral Notification (zero downstream side effects for
+  // notification_type: 'auth_success') and drive a rotation via a real
+  // SessionEnd for the OLD id -- production-realistic (SessionEnd genuinely
+  // fires on a clean exit) and, like the deleted SessionStart pre-empt,
+  // flips `mainSessionEnded` so the binder classifies the next event for a
+  // NEW id as 'restart' rather than 'foreign'.
+
   test('(a) normal first-bind + /clear rotation A -> B', async () => {
     const result = await runStream([
-      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
       {
-        event: 'SessionStart',
-        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+        event: 'Notification',
+        input: {
+          session_id: 'claude-A',
+          transcript_path: 'a.jsonl',
+          notification_type: 'auth_success',
+          message: '',
+        },
+      },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'clear' } },
+      {
+        event: 'Notification',
+        input: {
+          session_id: 'claude-B',
+          transcript_path: 'b.jsonl',
+          notification_type: 'auth_success',
+          message: '',
+        },
       },
     ]);
 
@@ -294,14 +318,34 @@ describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
 
   test('(b) A -> B -> A re-resume (idempotent emit)', async () => {
     const result = await runStream([
-      { event: 'SessionStart', input: { session_id: 'claude-A', transcript_path: 'a.jsonl' } },
       {
-        event: 'SessionStart',
-        input: { session_id: 'claude-B', transcript_path: 'b.jsonl', source: 'clear' },
+        event: 'Notification',
+        input: {
+          session_id: 'claude-A',
+          transcript_path: 'a.jsonl',
+          notification_type: 'auth_success',
+          message: '',
+        },
       },
+      { event: 'SessionEnd', input: { session_id: 'claude-A', reason: 'clear' } },
       {
-        event: 'SessionStart',
-        input: { session_id: 'claude-A', transcript_path: 'a.jsonl', source: 'resume' },
+        event: 'Notification',
+        input: {
+          session_id: 'claude-B',
+          transcript_path: 'b.jsonl',
+          notification_type: 'auth_success',
+          message: '',
+        },
+      },
+      { event: 'SessionEnd', input: { session_id: 'claude-B', reason: 'clear' } },
+      {
+        event: 'Notification',
+        input: {
+          session_id: 'claude-A',
+          transcript_path: 'a.jsonl',
+          notification_type: 'auth_success',
+          message: '',
+        },
       },
     ]);
 
@@ -319,8 +363,11 @@ describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
     // file the harness writes carries no marker, so ownsTranscript() is false.
     const result = await runStream(
       [
-        // Use PreToolUse (not SessionStart) so the SessionStart pre-empt does not
-        // fire; this exercises the first-adopt sibling/ownership gate directly.
+        // Use PreToolUse: SessionStart can no longer fire via hooks at all
+        // (#930), so this also exercises the first-adopt sibling/ownership
+        // gate directly, same as originally intended (avoiding the
+        // SessionStart pre-empt) -- just for a now-permanent reason rather
+        // than a deliberate choice among two working options.
         {
           event: 'PreToolUse',
           input: {

--- a/packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts
+++ b/packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts
@@ -61,8 +61,9 @@
  * despite being registered -- see `EVENTS_WITHOUT_FIXTURES` in
  * `contract-spec.ts`.
  *
- * `SessionStart` is registered too, and STILL has zero fixtures, for a
- * different and more interesting reason: the installed Claude Code binary
+ * `SessionStart` WAS registered too (at the time this corpus was first
+ * built) and STILL had zero fixtures, for a different and more interesting
+ * reason: the installed Claude Code binary
  * (`~/.local/share/claude/versions/2.1.220`) explicitly discards
  * `http`-type hook registrations for `SessionStart`/`Setup` before dispatch.
  * The relevant minified source (found via the same `rg -a -o -P` extraction
@@ -76,7 +77,7 @@
  * `hook-config-manager.ts:19` (`HookEntry.type: 'http'`) shows remi registers
  * EXCLUSIVELY via `http`-type hooks -- there is no code path that registers
  * `command`/`prompt`/`agent`-type hooks. So remi's SessionStart registration
- * is filtered out by Claude Code itself on every single session, silently
+ * was filtered out by Claude Code itself on every single session, silently
  * (the skip is logged only at Claude Code's own internal verbose level, which
  * remi has no visibility into) -- not a race with the hook server binding
  * (confirmed by reading `cli.ts`: `hookServer.start()` and
@@ -84,9 +85,11 @@
  * before the `claude` process is spawned), not a REMI_HOOK_DEBUG logging
  * gap (that write happens unconditionally at the top of `handleRequest`,
  * before dispatch, so it would catch a SessionStart POST if one ever
- * arrived). Filed as a new issue; see the #886 part 2 PR description for the
- * number. `Setup` was never registered by remi at all, so its absence needs
- * no separate explanation.
+ * arrived). Filed as #930; remi unregistered `SessionStart` in response (same
+ * issue) rather than build a `command`-type hook to recover it -- see
+ * `docs/claude-code-hook-contract.md`'s "Corpus status" section for the
+ * current state. `Setup` was never registered by remi at all, so its absence
+ * needs no separate explanation.
  *
  * TEST CONTAMINATION HAZARD, discovered building this corpus: that same
  * "unconditional write" is exactly what makes `~/.remi/hook-diag.jsonl`
@@ -192,10 +195,11 @@ const VERBATIM_PATHS = new Set<string>([
 /**
  * `trigger` and `source` are only ever sent by event types this corpus has
  * zero fixtures for today (Setup/PreCompact/PostCompact/ConfigChange/
- * DirectoryAdded/SessionStart -- none registered, or (SessionStart)
- * registered but never dispatched, see the module doc comment). Kept in the
- * allowlist anyway, inert on this data, so a future corpus rebuild (once one
- * of those events is registered) doesn't need this script re-reviewed.
+ * DirectoryAdded/SessionStart -- none registered today; SessionStart WAS
+ * registered but never dispatched before #930 unregistered it, see the
+ * module doc comment). Kept in the allowlist anyway, inert on this data, so
+ * a future corpus rebuild (once one of those events is registered) doesn't
+ * need this script re-reviewed.
  */
 const VERBATIM_NESTED_PATHS = new Set<string>(['effort.level']);
 

--- a/packages/daemon/tests/hooks/fixtures/contract-spec.ts
+++ b/packages/daemon/tests/hooks/fixtures/contract-spec.ts
@@ -10,7 +10,7 @@
  * drift test silently stop checking the changed field, not fail loudly —
  * so treat any such edit as also touching this file.
  *
- * SCOPE: only the 15 events in `REMI_REGISTERED_HOOK_EVENTS` are spec'd
+ * SCOPE: only the 14 events in `REMI_REGISTERED_HOOK_EVENTS` are spec'd
  * below. Every other one of the 31 names in `HOOK_EVENT_NAMES` is
  * structurally uncapturable in `~/.remi/hook-diag.jsonl` — Claude Code only
  * POSTs a hook Claude Code has a configured URL for, and remi registers
@@ -22,6 +22,14 @@
  * epic (each future Q that registers a new event adds fixture coverage for
  * it); it does not precede the epic, and its silence about an unregistered
  * or not-yet-captured event is not evidence about that event's shape.
+ *
+ * `SessionStart` was one of the 15 spec'd events until #930: registered but
+ * Claude Code hard-discards `http`-type hooks for it before dispatch, so it
+ * had (and could only ever have had) zero fixtures — see
+ * `docs/claude-code-hook-contract.md`'s "Corpus status" section. #930
+ * unregistered it, so it dropped out of this spec the same way any
+ * never-registered event is absent: no entry, no special case, nothing left
+ * to assert.
  */
 
 import type { RemiRegisteredHookEvent } from '../../../src/hooks/hook-types.ts';
@@ -97,10 +105,6 @@ export const EVENT_SPECS: Record<RemiRegisteredHookEvent, EventSpec> = {
     required: ['stop_hook_active'],
     optional: ['last_assistant_message', 'background_tasks', 'session_crons'],
   },
-  SessionStart: {
-    required: [],
-    optional: ['source', 'model', 'agent_type', 'session_title'],
-  },
   PermissionRequest: {
     required: ['tool_name', 'tool_input'],
     optional: ['permission_suggestions', 'tool_use_id'],
@@ -163,14 +167,18 @@ export const EVENT_SPECS: Record<RemiRegisteredHookEvent, EventSpec> = {
  * Registered event names with ZERO fixtures in `hook-corpus.jsonl` as of
  * this corpus build, and why — so `contract-drift.test.ts` can assert their
  * absence is EXPECTED (and stay useful if that ever changes) rather than
- * silently never iterating them. See `build-hook-corpus.ts`'s header for the
- * full investigation behind the `SessionStart` row.
+ * silently never iterating them.
+ *
+ * `SessionStart` used to have an entry here (registered, zero fixtures,
+ * because the installed Claude Code 2.1.220 binary discards `http`-type hook
+ * registrations for `SessionStart`/`Setup` before dispatch — confirmed
+ * directly against the binary, #930). #930 unregistered it instead of
+ * special-casing its absence, so it no longer has an `EVENT_SPECS` entry at
+ * all and needs no entry here either — same treatment as any other
+ * never-registered event. See `docs/claude-code-hook-contract.md`'s "Corpus
+ * status" section and `build-hook-corpus.ts`'s header for the investigation.
  */
 export const EVENTS_WITHOUT_FIXTURES: Partial<Record<RemiRegisteredHookEvent, string>> = {
-  SessionStart:
-    'registered, but the installed Claude Code 2.1.220 binary discards ' +
-    'http-type hook registrations for SessionStart/Setup before dispatch ' +
-    '— confirmed directly against the binary; see #930.',
   PermissionDenied: 'registered by #926, after most of this corpus was captured.',
   Elicitation: 'registered by #926, after most of this corpus was captured.',
   ElicitationResult: 'registered by #926, after most of this corpus was captured.',

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -9,7 +9,6 @@ import type {
   PostToolUseHookInput,
   PreToolUseHookInput,
   SessionEndHookInput,
-  SessionStartHookInput,
   StopFailureHookInput,
   StopHookInput,
   SubagentStartHookInput,
@@ -29,7 +28,6 @@ describe('HookEventBridge', () => {
   function createBridge() {
     const statuses: Array<{ status: AgentStatus; context?: string }> = [];
     const questions: Question[] = [];
-    const sessionInfos: Array<{ claudeSessionId: string; transcriptPath: string }> = [];
 
     const bridge = new HookEventBridge('session-1' as import('@remi/shared').UUID, {
       onStatusChange: (status, context) => {
@@ -40,10 +38,9 @@ describe('HookEventBridge', () => {
         }
       },
       onQuestion: (q) => questions.push(q),
-      onSessionInfo: (id, path) => sessionInfos.push({ claudeSessionId: id, transcriptPath: path }),
     });
 
-    return { bridge, statuses, questions, sessionInfos };
+    return { bridge, statuses, questions };
   }
 
   it('maps PreToolUse to executing status with tool name', () => {
@@ -116,21 +113,6 @@ describe('HookEventBridge', () => {
     } as StopHookInput);
 
     expect(statuses).toEqual([{ status: 'idle' }]);
-  });
-
-  it('maps SessionStart to session info', () => {
-    const { bridge, sessionInfos } = createBridge();
-
-    bridge.handleSessionStart({
-      ...makeCommon(),
-      hook_event_name: 'SessionStart',
-      source: 'startup',
-      model: 'claude-opus-4-6',
-    } as SessionStartHookInput);
-
-    expect(sessionInfos.length).toBe(1);
-    expect(sessionInfos[0]?.claudeSessionId).toBe('test-session');
-    expect(sessionInfos[0]?.transcriptPath).toBe('/tmp/test.jsonl');
   });
 
   it('an empty-message standalone Notification(permission_prompt) still only sets status (#890, Q5)', () => {
@@ -1210,29 +1192,6 @@ describe('HookEventBridge', () => {
       expect(bridge.isInSubagentContext()).toBe(true);
 
       bridge.resetSubagentContext();
-
-      expect(bridge.isInSubagentContext()).toBe(false);
-    });
-
-    it('handleSessionStart resets any stale state from prior session', () => {
-      const { bridge } = createBridge();
-      bridge.handlePreToolUse({
-        ...makeCommon(),
-        hook_event_name: 'PreToolUse',
-        tool_name: 'Task',
-        tool_input: {},
-        tool_use_id: 'tu_stale',
-      } as PreToolUseHookInput);
-      expect(bridge.isInSubagentContext()).toBe(true);
-
-      bridge.handleSessionStart({
-        ...makeCommon(),
-        session_id: 'new-session-id',
-        transcript_path: '/tmp/new.jsonl',
-        hook_event_name: 'SessionStart',
-        source: 'startup',
-        model: 'claude-opus',
-      } as SessionStartHookInput);
 
       expect(bridge.isInSubagentContext()).toBe(false);
     });

--- a/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
@@ -38,7 +38,6 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
         statuses.push(context !== undefined ? { status, context } : { status });
       },
       onQuestion: (q) => questions.push(q),
-      onSessionInfo: () => {},
     });
 
     server = new HookServer({ port: 0 });
@@ -130,7 +129,6 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},
       onQuestion: (q) => questions.push(q),
-      onSessionInfo: () => {},
     });
     server = new HookServer({ port: 0 });
     const h = bridge.hookHandlers();
@@ -179,7 +177,6 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},
       onQuestion: () => {},
-      onSessionInfo: () => {},
     });
 
     server = new HookServer({ port: 0 });


### PR DESCRIPTION
## Summary

Closes #930. Claude Code 2.1.220 hard-discards `http`-type hook registrations for `SessionStart`/`Setup` before dispatch (binary-verified: one `hook.type==="http"` filter site, gated on `r==="SessionStart"||r==="Setup"`, sitting in the generic matched-hooks pipeline). remi has registered `SessionStart` since #886, and it appears zero times across 5,000+ captured events in `~/.remi/hook-diag.jsonl`. The registration never gated Claude (Claude strips the entry before dispatch, so no HTTP roundtrip ever happened for it) -- the entire cost was epistemic: a dead listener that read as coverage and billed real hours in the #886 investigation.

- Removed `SessionStart` from `REMI_REGISTERED_HOOK_EVENTS` (`hook-types.ts`). It stays in `HOOK_EVENT_NAMES` -- Claude Code still defines the event, remi just declines to pay for a registration it discards.
- Deleted the dead code: the `SessionStart` listener in `hook-bridge-setup.ts`, `handleSessionStart` in `hook-event-bridge.ts`, and the `onSessionInfo` member + its no-op stub (confirmed `handleSessionStart` was `onSessionInfo`'s sole invoker before deleting).
- Kept `TranscriptBinder.preemptOnSessionStart` -- `feedSyntheticRotation` (the #452/#453 no-hooks rotation mirror) is its live caller and remains the designed no-hooks restart-detection signal (ADR 0001: pre-assigned `--session-id` + transcript path is the session source of truth).
- Updated `contract-spec.ts`'s total `Record<RemiRegisteredHookEvent, EventSpec>` (removing the registration broke the build until its `EVENT_SPECS`/`EVENTS_WITHOUT_FIXTURES` entries went too -- the guard working as intended).
- Recorded the finding in three places: the `REMI_REGISTERED_HOOK_EVENTS` doc comment, `docs/claude-code-hook-contract.md` (flagged the `SessionStart` row + "Corpus status" section), and `contract-spec.ts`'s own header (SessionStart's absence from the corpus needs no special case now -- same as any other never-registered event).
- Did **not** build a `command`-type hook to recover the event (considered and rejected: a shell string in `settings.local.json`, a process spawn per session start, and a second registration mechanism, for an instant-vs-dir-poll latency difference on a rare path).

## Test fallout (bigger than the plan anticipated -- reporting per the task's "verify before you describe" instruction)

`hook-bridge-setup.test.ts` drove the overwhelming majority of its test setup by firing a `SessionStart` hook event through a `RecordingHookServer` test double that **throws** if no listener is registered for the fired event name. Deleting the production listener broke 95 of 104 tests in that file, not just the single hardcoded listener-count assertion the plan called out.

- **Listener count: 14 -> 13** `.on()` registrations (test title + assertion updated).
- Locking-only usages (the overwhelming majority) now fire a neutral `Notification(notification_type: 'auth_success')` through the same `binder.onHookEvent()` first-adopt path -- zero downstream side effects (`handleNotification` no-ops outside `permission_prompt`/`idle_prompt`/`elicitation_dialog`).
- Two tests that asserted a real rotation side effect (`onRotation`'s `tracker.clearPending()` / `resolveAndClearQuestions()`) now drive the rotation via a real `SessionEnd` for the old id before the new id's event -- this is how rotation actually happens post-#930 (`SessionEnd` flips `mainSessionEnded`, same as the deleted `preemptOnSessionStart` used to, just via a still-registered, production-real path).
- Deleted 15 tests that specifically characterized the `SessionStart` pre-empt/rotation-classifier wiring itself (the six `#416`-labeled pre-empt tests, the 4-test `session_rotated emission` describe block, and 5 of 6 tests in the `child-liveness + port-ownership rotation (#451)` describe block). That wiring no longer exists, and the underlying binder logic (`preemptOnSessionStart`, `emitRotated` idempotency, the exact `golden master: multi-rotation control-plane sequence` scenario, `#451` zombie-sibling handling) is already directly unit-tested against `TranscriptBinder` in `tests/transcript/transcript-binder.test.ts`, unaffected by this change.
- `transcript-binder-drive.test.ts` had the same two-SessionStart-rotation pattern in 2 of its 3 tests; fixed the same way (`SessionEnd` + neutral `Notification`).

Per the task's explicit ask: **`handleSessionStart` WAS referenced by tests** -- `hook-event-bridge.test.ts` had two tests calling `bridge.handleSessionStart(...)` directly (`'maps SessionStart to session info'` and `'handleSessionStart resets any stale state from prior session'`). Both deleted along with the method (the second's subagent-reset claim is otherwise covered by `handleStop`/`handleStopFailure`/`handleSessionEnd`'s own resets). `onSessionInfo` was referenced as required-interface boilerplate (`() => {}`) in 3 other test files with no behavioral assertion on it; those lines were removed.

## Test plan

- [x] `bunx biome check .` -- clean (0 errors; 48 pre-existing warnings in files this PR does not touch)
- [x] `bun run typecheck` -- clean
- [x] `bun test packages/daemon/tests/hooks/ packages/daemon/tests/cli/session-phases/` -- 392 pass, 0 fail (run repeatedly for stability; one unrelated flake observed once out of ~6 runs, consistent with this suite's documented pre-existing flakiness, not reproduced on retry)
- [x] `bun test packages/daemon/tests/transcript/transcript-binder.test.ts` -- 62 pass, 0 fail (unaffected, as expected)