### PR TITLE
Return handleQuestion's registration outcome (#888 criterion iii)

### DIFF
--- a/packages/daemon/src/api/message-api.ts
+++ b/packages/daemon/src/api/message-api.ts
@@ -11,6 +11,37 @@ import { BulletEngine } from '../parser/bullet-engine.ts';
 import { BulletContentRegistry } from './bullet-content-registry.ts';
 import { QuestionDedup } from './question-dedup.ts';
 
+/**
+ * Outcome of a `handleQuestion` call (#888 criterion iii). Replaces a bare
+ * `void` return -- and deliberately not a bare `boolean` either.
+ *
+ * Two silent-drop defects (#925, #926) both traced to the same root cause:
+ * `handleQuestion` returned `void` and swallowed the outcome when
+ * `QuestionDedup` suppressed the emission, so the caller had no way to tell
+ * "the question is live" from "the question never registered" without
+ * re-querying `SessionRegistry` after the fact. A `boolean` return would
+ * fix the immediate defect but reopen a subtler one: `true` would have to
+ * mean both "registered" (the ordinary case) and "held" (the load-bearing
+ * #573 escalation that bypasses dedup entirely) -- collapsing two outcomes
+ * that call sites must treat differently invites exactly the kind of
+ * boolean-blindness bug this criterion exists to prevent. A discriminated
+ * union instead names all three outcomes and lets a caller `switch` on
+ * `status` with TypeScript exhaustiveness checking (a `default` branch
+ * asserting `never`): adding a fourth outcome later breaks every such
+ * switch at compile time instead of silently falling through one of them.
+ *
+ * Consumed directly by the two hand-rolled gates that used to re-query the
+ * store instead of trusting this return value:
+ *   - `QuestionPresenceTracker.pairAndPush`'s confirmed-delivery check (the
+ *     deleted `isQuestionLive` dep), via the `PushQuestion` callback type.
+ *   - `hook-bridge-setup.ts`'s `rememberElicitation`, via
+ *     `HookEventBridge.handleElicitation`'s return.
+ */
+export type QuestionRegistrationOutcome =
+  | { readonly status: 'registered' }
+  | { readonly status: 'deduped' }
+  | { readonly status: 'held' };
+
 /** Events emitted by MessageAPI to adapters */
 export interface MessageAPIEvents {
   /** New structured message created */
@@ -212,19 +243,25 @@ export class MessageAPI {
 
   /**
    * Emit a question, deduping against recent emissions. See QuestionDedup
-   * for upgrade rules.
+   * for upgrade rules. Returns the registration outcome (#888 criterion
+   * iii) instead of silently discarding it -- see `QuestionRegistrationOutcome`
+   * for why callers must not be left to guess.
    */
-  handleQuestion(question: Question, opts?: { held?: boolean }): void {
+  handleQuestion(question: Question, opts?: { held?: boolean }): QuestionRegistrationOutcome {
     // A HELD escalation (Model B, #573) bypasses the content-dedup: its card is
     // load-bearing — it registers the question that makes the held hook
     // answerable — not a PTY/hook echo. Deduping it away would leave the hook
     // held with no answerable question until it fails open (#603 Phase 3, R7).
+    // Its outcome is reported as its own distinct 'held' status, not folded
+    // into 'registered': a held push never passes through the dedup gate
+    // below, so conflating the two would misrepresent what actually happened.
     if (opts?.held) {
       this.events.onQuestion?.(question, opts);
-      return;
+      return { status: 'held' };
     }
-    if (!this.questionDedup.shouldEmit(question)) return;
+    if (!this.questionDedup.shouldEmit(question)) return { status: 'deduped' };
     this.events.onQuestion?.(question);
+    return { status: 'registered' };
   }
 
   handleStatusChange(status: AgentStatus, context?: string): void {

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -51,12 +51,15 @@
  * removed in one working day's capture, one still pending 2h51m later).
  * `observedHooklessQuestion` + `deps.onHooklessQuestionGone` close that gap,
  * but ONLY on a CONFIRMED-delivered replacement push in `pairAndPush` --
- * `deps.isQuestionLive` is the confirmation gate. An id-comparison-only
- * version of this (this file's own V1) could resolve a question that never
- * actually left the screen: the PTY parser mints a fresh id on every parse
+ * the `QuestionRegistrationOutcome` returned directly by the `push` call is
+ * the confirmation gate (#888 criterion iii; formerly a separate
+ * `deps.isQuestionLive` re-query of the store, deleted once the push call
+ * itself could report its own outcome). An id-comparison-only version of
+ * this (this file's own V1) could resolve a question that never actually
+ * left the screen: the PTY parser mints a fresh id on every parse
  * regardless of content (#486), and the replacement's own push can be
  * silently eaten by `QuestionDedup`'s 5s window -- found in review, see
- * `isQuestionLive`'s doc for the full failure chain. Status-leaves-'waiting'
+ * `pairAndPush`'s doc for the full failure chain. Status-leaves-'waiting'
  * and `clearPending` were dropped as triggers for the same reason (both can
  * fire on a signal unrelated to whether THIS question's render is actually
  * gone); see their own reset comments. See `pairAndPush` and
@@ -65,6 +68,7 @@
 
 import { MAIN_AGENT_ID } from '@remi/shared';
 import type { AgentStatus, Question } from '@remi/shared';
+import type { QuestionRegistrationOutcome } from './message-api.ts';
 
 export interface PushOptions {
   /**
@@ -81,8 +85,20 @@ export interface PushOptions {
  * should fire. Implementations forward to `MessageAPI.handleQuestion`,
  * which applies the content-identity QuestionDedup before the network
  * layer — unless `opts.held` marks the load-bearing held-hook card.
+ *
+ * Returns `MessageAPI.handleQuestion`'s own `QuestionRegistrationOutcome`
+ * (#888 criterion iii) — `pairAndPush` consumes this DIRECTLY as its
+ * confirmed-delivery signal instead of re-querying the store afterward (the
+ * deleted `isQuestionLive` dep). `| undefined` (not `| void` — this
+ * codebase's lint config forbids `void` inside a union) covers a push sink
+ * that does not participate in the outcome contract; production always
+ * returns the real outcome because `cli.ts` wires this straight to
+ * `messageApi.handleQuestion`.
  */
-export type PushQuestion = (question: Question, opts?: PushOptions) => void;
+export type PushQuestion = (
+  question: Question,
+  opts?: PushOptions,
+) => QuestionRegistrationOutcome | undefined;
 
 /**
  * Verdict of a parked-render arbitration (#814).
@@ -182,13 +198,14 @@ export interface QuestionPresenceTrackerDeps {
    * source-less questions never removed over one working day, one still
    * pending 2h51m later).
    *
-   * Fires ONLY from `pairAndPush`, and ONLY once `isQuestionLive` (below)
-   * CONFIRMS the replacement that superseded it actually landed -- see that
-   * dep's doc for why an id/status/restart-based trigger without that
-   * confirmation is unsound (found in review of the first version of this
-   * mechanism, #888). Does NOT touch push/arbitration decisions (ADR 0004
-   * unchanged) -- this only tells the caller a PREVIOUSLY PUSHED question's
-   * evidence is gone, so it can be removed from the pending store.
+   * Fires ONLY from `pairAndPush`, and ONLY once the `QuestionRegistrationOutcome`
+   * returned by the `push` call CONFIRMS the replacement that superseded it
+   * actually registered -- see `pairAndPush`'s doc for why an
+   * id/status/restart-based trigger without that confirmation is unsound
+   * (found in review of the first version of this mechanism, #888). Does NOT
+   * touch push/arbitration decisions (ADR 0004 unchanged) -- this only tells
+   * the caller a PREVIOUSLY PUSHED question's evidence is gone, so it can be
+   * removed from the pending store.
    *
    * MUST be synchronous and non-throwing (same contract as
    * `hasLiveQuestions`): invoked with no surrounding try/catch at most call
@@ -197,49 +214,6 @@ export interface QuestionPresenceTrackerDeps {
    * question-lifecycle trace.
    */
   onHooklessQuestionGone?: (questionId: string, reason: string) => void;
-  /**
-   * True iff `questionId` is CURRENTLY registered as pending
-   * (`sessionRegistry.getQuestion(sessionId, id) !== null`). The sole
-   * confirmation gate for `onHooklessQuestionGone` (#888 review fix).
-   *
-   * V1 of this mechanism compared the PTY-parsed render's `id` alone: "a
-   * different id arrived, so the old one must be superseded." That is
-   * unsound on two fronts, both found in review:
-   *   1. The PTY parser mints a FRESH id on every single parse (#486), even
-   *      when a prompt merely REDRAWS with unchanged text -- the exact
-   *      hazard `isPromptCurrent`'s own text fallback already documents
-   *      elsewhere in this file ("a prompt that merely redraws re-emits
-   *      under a fresh id ... matching on the id alone would call a live
-   *      prompt gone"). V1 applied no such guard to this mechanism.
-   *   2. Even a GENUINELY different render can be silently swallowed by
-   *      `QuestionDedup`'s 5s same-fingerprint window before it ever reaches
-   *      `SessionRegistry.addQuestion` -- and V1 resolved the OLD id
-   *      regardless, on the strength of the new render having merely been
-   *      PARSED, not actually delivered. Reachable in production: a false-
-   *      positive PTY-text status parse (`output-processor.ts`'s >= 0.5
-   *      confidence gate) flips status out of 'waiting' without resetting
-   *      `QuestionDedup` (cli.ts only resets it when no hook server is
-   *      active), status flips back to 'waiting' with the SAME prompt still
-   *      on screen, the redraw parses under a fresh id, and dedup silently
-   *      eats it -- net effect: the daemon told the client the question was
-   *      cancelled while the identical prompt sat unanswered on the real
-   *      screen. That is the disqualifying failure for this epic.
-   *
-   * `isQuestionLive` closes both: `pairAndPush` calls `deps.push(merged)`
-   * FIRST (synchronously; nothing in the push -> `MessageAPI.handleQuestion`
-   * -> `QuestionDedup` -> `SessionRegistry.addQuestion` chain is async), THEN
-   * asks this dep whether `merged.id` actually landed. Only a CONFIRMED
-   * landing is evidence the previously-tracked hook-less question is gone;
-   * an unconfirmed (deduped, or the dep unset) push changes nothing --
-   * `observedHooklessQuestion` is left exactly as it was, matching the "fail
-   * toward showing" rule every other ambiguous path in this codebase follows
-   * (`auto-approve-gate.ts`, "every ambiguous path resolves toward showing
-   * the user"). Defaults to `false` (not confirmed) when unset: losing this
-   * ONE resolution trigger is an acceptable cost; swallowing a live question
-   * is not. MUST be synchronous and non-throwing, called inline with no
-   * surrounding try/catch.
-   */
-  isQuestionLive?: (questionId: string) => boolean;
 }
 
 export class QuestionPresenceTracker {
@@ -616,23 +590,59 @@ export class QuestionPresenceTracker {
    * check lives only in `onPTYPromptVisible`; the #751 parked-render path and
    * the escalate-release path call this directly so an in-flight eval cannot
    * re-capture a prompt that has already won its arbitration.
+   *
+   * #888/#920 render-resolution, CONFIRMED-delivery gate: the confirmation
+   * that a hook-less question's replacement actually registered comes
+   * DIRECTLY from `push`'s own `QuestionRegistrationOutcome` return value
+   * (#888 criterion iii) rather than a separate `isQuestionLive` re-query of
+   * the store after the fact -- the information flows from the call itself.
+   * The push is synchronous end to end (push -> `MessageAPI.handleQuestion`
+   * -> `QuestionDedup` -> `SessionRegistry.addQuestion`), so the returned
+   * outcome is exactly as current as a post-hoc store query would have been.
+   *
+   * An id-comparison-only version of this check (this file's own V1) could
+   * resolve a question that never actually left the screen, for two reasons
+   * found in review:
+   *   1. The PTY parser mints a FRESH id on every single parse (#486), even
+   *      when a prompt merely REDRAWS with unchanged text -- the exact
+   *      hazard `isPromptCurrent`'s own text fallback already documents
+   *      elsewhere in this file ("a prompt that merely redraws re-emits
+   *      under a fresh id ... matching on the id alone would call a live
+   *      prompt gone"). V1 applied no such guard to this mechanism.
+   *   2. Even a GENUINELY different render can be silently swallowed by
+   *      `QuestionDedup`'s 5s same-fingerprint window before it ever reaches
+   *      `SessionRegistry.addQuestion` -- and V1 resolved the OLD id
+   *      regardless, on the strength of the new render having merely been
+   *      PARSED, not actually delivered. Reachable in production: a false-
+   *      positive PTY-text status parse (`output-processor.ts`'s >= 0.5
+   *      confidence gate) flips status out of 'waiting' without resetting
+   *      `QuestionDedup` (cli.ts only resets it when no hook server is
+   *      active), status flips back to 'waiting' with the SAME prompt still
+   *      on screen, the redraw parses under a fresh id, and dedup silently
+   *      eats it -- net effect: the daemon told the client the question was
+   *      cancelled while the identical prompt sat unanswered on the real
+   *      screen. That is the disqualifying failure for this epic.
+   *
+   * A push whose returned status is not `'registered'` (deduped, or the push
+   * sink does not report an outcome at all) changes nothing: an unconfirmed
+   * push must not resolve anything, matching the "fail toward showing" rule
+   * every other ambiguous path in this codebase follows (`auto-approve-gate.ts`,
+   * "every ambiguous path resolves toward showing the user"). Losing this ONE
+   * resolution trigger on an unconfirmed push is an acceptable cost;
+   * swallowing a live question is not.
    */
   private pairAndPush(ptyQuestion: Question): void {
     const { merged, hookRecord } = this.consumeAndMerge(ptyQuestion);
     this.ptyShowingQuestion = true;
-    this.pushMerged(merged);
-    // #888/#920 render-resolution, CONFIRMED-delivery gate (see
-    // `isQuestionLive`'s doc for why an id comparison alone is unsound). The
-    // push above is synchronous end to end (push -> MessageAPI.handleQuestion
-    // -> QuestionDedup -> SessionRegistry.addQuestion), so by this line the
-    // registry already reflects whether `merged` actually landed.
-    const delivered = this.deps.isQuestionLive?.(merged.id) ?? false;
+    const outcome = this.pushMerged(merged);
+    const delivered = outcome?.status === 'registered';
     if (!delivered) {
-      // Not confirmed (deduped, or the dep is unset): nothing is known to
-      // have changed. Leave `observedHooklessQuestion` exactly as it was --
-      // if it was tracking an older id, that question is STILL the best
-      // evidence of what's on screen, and must not be resolved on the
-      // strength of a replacement that never actually registered.
+      // Not confirmed (deduped, or the push sink returned no outcome):
+      // nothing is known to have changed. Leave `observedHooklessQuestion`
+      // exactly as it was -- if it was tracking an older id, that question
+      // is STILL the best evidence of what's on screen, and must not be
+      // resolved on the strength of a replacement that never actually
+      // registered.
       return;
     }
     if (this.observedHooklessQuestion !== null && this.observedHooklessQuestion !== merged.id) {
@@ -786,20 +796,28 @@ export class QuestionPresenceTracker {
   /** Push a merged question through the sink. Push errors are caught and
    *  logged but not rethrown — for a live render the next PTY emit for the
    *  same prompt retries WITHOUT the hook merge, which beats crashing on a
-   *  network blip.
+   *  network blip. Returns the sink's `QuestionRegistrationOutcome` (#888
+   *  criterion iii) so `pairAndPush` can consume it directly as its
+   *  confirmed-delivery signal; a thrown push (caught below) or a sink that
+   *  reports no outcome both surface as `undefined`, treated identically by
+   *  the caller (not confirmed).
    *
    *  `context` (#814) names the caller in the error line, because that retry
    *  argument does NOT hold for a post-arbitration push: its pending record
    *  was consumed at render time and a prompt sitting idle may never redraw,
    *  so a throw there is an unrecoverable missed notification and has to be
    *  greppable as such. */
-  private pushMerged(merged: Question, context = 'render'): void {
+  private pushMerged(
+    merged: Question,
+    context = 'render',
+  ): QuestionRegistrationOutcome | undefined {
     try {
-      this.push(merged);
+      return this.push(merged);
     } catch (err) {
       console.error(
         `[QuestionPresenceTracker] push sink threw (${context}): ${err instanceof Error ? err.message : String(err)}`,
       );
+      return undefined;
     }
   }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1551,6 +1551,13 @@ async function createNewSession(
   // silent paths never push. `hasLiveQuestions` backs the #712 orphan-prompt
   // fallback: it is how the tracker tells a PTY echo of a gate-pushed
   // escalation (already registered here) apart from a genuine orphan.
+  //
+  // The push callback forwards `messageApi.handleQuestion`'s
+  // `QuestionRegistrationOutcome` return straight through (#888 criterion
+  // iii): the tracker's own confirmed-delivery gate (`pairAndPush`) now
+  // consumes that value directly instead of a separate `isQuestionLive`
+  // dep that re-queried `sessionRegistry.getQuestion` after the fact -- the
+  // deleted dep used to live here.
   const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts), {
     hasLiveQuestions: () => (sessionRegistry.getSession(sessionId)?.currentQuestions.size ?? 0) > 0,
     // #888/#920 hard requirement: a hook-less pending question (no
@@ -1572,14 +1579,6 @@ async function createNewSession(
       );
       onQuestionResolved(sessionId, questionId as UUID, 'cancelled');
     },
-    // Confirmation gate for the above (#888 review fix): only a push that
-    // ACTUALLY landed in the single pendingness owner is evidence a
-    // previously-tracked question was superseded -- see
-    // `isQuestionLive`'s doc on the tracker for the swallow class this
-    // closes (a redraw's replacement push silently eaten by QuestionDedup
-    // must not resolve the still-live original).
-    isQuestionLive: (questionId) =>
-      sessionRegistry.getQuestion(sessionId, questionId as UUID) !== null,
   });
   // #920: register this session's tracker so the answer handler's
   // prompt-currency guard (input-events.ts) can reach it by sessionId.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -92,7 +92,7 @@
 import { createSessionUpdate, createSessionViews, errorToString } from '@remi/shared';
 import type { AgentStatus, ProtocolMessage, UUID } from '@remi/shared';
 
-import type { MessageAPI } from '../../api/message-api.ts';
+import type { MessageAPI, QuestionRegistrationOutcome } from '../../api/message-api.ts';
 import type { QuestionPresenceTracker } from '../../api/question-presence-tracker.ts';
 import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import {
@@ -440,19 +440,22 @@ export function setupHookBridge(
    *
    * `handleElicitation` mints an id and returns it unconditionally, but the
    * emission behind it is fire-and-forget and can be dropped: `MessageAPI.
-   * handleQuestion` returns void and silently skips `addQuestion` when
-   * `QuestionDedup.shouldEmit` is false (`message-api.ts`). A re-fired
-   * `Elicitation` for the SAME `elicitation_id` is exactly that case — same
-   * `mcp_server_name`/`message` text, same `options: []` + `allowsFreeText:
-   * true`, so never "richer" — and the dedup baseline is still live because
-   * `handleElicitation` emits the question BEFORE its `onStatusChange
-   * ('waiting')`, so status never leaves 'waiting' to reset it. Overwriting
-   * blindly therefore pointed the map at a card that was never registered,
-   * leaving the FIRST card (the one the user can actually see) unreachable:
-   * `ElicitationResult` resolved the phantom, and the live card could only
-   * clear by the user answering it or LRU eviction. Same defect class as #925
-   * — a resolution path that cannot reach the question it is for — so the same
-   * guard: confirm the target is really registered.
+   * handleQuestion` skips `addQuestion` when `QuestionDedup.shouldEmit` is
+   * false (`message-api.ts`) -- reported honestly today via its
+   * `QuestionRegistrationOutcome` return (#888 criterion iii; before that
+   * fix, `handleQuestion` returned `void` and the caller had to re-query
+   * `SessionRegistry` to find out). A re-fired `Elicitation` for the SAME
+   * `elicitation_id` is exactly that dedup case — same `mcp_server_name`/
+   * `message` text, same `options: []` + `allowsFreeText: true`, so never
+   * "richer" — and the dedup baseline is still live because `handleElicitation`
+   * emits the question BEFORE its `onStatusChange('waiting')`, so status
+   * never leaves 'waiting' to reset it. Overwriting blindly therefore
+   * pointed the map at a card that was never registered, leaving the FIRST
+   * card (the one the user can actually see) unreachable: `ElicitationResult`
+   * resolved the phantom, and the live card could only clear by the user
+   * answering it or LRU eviction. Same defect class as #925 — a resolution
+   * path that cannot reach the question it is for — so the same guard:
+   * confirm the target is really registered.
    *
    * Note the rule is the OPPOSITE of `cancelExternallyResolved`-before-
    * register (`auto-approve-gate.ts`), which resolves the earlier entry so the
@@ -461,9 +464,17 @@ export function setupHookBridge(
    * dialog, and the newer card is the one that does not exist; keeping the
    * older, still-live card is what makes `ElicitationResult` able to close it.
    */
-  const rememberElicitation = (elicitationId: string, questionId: UUID): void => {
+  const rememberElicitation = (
+    elicitationId: string,
+    questionId: UUID,
+    outcome: QuestionRegistrationOutcome | undefined,
+  ): void => {
     const previous = elicitationQuestions.get(elicitationId);
     if (previous !== undefined && previous !== questionId) {
+      // Distinct question, about the PREVIOUSLY tracked entry: whether THAT
+      // card is still live right now cannot come from this call's own return
+      // value (it is about a different id, possibly minutes old), so this
+      // half genuinely has to ask the store.
       const previousIsLive = sessionRegistry.getQuestion(sessionId, previous) !== null;
       if (previousIsLive) {
         logError(
@@ -472,12 +483,17 @@ export function setupHookBridge(
         return;
       }
     }
-    // Confirmed delivery, the #925 gate: `addQuestion` runs synchronously
-    // inside the `onQuestion` chain, so by now the card is either registered
-    // or was dropped. Tracking an id that never registered would make
+    // Confirmed delivery, the #925 gate (#888 criterion iii): consumes the
+    // `QuestionRegistrationOutcome` `handleElicitation` already returned for
+    // THIS exact call, instead of re-querying `SessionRegistry` after the
+    // fact -- the information flows from the call itself, which is
+    // synchronous end to end (`handleElicitation` -> `onQuestion` ->
+    // `MessageAPI.handleQuestion` -> `QuestionDedup` -> `addQuestion`), so the
+    // returned outcome is exactly as current as a post-hoc query would have
+    // been. Tracking an id that never registered would make
     // `ElicitationResult` broadcast a dismiss for a card no client ever saw
     // and consume a slot under `MAX_PENDING_ELICITATIONS` for nothing.
-    if (sessionRegistry.getQuestion(sessionId, questionId) === null) {
+    if (outcome?.status !== 'registered') {
       logError(
         `[Hooks] Elicitation card ${questionId} for ${elicitationId} was not registered (deduped as a repeat of a still-open prompt); not tracking it`,
       );
@@ -550,10 +566,14 @@ export function setupHookBridge(
       // client + lock screen, since the PTY-render push that used to deliver it
       // is suppressed for hooked sessions.
       if (question.source === 'permission_request') {
+        // recordPendingHook only stashes -- no `handleQuestion` call happens
+        // here, so there is no registration outcome to report (#888 criterion
+        // iii). This question is not registered until a later PTY render
+        // pairs with it (`QuestionPresenceTracker.pairAndPush`).
         tracker.recordPendingHook(question);
-      } else {
-        messageApi.handleQuestion(question);
+        return undefined;
       }
+      return messageApi.handleQuestion(question);
     },
   });
 
@@ -1149,9 +1169,9 @@ export function setupHookBridge(
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
     try {
-      const questionId = hookBridge.handleElicitation(input);
+      const { questionId, outcome } = hookBridge.handleElicitation(input);
       if (input.elicitation_id) {
-        rememberElicitation(input.elicitation_id, questionId);
+        rememberElicitation(input.elicitation_id, questionId, outcome);
       }
     } catch (err) {
       logError(`[Hooks] Elicitation handling failed for ${sessionId}: ${errorToString(err)}`);

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -30,6 +30,7 @@
 
 import { DEFAULT_PERMISSION_LABELS, generateId } from '@remi/shared';
 import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
+import type { QuestionRegistrationOutcome } from '../api/message-api.ts';
 import type { HookServerEvents } from './hook-server.ts';
 import type {
   ElicitationHookInput,
@@ -49,7 +50,23 @@ import { extractToolQuestion } from './tool-question.ts';
 
 export interface HookBridgeEvents {
   onStatusChange: (status: AgentStatus, context?: string) => void;
-  onQuestion: (question: Question) => void;
+  /**
+   * Returns the `QuestionRegistrationOutcome` (#888 criterion iii) when the
+   * implementation routed `question` through `MessageAPI.handleQuestion` --
+   * the ordinary direct-emit path every question source but
+   * 'permission_request' takes. A 'permission_request' question is instead
+   * stashed via `QuestionPresenceTracker.recordPendingHook` (no
+   * `handleQuestion` call happens at hook time; that question is not
+   * registered until a later PTY render pairs with it), so implementations
+   * return `undefined` for that branch. `handleElicitation`'s caller
+   * (`hook-bridge-setup.ts`'s `Elicitation` listener) consumes this directly
+   * instead of re-querying `SessionRegistry` after the fact (#925 gate).
+   * `| undefined` (not `| void` -- this codebase's lint config forbids `void`
+   * inside a union) covers every implementation that does not care about the
+   * outcome (`handlePermissionRequest`, `handleStopFailure`, and every test
+   * double that only collects emitted questions).
+   */
+  onQuestion: (question: Question) => QuestionRegistrationOutcome | undefined;
 }
 
 /** Honest Yes/No fallback options (#718): used when a PermissionRequest
@@ -554,8 +571,15 @@ export class HookEventBridge {
    * a later `ElicitationResult` (matched by `elicitation_id`, an exact key
    * both events carry) to resolve this exact card — the same "don't leave a
    * pending card with no resolution signal" shape as `PermissionDenied`.
+   * Also returns the `QuestionRegistrationOutcome` `onQuestion` reported for
+   * this exact call (#888 criterion iii), so the caller can tell whether the
+   * card actually registered WITHOUT a separate `SessionRegistry` re-query
+   * (`rememberElicitation`'s "was not registered" guard, `hook-bridge-setup.ts`).
    */
-  handleElicitation(input: ElicitationHookInput): UUID {
+  handleElicitation(input: ElicitationHookInput): {
+    questionId: UUID;
+    outcome: QuestionRegistrationOutcome | undefined;
+  } {
     const question: Question = {
       id: generateId(),
       text: input.message
@@ -573,9 +597,9 @@ export class HookEventBridge {
       // direct-emits, same as a source-less StopFailure card.
       source: 'elicitation',
     };
-    this.events.onQuestion(question);
+    const outcome = this.events.onQuestion(question);
     this.events.onStatusChange('waiting');
-    return question.id;
+    return { questionId: question.id, outcome };
   }
 
   handleSessionEnd(_input: SessionEndHookInput): void {

--- a/packages/daemon/tests/api/question-identity.test.ts
+++ b/packages/daemon/tests/api/question-identity.test.ts
@@ -144,6 +144,7 @@ function buildPipeline(
     (q) => {
       pushed.push(q);
       registry.addQuestion(SID, q, 'tracker-push');
+      return undefined;
     },
     { hasLiveQuestions: () => (registry.getSession(SID)?.currentQuestions.size ?? 0) > 0 },
   );
@@ -154,6 +155,7 @@ function buildPipeline(
       if (q.source === 'permission_request' || q.source === 'notification') {
         tracker.recordPendingHook(q);
       }
+      return undefined;
     },
   });
 

--- a/packages/daemon/tests/api/question-presence-tracker-messageapi-integration.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-messageapi-integration.test.ts
@@ -13,8 +13,9 @@
  * it always owns) + `QuestionPresenceTracker`, wired exactly the way
  * `cli.ts`'s `createNewSession` wires them:
  *   - the tracker's push sink is `messageApi.handleQuestion`, not a raw
- *     collector;
- *   - `isQuestionLive` reads `sessionRegistry.getQuestion`;
+ *     collector -- its `QuestionRegistrationOutcome` return (#888 criterion
+ *     iii) IS the confirmed-delivery signal `pairAndPush` consumes directly,
+ *     replacing the `isQuestionLive` dep this suite used to wire separately;
  *   - `onHooklessQuestionGone` calls `sessionRegistry.removeQuestion`.
  *
  * It reproduces the exact failure chain review found in the V1 mechanism:
@@ -91,7 +92,6 @@ function buildPipeline(): Pipeline {
   );
 
   const tracker = new QuestionPresenceTracker((q, opts) => messageApi.handleQuestion(q, opts), {
-    isQuestionLive: (id) => sessionRegistry.getQuestion(sid, id as UUID) !== null,
     onHooklessQuestionGone: (id, reason) => {
       sessionRegistry.removeQuestion(
         sid,

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -24,18 +24,22 @@
  * reported cancelled. Net: a live question, swallowed, in one status hiccup.
  *
  * This suite now pins the corrected design: `pairAndPush` pushes first, then
- * asks `isQuestionLive` to CONFIRM the replacement actually landed before
- * resolving the question it superseded (`QuestionPresenceTracker`'s own
- * `isQuestionLive` doc has the full chain). The status-leaves-'waiting' and
- * `clearPending` triggers were dropped entirely -- neither can be trusted as
- * evidence a SPECIFIC question's render is gone (see their own reset
- * comments in the tracker) -- so this suite also pins that they no longer
- * resolve anything.
+ * reads the `QuestionRegistrationOutcome` the push call itself returned
+ * (#888 criterion iii) to CONFIRM the replacement actually landed before
+ * resolving the question it superseded (`QuestionPresenceTracker.pairAndPush`'s
+ * own doc has the full chain -- this used to be a separate `isQuestionLive`
+ * dep that re-queried a store after the fact; deleted once the push's own
+ * return value could report the same thing directly). The status-leaves-
+ * 'waiting' and `clearPending` triggers were dropped entirely -- neither can
+ * be trusted as evidence a SPECIFIC question's render is gone (see their own
+ * reset comments in the tracker) -- so this suite also pins that they no
+ * longer resolve anything.
  */
 
 import { describe, expect, test } from 'bun:test';
 import type { Question, QuestionOption } from '@remi/shared';
 import { generateId } from '@remi/shared';
+import type { QuestionRegistrationOutcome } from '../../src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../src/api/question-presence-tracker.ts';
 
 function makeOption(
@@ -92,8 +96,11 @@ interface BuildOpts {
   /** Simulates QuestionDedup: return false to make a specific push NOT
    *  land (as if suppressed). Defaults to "every push lands". */
   shouldDeliver?: (q: Question) => boolean;
-  /** Omit isQuestionLive entirely, to test the safe-default (unwired) case. */
-  wireIsQuestionLive?: boolean;
+  /** Make the push sink report no outcome at all (`void`), to test the
+   *  safe-default case a push sink that does not implement the
+   *  `QuestionRegistrationOutcome` contract falls into. Defaults to
+   *  reporting the real outcome every time. */
+  reportOutcome?: boolean;
 }
 
 function buildTracker(opts: BuildOpts = {}): Harness {
@@ -101,18 +108,20 @@ function buildTracker(opts: BuildOpts = {}): Harness {
   const gone: Array<{ id: string; reason: string }> = [];
   const liveIds = new Set<string>();
   const shouldDeliver = opts.shouldDeliver ?? (() => true);
-  const wireIsQuestionLive = opts.wireIsQuestionLive ?? true;
+  const reportOutcome = opts.reportOutcome ?? true;
   const tracker = new QuestionPresenceTracker(
-    (q) => {
+    (q): QuestionRegistrationOutcome | undefined => {
       pushed.push(q);
-      if (shouldDeliver(q)) liveIds.add(q.id);
+      const delivered = shouldDeliver(q);
+      if (delivered) liveIds.add(q.id);
+      if (!reportOutcome) return undefined;
+      return delivered ? { status: 'registered' } : { status: 'deduped' };
     },
     {
       onHooklessQuestionGone: (id, reason) => {
         gone.push({ id, reason });
         liveIds.delete(id);
       },
-      ...(wireIsQuestionLive ? { isQuestionLive: (id: string) => liveIds.has(id) } : {}),
       ...opts.extraDeps,
     },
   );
@@ -256,18 +265,16 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
   });
 
   test('a throwing onHooklessQuestionGone dep is caught and logged, never propagated', () => {
-    const liveIds = new Set<string>();
     const pushed: Question[] = [];
     const tracker = new QuestionPresenceTracker(
-      (q) => {
+      (q): QuestionRegistrationOutcome => {
         pushed.push(q);
-        liveIds.add(q.id);
+        return { status: 'registered' };
       },
       {
         onHooklessQuestionGone: () => {
           throw new Error('boom');
         },
-        isQuestionLive: (id) => liveIds.has(id),
       },
     );
     const first = makeHooklessPTYQuestion('first');
@@ -282,6 +289,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     const pushed: Question[] = [];
     const tracker = new QuestionPresenceTracker((q) => {
       pushed.push(q);
+      return undefined;
     });
     const first = makeHooklessPTYQuestion('first');
     const second = makeHooklessPTYQuestion('second');
@@ -293,15 +301,16 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(pushed).toHaveLength(2);
   });
 
-  test('safe default: onHooklessQuestionGone wired but isQuestionLive NOT wired -- never resolves (fail toward showing)', () => {
-    const { tracker, gone } = buildTracker({ wireIsQuestionLive: false });
+  test('safe default: onHooklessQuestionGone wired but the push sink reports NO outcome -- never resolves (fail toward showing)', () => {
+    const { tracker, gone } = buildTracker({ reportOutcome: false });
     const first = makeHooklessPTYQuestion('first');
     const second = makeHooklessPTYQuestion('second');
     tracker.onPTYPromptVisible(first);
     tracker.onPTYPromptVisible(second);
 
-    // Without confirmation, "delivered" defaults to false -- the mechanism
-    // is fully inert, matching pre-#888 behavior rather than guessing.
+    // Without a reported outcome, "delivered" defaults to false -- the
+    // mechanism is fully inert, matching pre-#888 behavior rather than
+    // guessing.
     expect(gone).toHaveLength(0);
   });
 

--- a/packages/daemon/tests/api/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker.test.ts
@@ -69,7 +69,10 @@ describe('QuestionPresenceTracker', () => {
     // Covers anthropics/claude-code #23983: subagent permission requests
     // do not fire hooks at all; PTY is the only source and must still push.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     const ptyQ = makePTYQuestion('Subagent prompt visible');
 
     tracker.onPTYPromptVisible(ptyQ);
@@ -84,7 +87,10 @@ describe('QuestionPresenceTracker', () => {
     // matches neither must NOT guess — push the bare PTY question rather than
     // attach the wrong agent's option labels (#425).
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash A?'), agentId: 'subagent-A' });
     tracker.recordPendingHook({ ...makeHookQuestion('Allow Edit B?'), agentId: 'subagent-B' });
     const ptyQ = makePTYQuestion('Some prompt'); // no agentId -> 'main', matches neither
@@ -98,7 +104,10 @@ describe('QuestionPresenceTracker', () => {
 
   it('exactly one pending hook, PTY names no agent -> still pairs unambiguously (#483)', () => {
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash?'), agentId: 'subagent-A' });
     const ptyQ = makePTYQuestion('Allow Bash?'); // no agentId, but only one candidate
     tracker.onPTYPromptVisible(ptyQ);
@@ -108,7 +117,10 @@ describe('QuestionPresenceTracker', () => {
 
   it('hook then PTY — pushes once with the hook rich text + options (#497)', () => {
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     // Reality: the hook carries the rich tool/command text; the PTY is the bare
     // terminal prompt that confirms the prompt is on screen.
     const hookMeta = makeHookQuestion('Allow Edit: /tmp/foo.ts');
@@ -133,7 +145,10 @@ describe('QuestionPresenceTracker', () => {
 
   it('falls back to the PTY text when the hook text is empty (#497)', () => {
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     const hookMeta = { ...makeHookQuestion(''), text: '' };
     const ptyQ = makePTYQuestion('Do you want to proceed?');
     tracker.recordPendingHook(hookMeta);
@@ -145,7 +160,10 @@ describe('QuestionPresenceTracker', () => {
     // Auto-approve in progress: hook fired, LLM is evaluating. We have
     // not yet seen the prompt on screen. No push must fire yet.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.recordPendingHook(makeHookQuestion('Bash'));
 
@@ -159,7 +177,10 @@ describe('QuestionPresenceTracker', () => {
     // screen; the iOS user must not be poked for a prompt that no longer
     // exists.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.recordPendingHook(makeHookQuestion('Bash'));
     tracker.onStatusChange('executing');
@@ -170,7 +191,10 @@ describe('QuestionPresenceTracker', () => {
 
   it('hook then status transitions to thinking — pending dropped, no push', () => {
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.recordPendingHook(makeHookQuestion('Bash'));
     tracker.onStatusChange('thinking');
@@ -184,7 +208,10 @@ describe('QuestionPresenceTracker', () => {
     // status update arrives (e.g. hook-bridge's onStatusChange) — must
     // NOT drop the pending; we're still expecting PTY confirmation.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.recordPendingHook(makeHookQuestion('Edit'));
     tracker.onStatusChange('waiting');
@@ -199,7 +226,10 @@ describe('QuestionPresenceTracker', () => {
     // counts as a second hook arrival. Only the user-visible prompt
     // matters; pair the most recent hook with the PTY confirmation.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     const ptyQ = makePTYQuestion();
 
     tracker.recordPendingHook(makeHookQuestion('Bash'));
@@ -227,7 +257,10 @@ describe('QuestionPresenceTracker', () => {
     // both; clearing pending state on status change does not block the
     // next PTY emission.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.onPTYPromptVisible(makePTYQuestion('first'));
     tracker.onStatusChange('executing');
@@ -244,7 +277,10 @@ describe('QuestionPresenceTracker', () => {
     // only suggestion that hook-event-bridge filtered out). We should
     // still push, but with the PTY question's own options.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
     const ptyQ = makePTYQuestion();
 
     const emptyOptionsHook: Question = {
@@ -267,7 +303,10 @@ describe('QuestionPresenceTracker', () => {
     // a slash command). Without clearPending, the pending hook would
     // merge stale option labels onto the next unrelated prompt.
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      return undefined;
+    });
 
     tracker.recordPendingHook(makeHookQuestion('Edit'));
     expect(tracker.hasPendingForTest()).toBe(true);
@@ -285,7 +324,7 @@ describe('QuestionPresenceTracker', () => {
     // next subagent PermissionRequest arriving before any onStatusChange
     // would find the gate open and inject "1"/"3" into a PTY that is no
     // longer showing a prompt.
-    const tracker = new QuestionPresenceTracker(() => {});
+    const tracker = new QuestionPresenceTracker(() => undefined);
     tracker.onPTYPromptVisible(makePTYQuestion());
     expect(tracker.isPromptVisibleOnPTY()).toBe(true);
 
@@ -311,7 +350,7 @@ describe('QuestionPresenceTracker', () => {
 
   describe('isPromptVisibleOnPTY (subagent auto-approve gate)', () => {
     it('starts false before any PTY confirmation', () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
     });
 
@@ -320,19 +359,19 @@ describe('QuestionPresenceTracker', () => {
       // the prompt is NOT on the main PTY. The gate must report false so
       // hook-bridge-setup drops the inject instead of typing "1" into
       // the main agent's input.
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.recordPendingHook(makeHookQuestion('Bash'));
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
     });
 
     it('flips to true once PTY confirms a prompt is on screen', () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.onPTYPromptVisible(makePTYQuestion());
       expect(tracker.isPromptVisibleOnPTY()).toBe(true);
     });
 
     it('flips back to false when status leaves waiting (prompt consumed)', () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.onPTYPromptVisible(makePTYQuestion());
       expect(tracker.isPromptVisibleOnPTY()).toBe(true);
       tracker.onStatusChange('executing');
@@ -340,14 +379,14 @@ describe('QuestionPresenceTracker', () => {
     });
 
     it("stays true while status stays 'waiting'", () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.onPTYPromptVisible(makePTYQuestion());
       tracker.onStatusChange('waiting');
       expect(tracker.isPromptVisibleOnPTY()).toBe(true);
     });
 
     it('also flips false on transition to thinking or idle', () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.onPTYPromptVisible(makePTYQuestion());
       tracker.onStatusChange('thinking');
       expect(tracker.isPromptVisibleOnPTY()).toBe(false);
@@ -361,7 +400,10 @@ describe('QuestionPresenceTracker', () => {
   describe('PermissionRequest vs Notification merge policy (#574)', () => {
     it('a trailing generic Notification does NOT overwrite a rich PermissionRequest for the same agent', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       // Claude fires both for one prompt: the rich request first, the bland
       // notification second. The notification must be dropped.
       tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push origin main'));
@@ -380,7 +422,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a source-less (StopFailure-shaped) question does NOT evict a pending permission_request, but a newer permission_request DOES replace it (FIX 2A)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: git push'));
 
       // A StopFailure "Retry?" card for the same agent carries no source; it
@@ -405,11 +450,14 @@ describe('QuestionPresenceTracker', () => {
       expect(pushes[0]?.text).toBe('Allow Bash: git push');
 
       // A genuinely new permission cycle (another permission_request) DOES replace it.
-      const tracker2 = new QuestionPresenceTracker(() => {});
+      const tracker2 = new QuestionPresenceTracker(() => undefined);
       tracker2.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
       tracker2.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
       const pushes2: Question[] = [];
-      const tracker3 = new QuestionPresenceTracker((q) => pushes2.push(q));
+      const tracker3 = new QuestionPresenceTracker((q) => {
+        pushes2.push(q);
+        return undefined;
+      });
       tracker3.recordPendingHook(makePermissionRequestHook('Allow Bash: old cmd'));
       tracker3.recordPendingHook(makePermissionRequestHook('Allow Edit: new cmd'));
       tracker3.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
@@ -418,7 +466,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a PermissionRequest arriving AFTER a Notification still wins (richer replaces generic)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.recordPendingHook(makeNotificationHook());
       tracker.recordPendingHook(makePermissionRequestHook('Allow Edit: /tmp/foo.ts'));
 
@@ -430,7 +481,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('raw PTY text never wins over the hook text for the notification (#574 issue 3)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: rm -rf build'));
       // The PTY's literal screen text is the bare prompt; it must not surface.
       tracker.onPTYPromptVisible(makePTYQuestion('Do you want to proceed?'));
@@ -444,7 +498,10 @@ describe('QuestionPresenceTracker', () => {
       // so they remain answerable; the drop only applies when a richer request
       // for the SAME agent already exists.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.recordPendingHook(makeNotificationHook('Claude needs your permission to use Bash'));
       expect(tracker.hasPendingForTest()).toBe(true);
 
@@ -454,7 +511,7 @@ describe('QuestionPresenceTracker', () => {
     });
 
     it("different agents: a notification for agent B does not touch agent A's request", () => {
-      const tracker = new QuestionPresenceTracker(() => {});
+      const tracker = new QuestionPresenceTracker(() => undefined);
       tracker.recordPendingHook({
         ...makePermissionRequestHook('Allow Bash A'),
         agentId: 'agent-A',
@@ -471,7 +528,10 @@ describe('QuestionPresenceTracker', () => {
   describe('fallback options do not overwrite PTY truth (#718)', () => {
     it('a fallback hook record loses its options to a concrete PTY option set (hook text still wins)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       const fallbackHook: Question = {
         ...makePermissionRequestHook('Allow Bash: git push'),
         options: [
@@ -513,7 +573,10 @@ describe('QuestionPresenceTracker', () => {
       // (#718 review) — the merged flag must reflect the hook record, not
       // whatever the PTY parser separately decided about ITS OWN options.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       const structuredHook: Question = {
         ...makePermissionRequestHook('Allow Bash: rm -rf /tmp/foo'),
         options: [
@@ -547,7 +610,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a suggestion-derived (non-fallback) hook record still wins over the PTY options', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       const structuredHook: Question = {
         ...makePermissionRequestHook('Allow Bash: rm -rf /tmp/foo'),
         options: [
@@ -577,7 +643,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a fallback hook record keeps its own options when the PTY question has none', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       const fallbackHook: Question = {
         ...makePermissionRequestHook('Allow Bash: git push'),
         options: [
@@ -602,7 +671,10 @@ describe('QuestionPresenceTracker', () => {
   describe('auto-approve buffer (#484)', () => {
     it('PTY prompt during an eval is BUFFERED, not pushed', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
       expect(pushes.length).toBe(0); // held until the verdict
@@ -610,7 +682,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('escalate verdict releases the buffered prompt once, merged with the hook', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
       expect(pushes.length).toBe(0);
@@ -623,7 +698,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('auto-approved (no escalate): status-leaves-waiting discards the buffer, never pushes', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
       tracker.onStatusChange('idle'); // injected silently -> agent advanced
@@ -635,7 +713,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('escalate before any PTY prompt -> the next PTY prompt pushes normally', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
       tracker.onAutoApproveEscalate(); // nothing buffered yet
@@ -646,7 +727,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('onAutoApproveHandled discards the buffer and closes the window (#484)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Read?'));
       tracker.onAutoApproveHandled(); // auto-approved -> discard, no push
@@ -663,7 +747,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a subagent eval does not open the buffer window — renders flow during it', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart(true); // subagent WebFetch eval in flight
       tracker.onPTYPromptVisible(makePTYQuestion('Teammate permission prompt'));
       expect(pushes.length).toBe(1); // NOT buffered
@@ -674,10 +761,16 @@ describe('QuestionPresenceTracker', () => {
       // window open, every hook-less teammate prompt was buffered, and each
       // unrelated approve discarded it — questions never routed at all.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.onAutoApproveStart(true);
       tracker.onOrphanPTYPrompt(makePTYQuestion('Agent-team permission prompt'));
       tracker.onAutoApproveHandled(true); // unrelated approve lands
@@ -688,7 +781,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a subagent approve does not discard a MAIN-buffered prompt', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart(); // main eval opens the window
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
       expect(pushes.length).toBe(0);
@@ -701,7 +797,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('a subagent escalate (park path) does not release a MAIN-buffered prompt early', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onPTYPromptVisible(makePTYQuestion('Allow Bash?'));
       tracker.onAutoApproveEscalate(true); // a teammate's park fires the cue
@@ -714,9 +813,15 @@ describe('QuestionPresenceTracker', () => {
       // The #751 push trigger must survive the eval storm: park -> render ->
       // push, regardless of whichever other agent is being evaluated.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+        },
+      );
       tracker.parkAwaitingPTY({
         ...makePermissionRequestHook('researcher · WebFetch: example.com'),
         agentId: 'subagent-A',
@@ -729,9 +834,15 @@ describe('QuestionPresenceTracker', () => {
 
     it('a parked render wins over the main-eval buffer (parked check runs first)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+        },
+      );
       tracker.parkAwaitingPTY({
         ...makePermissionRequestHook('researcher · Edit: notes.md'),
         agentId: 'subagent-A',
@@ -749,7 +860,10 @@ describe('QuestionPresenceTracker', () => {
 
     it('concurrent main evals: the first verdict does not close the window the second owns', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q));
+      const tracker = new QuestionPresenceTracker((q) => {
+        pushes.push(q);
+        return undefined;
+      });
       tracker.onAutoApproveStart();
       tracker.onAutoApproveStart();
       tracker.onAutoApproveHandled(); // first settles; window must stay open
@@ -769,10 +883,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('genuine orphan (no live questions, no pending hooks, no eval) pushes after the debounce', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       const ptyQ = makePTYQuestion('Agent-team permission prompt');
 
       tracker.onOrphanPTYPrompt(ptyQ);
@@ -786,12 +906,18 @@ describe('QuestionPresenceTracker', () => {
 
     it('a prompt while the gate has a live registered question does NOT push', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        // Gate already registered (and likely already pushed) a question for
-        // this prompt cycle: this is the echo the #625 suppression exists for.
-        hasLiveQuestions: () => true,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          // Gate already registered (and likely already pushed) a question for
+          // this prompt cycle: this is the echo the #625 suppression exists for.
+          hasLiveQuestions: () => true,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
       await wait(DEBOUNCE_MS * 2);
@@ -801,10 +927,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('a SAME-AGENT pending hook record does NOT double-push via the orphan path', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       // A hook fired for the main agent (no agentId -> MAIN_AGENT_ID key,
       // same as the PTY question below) and the gate has not resolved it yet.
       tracker.recordPendingHook(makeHookQuestion('Allow Bash?'));
@@ -832,10 +964,16 @@ describe('QuestionPresenceTracker', () => {
       // cross-agent attribution question this test does not assert on.
       // What matters here is that the push fires at all.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash?'), agentId: 'agent-X' });
 
       // No agentId -> keyed to MAIN_AGENT_ID, distinct from 'agent-X'.
@@ -852,10 +990,16 @@ describe('QuestionPresenceTracker', () => {
       // ambiguity: a clean demonstration that scoped ownership lets the
       // orphan through untouched by other agents' in-flight hooks.
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.recordPendingHook({ ...makeHookQuestion('Allow Bash A?'), agentId: 'agent-A' });
       tracker.recordPendingHook({ ...makeHookQuestion('Allow Edit B?'), agentId: 'agent-B' });
 
@@ -870,10 +1014,16 @@ describe('QuestionPresenceTracker', () => {
 
     it("status leaving 'waiting' before the debounce fires cancels the push", async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onOrphanPTYPrompt(makePTYQuestion('Agent-team permission prompt'));
       expect(tracker.hasArmedOrphanTimerForTest()).toBe(true);
@@ -887,10 +1037,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('clearPending cancels the armed orphan timer', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onOrphanPTYPrompt(makePTYQuestion('Agent-team permission prompt'));
       expect(tracker.hasArmedOrphanTimerForTest()).toBe(true);
@@ -904,10 +1060,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('autoApproveInFlight still buffers the orphan prompt; escalate releases it (#484 semantics unchanged)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onAutoApproveStart();
       tracker.onOrphanPTYPrompt(makePTYQuestion('Allow Bash?'));
@@ -924,10 +1086,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('a second orphan before the timer fires replaces the first — only the latest pushes, once', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onOrphanPTYPrompt(makePTYQuestion('first orphan'));
       tracker.onOrphanPTYPrompt(makePTYQuestion('second orphan'));
@@ -941,10 +1109,16 @@ describe('QuestionPresenceTracker', () => {
     it('re-checks ownership at debounce fire: a live question registered mid-window suppresses the push', async () => {
       const pushes: Question[] = [];
       let live = false;
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => live,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => live,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));
       live = true; // the gate registered a question for this cycle mid-debounce
@@ -955,12 +1129,18 @@ describe('QuestionPresenceTracker', () => {
 
     it('hasLiveQuestions() throwing is caught and treated as no live questions (fail-open)', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => {
-          throw new Error('sessionRegistry lookup blew up');
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
         },
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+        {
+          hasLiveQuestions: () => {
+            throw new Error('sessionRegistry lookup blew up');
+          },
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
 
       // Must not throw synchronously out of onOrphanPTYPrompt, and must not
       // get stuck suppressed forever — a possibly-redundant push beats a
@@ -980,10 +1160,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('a parked record + rendered prompt pushes IMMEDIATELY, merged, no debounce', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.parkAwaitingPTY(makePermissionRequestHook('reviewer · Bash: git push'));
       expect(tracker.awaitingPTYCountForTest()).toBe(1);
 
@@ -998,10 +1184,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('an unrelated LIVE question does not suppress a parked prompt (bypasses gate-owned check)', () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => true, // e.g. a held main card is open
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => true, // e.g. a held main card is open
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.parkAwaitingPTY({
         ...makePermissionRequestHook('agent · Edit: config.toml'),
         agentId: 'agent-1',
@@ -1016,10 +1208,16 @@ describe('QuestionPresenceTracker', () => {
 
     it("#763: a fresh parked record SURVIVES another agent's status churn and still merges on render", () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.parkAwaitingPTY({
         ...makePermissionRequestHook('agent · Bash: ls'),
         agentId: 'agent-A',
@@ -1038,10 +1236,16 @@ describe('QuestionPresenceTracker', () => {
 
     it("#763: noteAgentAdvanced expires exactly that agent's parked record (allowlist absorbed)", async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.parkAwaitingPTY({
         ...makePermissionRequestHook('A · Bash: ls'),
         agentId: 'agent-A',
@@ -1070,11 +1274,17 @@ describe('QuestionPresenceTracker', () => {
     it('#763: a parked record past the TTL is dropped by the next status change', () => {
       let now = 1_000_000;
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-        nowMs: () => now,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+          nowMs: () => now,
+        },
+      );
       tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
 
       now += 119_000;
@@ -1088,7 +1298,7 @@ describe('QuestionPresenceTracker', () => {
     });
 
     it("#763: NORMAL pending records still clear when status leaves 'waiting'", () => {
-      const tracker = new QuestionPresenceTracker(() => {}, {
+      const tracker = new QuestionPresenceTracker(() => undefined, {
         hasLiveQuestions: () => false,
         orphanDebounceMs: DEBOUNCE_MS,
       });
@@ -1105,7 +1315,7 @@ describe('QuestionPresenceTracker', () => {
     });
 
     it('#763: clearPending (restart/rotation) still wipes parked records', () => {
-      const tracker = new QuestionPresenceTracker(() => {}, {
+      const tracker = new QuestionPresenceTracker(() => undefined, {
         hasLiveQuestions: () => false,
         orphanDebounceMs: DEBOUNCE_MS,
       });
@@ -1117,10 +1327,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('a NORMAL pending record for the prompt agent still suppresses (echo protection intact)', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       // A normal gate escalation is mid-flight for main; a parked record
       // exists for a different agent. The unnamed PTY prompt matches main's
       // normal record -> gate-owned -> suppressed (not stolen by the parked one).
@@ -1138,10 +1354,16 @@ describe('QuestionPresenceTracker', () => {
 
     it('a normal recordPendingHook for the same agent clears the parked flag', async () => {
       const pushes: Question[] = [];
-      const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-        hasLiveQuestions: () => false,
-        orphanDebounceMs: DEBOUNCE_MS,
-      });
+      const tracker = new QuestionPresenceTracker(
+        (q) => {
+          pushes.push(q);
+          return undefined;
+        },
+        {
+          hasLiveQuestions: () => false,
+          orphanDebounceMs: DEBOUNCE_MS,
+        },
+      );
       tracker.parkAwaitingPTY(makePermissionRequestHook('agent · Bash: ls'));
       // A real gate escalation for the same agent takes over the prompt cycle.
       tracker.recordPendingHook(makePermissionRequestHook('Allow Bash: ls'));
@@ -1164,10 +1386,16 @@ describe('parked-render arbitration (#814)', () => {
     pushes: Question[],
     arbiter: Parameters<QuestionPresenceTracker['setParkedRenderArbiter']>[0],
   ): QuestionPresenceTracker {
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-      hasLiveQuestions: () => false,
-      orphanDebounceMs: DEBOUNCE_MS,
-    });
+    const tracker = new QuestionPresenceTracker(
+      (q) => {
+        pushes.push(q);
+        return undefined;
+      },
+      {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      },
+    );
     tracker.setParkedRenderArbiter(arbiter);
     return tracker;
   }
@@ -1407,10 +1635,16 @@ describe('parked-render arbitration (#814)', () => {
 
   it('without an arbiter a parked render still pushes SYNCHRONOUSLY (pre-#814 behavior)', () => {
     const pushes: Question[] = [];
-    const tracker = new QuestionPresenceTracker((q) => pushes.push(q), {
-      hasLiveQuestions: () => false,
-      orphanDebounceMs: DEBOUNCE_MS,
-    });
+    const tracker = new QuestionPresenceTracker(
+      (q) => {
+        pushes.push(q);
+        return undefined;
+      },
+      {
+        hasLiveQuestions: () => false,
+        orphanDebounceMs: DEBOUNCE_MS,
+      },
+    );
     tracker.parkAwaitingPTY(makePermissionRequestHook('reviewer · Bash: git push'));
 
     tracker.onOrphanPTYPrompt(makePTYQuestion('Do you want to proceed?'));

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -178,7 +178,7 @@ describe('AutoApproveGate', () => {
     subagent = false;
     resets = 0;
     parks = [];
-    tracker = new QuestionPresenceTracker(() => {});
+    tracker = new QuestionPresenceTracker(() => undefined);
     configureLogger({ writeLog: () => {} });
   });
 
@@ -681,7 +681,7 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
     submits = [];
     events = [];
     subagent = false;
-    tracker = new QuestionPresenceTracker(() => {});
+    tracker = new QuestionPresenceTracker(() => undefined);
     configureLogger({ writeLog: () => {} });
   });
 
@@ -809,7 +809,7 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
       handleQuestion: () => {},
       handleStatusChange: () => {},
     } as never);
-    const tracker = new QuestionPresenceTracker(() => {});
+    const tracker = new QuestionPresenceTracker(() => undefined);
     return new AutoApproveGate(
       {
         service,
@@ -1109,7 +1109,7 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
       handleQuestion: () => {},
       handleStatusChange: () => {},
     } as never);
-    const tracker = new QuestionPresenceTracker(() => {});
+    const tracker = new QuestionPresenceTracker(() => undefined);
     const gate = new AutoApproveGate(
       {
         service: {
@@ -1154,7 +1154,7 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
       {
         service: { evaluate: async () => escalate, cancel: () => true },
         sessionRegistry: registryB,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           qidB = generateId();
@@ -1220,7 +1220,7 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -1344,7 +1344,7 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -1389,7 +1389,7 @@ describe('AutoApproveGate Stop mainOnly scoping (#711)', () => {
       {
         service: evaluator(approve),
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => undefined,
         onEvalStart: (ctx) => ctxLog.push(ctx),
@@ -1447,7 +1447,7 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: (i) => {
           escalations.push(i);
@@ -1611,7 +1611,7 @@ describe('AutoApproveGate onResolved cross-client dismissal (#585 P7)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -1836,7 +1836,7 @@ describe('AutoApproveGate delivery gating (#603 Phase 1)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: (i) => {
           escalations.push(i);
@@ -2126,7 +2126,7 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
       {
         service,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: (i) => {
           escalations.push(i);
@@ -2520,7 +2520,7 @@ describe('AutoApproveGate subagent external-resolution (#799)', () => {
         // (deterministic, no eval timing to await).
         service: null,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         // Unused by these subagent-only tests (no main escalation is ever
         // driven), but AutoApproveGateDeps requires it.
@@ -2700,7 +2700,7 @@ describe('AutoApproveGate Stop resolves a still-open MAIN passthrough question (
       {
         service: null,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -2838,7 +2838,7 @@ describe('AutoApproveGate cancelStaleForAgent (#799 part 2, subagent)', () => {
       {
         service: null,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         // Unused by these subagent-only tests (no main escalation is ever
         // driven), but AutoApproveGateDeps requires it.
@@ -3098,7 +3098,7 @@ describe('AutoApproveGate parked-render arbitration (#814)', () => {
     submits = [];
     evalCalls = [];
     resolvedLog = [];
-    tracker = new QuestionPresenceTracker(() => {});
+    tracker = new QuestionPresenceTracker(() => undefined);
     configureLogger({ writeLog: () => {} });
   });
 

--- a/packages/daemon/tests/auto-approve/force-release.test.ts
+++ b/packages/daemon/tests/auto-approve/force-release.test.ts
@@ -103,7 +103,7 @@ describe('per-eval cancellation + force-release (#617)', () => {
       {
         service: harness.evaluator,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -169,7 +169,7 @@ describe('per-eval cancellation + force-release (#617)', () => {
       {
         service: null,
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => generateId(),
       },

--- a/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
+++ b/packages/daemon/tests/auto-approve/held-escalation-roundtrip.test.ts
@@ -132,6 +132,7 @@ describe('Held escalation round-trip — register + push + shared answer (#573)'
     tracker = new QuestionPresenceTracker((q) => {
       pushes.push(q);
       registry.addQuestion(SID, q);
+      return undefined;
     });
   });
 

--- a/packages/daemon/tests/auto-approve/hold-hook.test.ts
+++ b/packages/daemon/tests/auto-approve/hold-hook.test.ts
@@ -78,7 +78,7 @@ describe('Model B hold over a real HookServer (#573)', () => {
       {
         service: evaluator(escalate),
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           lastQuestionId = generateId();
@@ -159,7 +159,7 @@ describe('Model B hold over a real HookServer (#573)', () => {
       {
         service: evaluator(escalate),
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           qid = generateId();
@@ -202,7 +202,7 @@ describe('Model B hold over a real HookServer (#573)', () => {
       {
         service: evaluator(escalate),
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           qid = generateId();
@@ -240,7 +240,7 @@ describe('Model B hold over a real HookServer (#573)', () => {
       {
         service: evaluator(escalate),
         sessionRegistry: registry,
-        tracker: new QuestionPresenceTracker(() => {}),
+        tracker: new QuestionPresenceTracker(() => undefined),
         isInSubagentContext: () => false,
         escalate: () => {
           qid = generateId();

--- a/packages/daemon/tests/auto-approve/scope-isolation.test.ts
+++ b/packages/daemon/tests/auto-approve/scope-isolation.test.ts
@@ -366,7 +366,7 @@ describe('AutoApproveGate cross-session isolation via shared AutoApproveService 
   beforeEach(() => {
     server = startGatedServer();
     registries = [];
-    tracker = new QuestionPresenceTracker(() => {});
+    tracker = new QuestionPresenceTracker(() => undefined);
     configureLogger({ writeLog: () => {} });
   });
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -1560,7 +1560,10 @@ describe('setupHookBridge', () => {
     const pushed: Question[] = [];
     const localApi = fakeMessageAPI(messageApiLog);
     sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits), localApi);
-    const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushed.push(q);
+      return undefined;
+    });
 
     bridgeHandles.push(
       setupHookBridge(
@@ -1641,7 +1644,10 @@ describe('setupHookBridge', () => {
     const pushed: Question[] = [];
     const localApi = fakeMessageAPI(messageApiLog);
     sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits), localApi);
-    const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushed.push(q);
+      return undefined;
+    });
 
     bridgeHandles.push(
       setupHookBridge(
@@ -1716,7 +1722,10 @@ describe('setupHookBridge', () => {
     const pushed: Question[] = [];
     const localApi = fakeMessageAPI(messageApiLog);
     sessionRegistry.registerSession(SID, tmpDir, fakePTY(ptySubmits), localApi);
-    const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushed.push(q);
+      return undefined;
+    });
 
     bridgeHandles.push(
       setupHookBridge(
@@ -2910,6 +2919,63 @@ describe('setupHookBridge', () => {
       expect(broadcastResolvedLog[0]?.questionId).toBe(cardA as UUID);
     });
 
+    test('a re-fired Elicitation with a CHANGED message (genuinely richer, not deduped) still keeps the OLDER live card resolvable', () => {
+      // Isolates the "still live" guard (:479, `previousIsLive`) from the
+      // "was not registered" guard (:496) above -- mutation testing this
+      // suite found the test above passes even with `previousIsLive`
+      // neutered, because a byte-identical re-fire is ALSO caught by the
+      // "was not registered" guard alone (QuestionDedup suppresses an
+      // unchanged re-emission regardless). That means the test above never
+      // actually exercised this guard's own reason to exist. A DIFFERENT
+      // message for the same elicitation_id has a DIFFERENT dedup
+      // fingerprint, so QuestionDedup lets it through (registers, does not
+      // dedupe) -- the only way to isolate `previousIsLive` from the dedup
+      // guard it sits beside.
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ realMessageApi: true, broadcastResolvedLog });
+      lock('claude-889-elicit-changed');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-changed',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-changed',
+      });
+      const cardA = [...(sessionRegistry.getSession(SID)?.currentQuestions.keys() ?? [])][0];
+      expect(cardA).toBeDefined();
+
+      // Different message -> different fingerprint -> QuestionDedup does NOT
+      // suppress this one; it registers as its own, genuinely separate card.
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-changed',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city, and for what date?',
+        elicitation_id: 'elicit-changed',
+      });
+      // Both cards are real, live questions in the registry -- rememberElicitation
+      // only controls the elicitation_id CORRELATION, not whether MessageAPI
+      // registered the second card.
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(2);
+
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-changed',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-changed',
+        action: 'accept',
+      });
+
+      // The guard kept tracking card A (still live when the second fired),
+      // so THIS is the one that resolves -- card B (registered but never
+      // adopted into the correlation map) stays.
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(broadcastResolvedLog[0]?.questionId).toBe(cardA as UUID);
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+      expect(sessionRegistry.getQuestion(SID, cardA as UUID)).toBeNull();
+    });
+
     test('ElicitationResult with an UNKNOWN elicitation_id is a no-op (card, if any, stays)', () => {
       const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
       build({ realMessageApi: true, broadcastResolvedLog });
@@ -2958,6 +3024,70 @@ describe('setupHookBridge', () => {
         elicitation_id: 'some-other-id',
       });
       expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1); // still there
+    });
+
+    test('a NEW elicitation_id whose own card is deduped is never tracked (#888 criterion iii, "was not registered" guard)', () => {
+      // Distinct from the re-fired-same-id test above: that one exercises
+      // rememberElicitation's OTHER guard (a PREVIOUSLY tracked, still-live
+      // card must not be displaced -- necessarily a store re-query, since it
+      // asks about history). This test isolates the guard #888 criterion iii
+      // actually changed: a FIRST-time elicitation_id whose OWN push never
+      // registered (deduped against an unrelated still-live baseline) must
+      // not be tracked either -- decided directly from handleElicitation's
+      // returned QuestionRegistrationOutcome, not a SessionRegistry re-query.
+      const broadcastResolvedLog: Array<{ questionId: UUID; reason: string }> = [];
+      build({ realMessageApi: true, broadcastResolvedLog });
+      lock('claude-889-elicit-notreg');
+
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-notreg',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-first',
+      });
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1);
+
+      // Same mcp_server_name/message -> identical text/options/allowsFreeText
+      // fingerprint, same agent ('main'), still inside QuestionDedup's
+      // window: this second card is DEDUPED (QuestionDedup makes no
+      // exception for a different elicitation_id -- it only sees the
+      // Question). handleElicitation still mints and returns a fresh
+      // questionId regardless; that id must never reach elicitationQuestions.
+      hookServer.fire('Elicitation', {
+        session_id: 'claude-889-elicit-notreg',
+        hook_event_name: 'Elicitation',
+        mcp_server_name: 'weather-mcp',
+        message: 'Which city?',
+        elicitation_id: 'elicit-second',
+      });
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1); // no second card
+
+      // The deciding assertion: resolving the NEVER-REGISTERED id must be a
+      // no-op -- no broadcast for a card no client ever saw. Neutering the
+      // guard (`if (outcome?.status !== 'registered')`) makes this fire a
+      // phantom broadcast while every assertion above still passes.
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-notreg',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-second',
+        action: 'accept',
+      });
+      expect(broadcastResolvedLog).toHaveLength(0);
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(1); // still there
+
+      // The FIRST id, which DID register, remains resolvable -- proving the
+      // guard is scoped correctly and not just refusing everything.
+      hookServer.fire('ElicitationResult', {
+        session_id: 'claude-889-elicit-notreg',
+        hook_event_name: 'ElicitationResult',
+        mcp_server_name: 'weather-mcp',
+        elicitation_id: 'elicit-first',
+        action: 'accept',
+      });
+      expect(broadcastResolvedLog).toHaveLength(1);
+      expect(sessionRegistry.getSession(SID)?.currentQuestions.size).toBe(0);
     });
 
     test('Elicitation for a FOREIGN session_id is dropped by the admit gate', () => {

--- a/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
+++ b/packages/daemon/tests/cli/session-phases/transcript-binder-drive.test.ts
@@ -165,7 +165,7 @@ describe('TranscriptBinder drive mode (#453 phase 3, commit 5)', () => {
     const transcriptDiscovery = new TranscriptDiscovery();
     const hookServer = new RecordingHookServer();
     const messageApi = noopMessageAPI();
-    const tracker = new QuestionPresenceTracker(() => {});
+    const tracker = new QuestionPresenceTracker(() => undefined);
 
     sessionRegistry.registerSession(SID, tmpDir, fakePTY(), messageApi);
 

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -37,7 +37,10 @@ describe('HookEventBridge', () => {
           statuses.push({ status });
         }
       },
-      onQuestion: (q) => questions.push(q),
+      onQuestion: (q) => {
+        questions.push(q);
+        return undefined;
+      },
     });
 
     return { bridge, statuses, questions };
@@ -764,7 +767,7 @@ describe('HookEventBridge', () => {
     it('builds a free-text answerable card, not fabricated Accept/Decline options', () => {
       const { bridge, statuses, questions } = createBridge();
 
-      const id = bridge.handleElicitation({
+      const { questionId, outcome } = bridge.handleElicitation({
         ...makeCommon(),
         hook_event_name: 'Elicitation',
         mcp_server_name: 'some-mcp-server',
@@ -774,11 +777,16 @@ describe('HookEventBridge', () => {
 
       expect(statuses).toEqual([{ status: 'waiting' }]);
       expect(questions.length).toBe(1);
-      expect(questions[0]?.id).toBe(id);
+      expect(questions[0]?.id).toBe(questionId);
       expect(questions[0]?.text).toBe('some-mcp-server: Please provide your API key');
       expect(questions[0]?.options).toEqual([]);
       expect(questions[0]?.allowsFreeText).toBe(true);
       expect(questions[0]?.source).toBe('elicitation');
+      // #888 criterion iii: the outcome flows back from the same call --
+      // this test's onQuestion sink just collects into `questions` and
+      // returns nothing, so the outcome is `undefined` (not `'deduped'`,
+      // which would falsely imply the sink actively rejected it).
+      expect(outcome).toBeUndefined();
     });
 
     it('falls back to a generic prompt when no message is present', () => {

--- a/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
+++ b/packages/daemon/tests/hooks/hook-server-bridge-integration.test.ts
@@ -37,7 +37,10 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
       onStatusChange: (status, context) => {
         statuses.push(context !== undefined ? { status, context } : { status });
       },
-      onQuestion: (q) => questions.push(q),
+      onQuestion: (q) => {
+        questions.push(q);
+        return undefined;
+      },
     });
 
     server = new HookServer({ port: 0 });
@@ -128,7 +131,10 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
     const questions: Question[] = [];
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},
-      onQuestion: (q) => questions.push(q),
+      onQuestion: (q) => {
+        questions.push(q);
+        return undefined;
+      },
     });
     server = new HookServer({ port: 0 });
     const h = bridge.hookHandlers();
@@ -176,7 +182,7 @@ describe('HookServer -> HookEventBridge (HTTP integration)', () => {
   test('PreToolUse without tool_use_id degrades gracefully (no context)', async () => {
     const bridge = new HookEventBridge('session-1' as UUID, {
       onStatusChange: () => {},
-      onQuestion: () => {},
+      onQuestion: () => undefined,
     });
 
     server = new HookServer({ port: 0 });

--- a/packages/daemon/tests/message-api.test.ts
+++ b/packages/daemon/tests/message-api.test.ts
@@ -246,9 +246,11 @@ describe('MessageAPI', () => {
         isAnswered: false,
       };
 
-      api.handleQuestion(question);
+      const outcome = api.handleQuestion(question);
 
       expect(events.onQuestion).toHaveBeenCalledWith(question);
+      // #888 criterion iii: the registration outcome is returned, not void.
+      expect(outcome).toEqual({ status: 'registered' });
     });
 
     test('handleStatusChange emits onStatusChange', () => {
@@ -273,12 +275,17 @@ describe('MessageAPI', () => {
       } as const;
       const q2 = { ...q1, id: 'q-2' };
 
-      api.handleQuestion(q1);
-      api.handleQuestion(q2);
+      const outcome1 = api.handleQuestion(q1);
+      const outcome2 = api.handleQuestion(q2);
 
       expect(events.onQuestion).toHaveBeenCalledTimes(1);
       const survivor = events.onQuestion.mock.calls[0]?.[0] as { id: string };
       expect(survivor.id).toBe('q-1');
+      // #888 criterion iii: the registered question reports success; the
+      // deduped one reports "not registered" -- distinct, non-void outcomes
+      // instead of a caller having to re-query a store to find out.
+      expect(outcome1).toEqual({ status: 'registered' });
+      expect(outcome2).toEqual({ status: 'deduped' });
     });
 
     test('a held question bypasses dedup and forwards the held flag (#603 Phase 3)', () => {
@@ -297,10 +304,15 @@ describe('MessageAPI', () => {
 
       api.handleQuestion(q1); // emits
       // Identical content -> would normally be deduped, but held is load-bearing.
-      api.handleQuestion(q2, { held: true });
+      const heldOutcome = api.handleQuestion(q2, { held: true });
 
       expect(events.onQuestion).toHaveBeenCalledTimes(2);
       expect(events.onQuestion.mock.calls[1]?.[1]).toEqual({ held: true });
+      // #888 criterion iii: a held push reports its OWN distinct outcome --
+      // never 'deduped' (it bypassed the gate entirely) and never conflated
+      // with an ordinary 'registered' push (see QuestionRegistrationOutcome's
+      // doc for why collapsing the two would be boolean-blindness).
+      expect(heldOutcome).toEqual({ status: 'held' });
     });
 
     test('emits upgrade when later question has more options', () => {
@@ -408,6 +420,56 @@ describe('MessageAPI', () => {
       // immediately after a question, dedup baseline must persist.
       api.handleQuestion({ ...q1, id: 'q-2' });
       expect(events.onQuestion).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleQuestion registration outcome (#888 criterion iii)', () => {
+    // Two silent-drop defects (#925, #926) both traced to handleQuestion
+    // returning void and swallowing the outcome when QuestionDedup
+    // suppressed the emission. These tests pin the fix directly, independent
+    // of the two call sites (QuestionPresenceTracker.pairAndPush,
+    // hook-bridge-setup.ts's rememberElicitation) that now consume it.
+    const question = {
+      id: 'q-outcome-1',
+      text: 'Allow Bash: ls',
+      options: [
+        { label: 'Yes', value: '1', isRecommended: true, isYes: true, isNo: false },
+        { label: 'No', value: '2', isRecommended: false, isYes: false, isNo: true },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    } as const;
+
+    test('a registered (non-deduped) question reports { status: "registered" }', () => {
+      const outcome = api.handleQuestion(question);
+      expect(outcome).toEqual({ status: 'registered' });
+    });
+
+    test('a deduped question reports { status: "deduped" }, not void or a bare falsy value', () => {
+      api.handleQuestion(question);
+      const outcome = api.handleQuestion({ ...question, id: 'q-outcome-2' });
+      expect(outcome).toEqual({ status: 'deduped' });
+      expect(outcome).not.toBeUndefined();
+    });
+
+    test('a held question reports { status: "held" } and is unreachable by dedup even when identical', () => {
+      api.handleQuestion(question); // registers, arms the dedup baseline
+      const heldOutcome = api.handleQuestion({ ...question, id: 'q-outcome-3' }, { held: true });
+      // Distinct from both other outcomes -- collapsing it into 'registered'
+      // would hide that it bypassed dedup; collapsing it into 'deduped'
+      // would be simply wrong (it always emits).
+      expect(heldOutcome).toEqual({ status: 'held' });
+      expect(heldOutcome).not.toEqual({ status: 'registered' });
+      expect(heldOutcome).not.toEqual({ status: 'deduped' });
+    });
+
+    test('the three outcomes are pairwise distinct status literals', () => {
+      const registered = api.handleQuestion({ ...question, id: 'q-outcome-4' });
+      const deduped = api.handleQuestion({ ...question, id: 'q-outcome-4' });
+      api.handleStatusChange('thinking'); // reset dedup baseline
+      const held = api.handleQuestion({ ...question, id: 'q-outcome-5' }, { held: true });
+      const statuses = new Set([registered.status, deduped.status, held.status]);
+      expect(statuses.size).toBe(3);
     });
   });
 });

--- a/packages/daemon/tests/question-presence-tracker.test.ts
+++ b/packages/daemon/tests/question-presence-tracker.test.ts
@@ -29,7 +29,10 @@ function question(opts: {
 
 function makeTracker() {
   const pushed: Question[] = [];
-  const tracker = new QuestionPresenceTracker((q) => pushed.push(q));
+  const tracker = new QuestionPresenceTracker((q) => {
+    pushed.push(q);
+    return undefined;
+  });
   return { tracker, pushed };
 }
 
@@ -100,6 +103,7 @@ describe('QuestionPresenceTracker per-agent pending', () => {
     const tracker = new QuestionPresenceTracker(() => {
       calls++;
       if (calls === 1) throw new Error('network blip');
+      return undefined;
     });
     tracker.recordPendingHook(question({ agentId: undefined, options: [opt('Yes', 'y')] }));
     tracker.onPTYPromptVisible(question({ agentId: undefined }));

--- a/packages/web/tests/lib/question-store-conformance.test.ts
+++ b/packages/web/tests/lib/question-store-conformance.test.ts
@@ -248,10 +248,6 @@ describe('question-store conformance: real daemon store <-> real web reducer (#8
             adapter.sendRaw(connectionId, createQuestionResolved(SID, questionId as UUID, 'cancelled'));
           }
         },
-        // Confirmation gate (#888 review fix): only a push that actually
-        // landed in the store (survived QuestionDedup) is evidence of
-        // supersession.
-        isQuestionLive: (id) => sessionRegistry.getQuestion(SID, id as UUID) !== null,
       },
     );
   });


### PR DESCRIPTION
## Summary

Implements criterion (iii) of #888: `MessageAPI.handleQuestion` returns its
registration outcome instead of `void`, and the two hand-rolled gates that
used to re-query the store after the fact now consume that value directly.

- `QuestionRegistrationOutcome` is a discriminated union
  (`{status: 'registered'|'deduped'|'held'}`), not a bare `boolean`: a
  boolean would collapse "registered" and "held" (the load-bearing #573
  escalation that bypasses dedup) into the same `true`, which is exactly
  the kind of boolean-blindness this criterion exists to prevent. Callers
  that switch on `status` get TypeScript exhaustiveness checking for free.
- `QuestionPresenceTracker.pairAndPush` now reads the outcome the `push`
  call itself returned as its confirmed-delivery gate, replacing the
  `isQuestionLive` dep that re-queried `SessionRegistry` after the fact.
- `HookEventBridge.handleElicitation` returns the outcome its `onQuestion`
  call produced; `hook-bridge-setup.ts`'s `rememberElicitation` consumes it
  directly for its "was not registered" guard, instead of re-querying
  `SessionRegistry`. Its OTHER guard ("previously tracked card still live")
  is left querying the store — it asks about a different, historical id,
  which the current call's return value cannot answer.

Behavior-preserving: the same questions register, the same ones are
suppressed, held escalations still bypass dedup. No store is folded or
consolidated; ADR 0004 surface untouched.

## Mutation-testing findings

Per the epic's standing instruction, every guard touched was neutered,
confirmed red for the right reason, then restored and confirmed green.

- `pairAndPush`'s `delivered` check: neutering it broke 4 tests across the
  render-resolution and messageapi-integration suites (the exact swallow
  class #925/#888 exist to prevent).
- `rememberElicitation`'s "was not registered" guard: **no existing test
  detected its removal.** Added a new test
  ("a NEW elicitation_id whose own card is deduped is never tracked") that
  isolates it — confirmed red with the guard neutered, green restored.
- `rememberElicitation`'s "still live" guard (unrelated to this criterion,
  pre-existing): mutation testing found the existing "re-fired Elicitation"
  regression test for #926 passes even with THIS guard neutered, because a
  byte-identical re-fire is also caught by the "was not registered" guard
  alone — the test never actually exercised what it claimed to. Added a
  second test using a CHANGED message (different dedup fingerprint, not
  suppressed) to isolate it; confirmed red/green.
- `handleQuestion`'s three outcome branches (held / deduped / registered):
  each mutated individually in `message-api.ts`; each broke exactly the
  tests naming that branch, restored, confirmed green.

## Test plan

- [x] `bunx biome check .`
- [x] `bun run typecheck`
- [x] `bun test packages/daemon/tests/api/ packages/daemon/tests/session/ packages/daemon/tests/cli/session-phases/` — 363 pass, 0 fail
- [x] `bun test packages/daemon/tests/auto-approve/ packages/daemon/tests/hooks/ packages/daemon/tests/message-api.test.ts packages/daemon/tests/question-presence-tracker.test.ts` — 1071 pass, 0 fail
- [x] Mutation testing on every touched guard (see above)

Refs #888.