### PR TITLE
Add typecheck:web-tests and typecheck:signaling gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
       # non-exhaustive switch over a protocol message — merges green (#883).
       # Verified clean when added, so this gate starts with no backlog.
       - run: bun run typecheck:web
+      # typecheck:web only covers tsconfig.app.json's `include: ["src"]`.
+      # packages/web/tests/** (30 files, including the ADR 0014 two-sided
+      # conformance tests that import daemon source directly) sat outside
+      # both gates above until #946 — a test referencing a since-deleted
+      # interface field passed clean, caught only by manual review (#945).
+      - run: bun run typecheck:web-tests
+      # packages/signaling is the Cloudflare Worker relay -- shipped code on
+      # the remote transport, not test scaffolding. It has its own
+      # `typecheck` script (packages/signaling/package.json) but nothing
+      # called it until #946; the root tsconfig excludes the package
+      # entirely. Given #543/#881's history here, an undetected type error
+      # in this package is the more serious half of #946's gap.
+      - run: bun run typecheck:signaling
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:e2e": "bunx playwright test --config tests/e2e/playwright.config.ts",
     "typecheck": "tsc --noEmit",
     "typecheck:web": "cd packages/web && tsc -p tsconfig.app.json --noEmit",
+    "typecheck:web-tests": "cd packages/web && tsc -p tsconfig.test.json --noEmit",
+    "typecheck:signaling": "cd packages/signaling && tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/packages/daemon/src/parser/bullet-engine.ts
+++ b/packages/daemon/src/parser/bullet-engine.ts
@@ -37,11 +37,14 @@ export interface BulletEngineConfig {
  */
 export class BulletEngine {
   private nextBulletId: number;
-  private readonly sessionId: UUID;
   private readonly maxBulletLength: number;
 
-  constructor(sessionId: UUID, initialBulletId = 1, config?: BulletEngineConfig) {
-    this.sessionId = sessionId;
+  // `_sessionId` has never been read anywhere in this class (found by #946's
+  // web-tests typecheck gate, which pulls this file in via a conformance
+  // test); the field that stored it is gone. Kept as a parameter, not
+  // removed, to avoid a signature change across its 9 call sites for a
+  // no-op cleanup.
+  constructor(_sessionId: UUID, initialBulletId = 1, config?: BulletEngineConfig) {
     this.nextBulletId = initialBulletId;
     this.maxBulletLength = config?.maxBulletLength ?? DEFAULT_MAX_BULLET_LENGTH;
   }

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -132,7 +132,17 @@ export class Connection {
   private authenticatedFingerprint: string | null = null;
 
   private readonly ws: WebSocket;
-  private readonly config: Required<ConnectionConfig> & {
+  // `Omit` before re-adding `authenticator` so the property isn't inherited
+  // from `Required<ConnectionConfig>` and then intersected with the explicit
+  // override below: under `exactOptionalPropertyTypes: false`, `Required<>`
+  // collapses an already-optional `X | undefined` field down to plain `X`,
+  // and intersecting that with `X | undefined` collapses back to `X` --
+  // rejecting the `undefined` assignment two lines below. This repo's root
+  // tsconfig has the flag on, so this file alone never showed it, but
+  // `packages/web`'s stricter-in-other-ways / laxer-here tsconfig checks
+  // this file too via the conformance tests (ADR 0014, #946), and the flag
+  // is off there. `Omit` sidesteps the collapse regardless of the flag.
+  private readonly config: Omit<Required<ConnectionConfig>, 'skipHelloAck' | 'authenticator'> & {
     skipHelloAck: boolean;
     authenticator: Authenticator | undefined;
   };

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -329,8 +329,12 @@ export default {
             body: body.body ?? '',
             bundleId,
             sandbox,
-            data: Object.keys(data).length > 0 ? data : undefined,
-            category,
+            // `data`/`category` are optional-without-`| undefined` on
+            // ApnsPayload; spread instead of assigning `undefined` so an
+            // absent value omits the key rather than tripping
+            // exactOptionalPropertyTypes (#946).
+            ...(Object.keys(data).length > 0 ? { data } : {}),
+            ...(category ? { category } : {}),
             // #719: mutable-content lets the NSE intercept and mutate the
             // notification before display (to attach the dynamic category);
             // only set when there is something for it to build actions from.

--- a/packages/signaling/src/types.ts
+++ b/packages/signaling/src/types.ts
@@ -108,7 +108,7 @@ export function parseMessage(data: string): SignalingMessage | null {
     }
 
     const obj = parsed as Record<string, unknown>;
-    if (typeof obj.type !== 'string') {
+    if (typeof obj['type'] !== 'string') {
       console.warn('Signaling message missing "type" field');
       return null;
     }
@@ -127,8 +127,8 @@ export function parseMessage(data: string): SignalingMessage | null {
       'relay',
     ];
 
-    if (!validTypes.includes(obj.type)) {
-      console.warn(`Unknown signaling message type: ${obj.type}`);
+    if (!validTypes.includes(obj['type'])) {
+      console.warn(`Unknown signaling message type: ${obj['type']}`);
       return null;
     }
 

--- a/packages/web/tests/lib/client-to-daemon-conformance.test.ts
+++ b/packages/web/tests/lib/client-to-daemon-conformance.test.ts
@@ -36,8 +36,9 @@ import type { ProtocolMessage, ProtocolMessageMap } from '@remi/shared/protocol.
 import { MESSAGE_DIRECTION, createHello, deserialize, generateId } from '@remi/shared/protocol.ts';
 import type { AdapterEvents } from '../../../daemon/src/adapters/connection-adapter.ts';
 // Real daemon adapter -- not a test double. Relative import: packages/web has
-// no `@remi/daemon` path alias (only `packages/web/tests/**` is exempt from
-// both typecheck gates, so this resolves fine at `bun test` runtime; see
+// no `@remi/daemon` path alias, so this stays a relative path even though
+// `packages/web/tests/**` is now typechecked too (`typecheck:web-tests`,
+// #946 -- it was exempt from both gates before that); see
 // message-dispatch-conformance.test.ts's "conformance-test placement
 // decision" comment for the precedent this follows).
 import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
@@ -174,7 +175,11 @@ describe('daemon inbound dispatch: real web client -> real daemon adapter confor
 
       await waitFor(() => eventCalls.length > before);
       const call = eventCalls[eventCalls.length - 1];
-      expect(call?.event).toBe(EXPECTED_EVENT[type]);
+      // Guaranteed by the describe.each filter above; TS can't see through
+      // that filter into this callback, so prove it rather than assert `!`.
+      const expectedEvent = EXPECTED_EVENT[type];
+      if (!expectedEvent) throw new Error(`unreachable: ${type} has no EXPECTED_EVENT entry`);
+      expect(call?.event).toBe(expectedEvent);
       // First positional arg on every AdapterEvents callback is connectionId.
       expect(call?.args[0]).toBe(connectionId);
     });
@@ -183,6 +188,19 @@ describe('daemon inbound dispatch: real web client -> real daemon adapter confor
   test('sanity: every EXPECTED_EVENT key is a real c2d type covered by the loop above', () => {
     for (const type of Object.keys(EXPECTED_EVENT)) {
       expect(C2D_TYPES).toContain(type as keyof ProtocolMessageMap);
+    }
+  });
+
+  // NO_EVENT_TYPES documents which c2d types deliberately have no
+  // AdapterEvents callback; this is the other half of the completeness
+  // invariant the type's own doc comment describes -- until #946, nothing
+  // asserted it, so a new c2d type added to the registry without an
+  // EXPECTED_EVENT entry (and not added here either) would silently fall
+  // through both this loop and the generic one above.
+  test('sanity: every C2D type is covered by EXPECTED_EVENT or NO_EVENT_TYPES', () => {
+    for (const type of C2D_TYPES) {
+      const covered = type in EXPECTED_EVENT || NO_EVENT_TYPES.has(type);
+      expect(covered).toBe(true);
     }
   });
 

--- a/packages/web/tests/lib/message-dispatch-conformance.test.ts
+++ b/packages/web/tests/lib/message-dispatch-conformance.test.ts
@@ -55,9 +55,10 @@ import {
 } from '@remi/shared/protocol.ts';
 import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts';
 // Real daemon adapter -- not a test double. Relative import: packages/web has
-// no `@remi/daemon` path alias (only `packages/web/tests/**` is exempt from
-// both typecheck gates, so this resolves fine at `bun test` runtime; see the
-// PR body's "conformance-test placement decision").
+// no `@remi/daemon` path alias, so this stays a relative path even though
+// `packages/web/tests/**` is now typechecked too (`typecheck:web-tests`,
+// #946 -- it was exempt from both gates before that); see the PR body's
+// "conformance-test placement decision").
 import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
 import { WebSocketClient } from '../../src/lib/websocket-client.ts';
 

--- a/packages/web/tests/lib/port-discovery.test.ts
+++ b/packages/web/tests/lib/port-discovery.test.ts
@@ -14,19 +14,30 @@ import {
   resolveDaemonPort,
 } from '../../src/lib/port-discovery';
 
+/** `Bun.serve()`'s `.port` is typed `number | undefined` (a unix-socket
+ *  server has none). Every server bound in this file passes a numeric TCP
+ *  `port`, so it is always defined in practice; narrow once at the bind
+ *  site instead of asserting at each of the many later reads. */
+function requirePort<T extends { port: number | undefined }>(server: T): T & { port: number } {
+  if (server.port === undefined) throw new Error('server bound without a TCP port');
+  return server as T & { port: number };
+}
+
 function authInfoServer() {
-  return Bun.serve({
-    port: 0,
-    fetch(req) {
-      const u = new URL(req.url);
-      if (u.pathname === '/auth-info') {
-        return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-      return new Response('Not found', { status: 404 });
-    },
-  });
+  return requirePort(
+    Bun.serve({
+      port: 0,
+      fetch(req) {
+        const u = new URL(req.url);
+        if (u.pathname === '/auth-info') {
+          return new Response(JSON.stringify({ authRequired: false, fingerprint: null }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('Not found', { status: 404 });
+      },
+    }),
+  );
 }
 
 /**
@@ -42,7 +53,7 @@ function bindNear(
 ): { port: number; stop(): void } {
   for (let offset = 1; offset < 50; offset++) {
     try {
-      return Bun.serve({ port: anchorPort + offset, fetch });
+      return requirePort(Bun.serve({ port: anchorPort + offset, fetch }));
     } catch {
       // Port in use; try next.
     }
@@ -205,6 +216,7 @@ describe('discoverDaemonPort', () => {
         portRange: b.port - a.port + 1,
         timeoutMs: 800,
       });
+      if (found === null) throw new Error('expected one of the two daemons to answer');
       expect([a.port, b.port]).toContain(found);
     } finally {
       a.stop();
@@ -300,10 +312,12 @@ describe('discoverDaemonPort', () => {
   test('per-probe timeout fires against a hung server', async () => {
     // Server accepts the connection but never replies. Without the
     // per-probe timer, the scan would hang indefinitely.
-    const hung = Bun.serve({
-      port: 0,
-      fetch: () => new Promise<Response>(() => {}),
-    });
+    const hung = requirePort(
+      Bun.serve({
+        port: 0,
+        fetch: () => new Promise<Response>(() => {}),
+      }),
+    );
     try {
       const start = Date.now();
       const found = await discoverDaemonPort('127.0.0.1', {
@@ -321,10 +335,12 @@ describe('discoverDaemonPort', () => {
   });
 
   test('outer signal aborted mid-flight cancels the scan promptly', async () => {
-    const hung = Bun.serve({
-      port: 0,
-      fetch: () => new Promise<Response>(() => {}),
-    });
+    const hung = requirePort(
+      Bun.serve({
+        port: 0,
+        fetch: () => new Promise<Response>(() => {}),
+      }),
+    );
     const ctl = new AbortController();
     setTimeout(() => ctl.abort(), 50);
     try {

--- a/packages/web/tests/lib/push-answer-relay.test.ts
+++ b/packages/web/tests/lib/push-answer-relay.test.ts
@@ -69,11 +69,16 @@ describe('relayAnswerDirect (#575 P4a)', () => {
   }
 
   test('no-auth daemon: posts the answer and returns delivered', async () => {
-    let received: { sessionId: string; questionId: string; answer: string } | null = null;
+    type ReceivedBody = { sessionId: string; questionId: string; answer: string } | null;
+    // `= null as ReceivedBody`, not `= null`: a bare `null` initializer keeps
+    // this narrowed to the literal `null` type at every read in this
+    // function, including after the fetch handler below reassigns it (TS
+    // does not widen `let` narrowing back out for closure-only writes).
+    let received: ReceivedBody = null as ReceivedBody;
     const server = startServer(async (req) => {
       const u = new URL(req.url);
       if (u.pathname === '/answer' && req.method === 'POST') {
-        received = (await req.json()) as typeof received;
+        received = (await req.json()) as ReceivedBody;
         return new Response(JSON.stringify({ result: 'delivered' }), {
           headers: { 'Content-Type': 'application/json' },
         });
@@ -87,9 +92,6 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
-        // Pre-#875 daemon: publishes no answer key, so there is nothing to
-        // seal to. The sealed path has its own tests below.
-        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
       expect(received).toEqual({ sessionId: 's1', questionId: 'q1', answer: 'Yes' });
@@ -113,9 +115,6 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
-        // Pre-#875 daemon: publishes no answer key, so there is nothing to
-        // seal to. The sealed path has its own tests below.
-        sealRequired: false,
       });
       expect(result.kind).toBe('rejected');
     } finally {
@@ -138,9 +137,6 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: false,
-        // Pre-#875 daemon: publishes no answer key, so there is nothing to
-        // seal to. The sealed path has its own tests below.
-        sealRequired: false,
       });
       expect(result.kind).toBe('auth-failed');
     } finally {
@@ -178,7 +174,6 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
-        sealRequired: false,
       });
       expect(result.kind).toBe('needs-passphrase');
       expect(hit).toBe(false); // failed fast, never reached the daemon
@@ -202,7 +197,6 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
-        sealRequired: false,
       });
       expect(result.kind).toBe('needs-passphrase');
       expect(hit).toBe(false);
@@ -215,12 +209,18 @@ describe('relayAnswerDirect (#575 P4a)', () => {
     const unencrypted = await createIdentity(); // no passphrase => signable without a prompt
     store.setItem('remi-identity', serializeIdentity(unencrypted));
 
-    let body: {
+    type AuthBody = {
       sessionId?: string;
       auth?: { signature?: string; clientPublicKey?: string; clientFingerprint?: string };
-    } | null = null;
+    } | null;
+    // `= null as AuthBody`, not `= null`: TS narrows a bare `= null`
+    // initializer to the literal `null` type and never widens it back for
+    // reads outside the closure that reassigns it below (a known control-flow
+    // analysis gap, not specific to this repo), which turns every `body.auth`
+    // read after the guard into "Property does not exist on type 'never'".
+    let body: AuthBody = null as AuthBody;
     const server = startServer(async (req) => {
-      body = (await req.json()) as typeof body;
+      body = (await req.json()) as AuthBody;
       return new Response(JSON.stringify({ result: 'delivered' }), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -232,13 +232,15 @@ describe('relayAnswerDirect (#575 P4a)', () => {
         questionId: 'q1',
         answer: 'Yes',
         authRequired: true,
-        sealRequired: false,
       });
       expect(result).toEqual({ kind: 'delivered' });
-      expect(body?.auth?.clientPublicKey).toBe(unencrypted.publicKey);
-      expect(body?.auth?.clientFingerprint).toBe(unencrypted.fingerprint);
-      expect(typeof body?.auth?.signature).toBe('string');
-      expect((body?.auth?.signature ?? '').length).toBeGreaterThan(0);
+      // `body` is only ever written from inside the fetch handler above; the
+      // awaited `relayAnswerDirect` call proves that handler ran.
+      if (body === null) throw new Error('expected the daemon to have received a body');
+      expect(body.auth?.clientPublicKey).toBe(unencrypted.publicKey);
+      expect(body.auth?.clientFingerprint).toBe(unencrypted.fingerprint);
+      expect(typeof body.auth?.signature).toBe('string');
+      expect((body.auth?.signature ?? '').length).toBeGreaterThan(0);
     } finally {
       server.stop();
     }
@@ -277,12 +279,13 @@ describe('relayAnswerViaSignaling (#591)', () => {
 
   test('no-auth: POSTs to /answer/{code} and returns delivered', async () => {
     let path = '';
-    let received: { sessionId: string; questionId: string; answer: string } | null = null;
+    type ReceivedBody = { sessionId: string; questionId: string; answer: string } | null;
+    let received: ReceivedBody = null as ReceivedBody;
     const server = startServer(async (req) => {
       const u = new URL(req.url);
       path = u.pathname;
       if (req.method === 'POST') {
-        received = (await req.json()) as typeof received;
+        received = (await req.json()) as ReceivedBody;
         return new Response(JSON.stringify({ result: 'delivered' }), {
           headers: { 'Content-Type': 'application/json' },
         });
@@ -338,11 +341,12 @@ describe('relayAnswerViaSignaling (#591)', () => {
   test('auth required + unencrypted identity: signs and the Worker receives the auth block', async () => {
     const unencrypted = await createIdentity();
     store.setItem('remi-identity', serializeIdentity(unencrypted));
-    let body: {
+    type AuthBody = {
       auth?: { signature?: string; clientPublicKey?: string; clientFingerprint?: string };
-    } | null = null;
+    } | null;
+    let body: AuthBody = null as AuthBody;
     const server = startServer(async (req) => {
-      body = (await req.json()) as typeof body;
+      body = (await req.json()) as AuthBody;
       return new Response(JSON.stringify({ result: 'delivered' }), {
         headers: { 'Content-Type': 'application/json' },
       });

--- a/packages/web/tests/lib/question-merge.test.ts
+++ b/packages/web/tests/lib/question-merge.test.ts
@@ -3,13 +3,9 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
 import { shouldKeepExisting } from '../../src/lib/question-merge';
-import type {
-  UIQuestion,
-  UIQuestionOption,
-  UIQuestionResolvedReason,
-  UUID,
-} from '../../src/types';
+import type { UIQuestion, UIQuestionOption, UIQuestionResolvedReason } from '../../src/types';
 
 let nextId = 0;
 function uiq(

--- a/packages/web/tests/lib/question-store-conformance.test.ts
+++ b/packages/web/tests/lib/question-store-conformance.test.ts
@@ -38,9 +38,11 @@ import { reserveRange } from '../../../daemon/tests/session/port-test-helpers.ts
 import { MessageAPI } from '../../../daemon/src/api/message-api.ts';
 import { QuestionPresenceTracker } from '../../../daemon/src/api/question-presence-tracker.ts';
 // Real daemon adapter + session pipeline -- not test doubles. Relative
-// import: packages/web has no `@remi/daemon` path alias (only
-// `packages/web/tests/**` is exempt from both typecheck gates, matching the
-// #897 conformance test's own "conformance-test placement decision").
+// import: packages/web has no `@remi/daemon` path alias, so this stays a
+// relative path even though `packages/web/tests/**` is now typechecked too
+// (`typecheck:web-tests`, #946 -- it was exempt from both gates before
+// that), matching the #897 conformance test's own "conformance-test
+// placement decision".
 import { WebSocketAdapter } from '../../../daemon/src/adapters/websocket-adapter.ts';
 import type { PTYSession } from '../../../daemon/src/pty/pty-session.ts';
 import { SessionRegistry } from '../../../daemon/src/session/session-registry.ts';

--- a/packages/web/tests/lib/session-dedup.test.ts
+++ b/packages/web/tests/lib/session-dedup.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, test } from 'bun:test';
 import { compositeKey, dedupSessions } from '../../src/lib/session-dedup';
 import type { ConnectionId, UISession } from '../../src/types';
 
+const cid = (s: string) => s as ConnectionId;
+
 function makeSession(overrides: Partial<UISession>): UISession {
   return {
     id: '11111111-1111-1111-1111-111111111111',
@@ -63,8 +65,8 @@ describe('dedupSessions (the core safety invariant of #430)', () => {
     const result = dedupSessions([a, b]);
 
     expect(result).toHaveLength(2);
-    expect(result[0]?.connectionId).toBe('host:18766');
-    expect(result[1]?.connectionId).toBe('host:18767');
+    expect(result[0]?.connectionId).toBe(cid('host:18766'));
+    expect(result[1]?.connectionId).toBe(cid('host:18767'));
   });
 
   test('same daemon reporting the same binding twice collapses to one row', () => {
@@ -126,8 +128,8 @@ describe('dedupSessions (the core safety invariant of #430)', () => {
 
     expect(result).toHaveLength(2);
     expect(result.map((s) => s.connectionId).sort()).toEqual([
-      'host:18766',
-      'host:18767',
+      cid('host:18766'),
+      cid('host:18767'),
     ]);
   });
 });

--- a/packages/web/tests/lib/websocket-client.test.ts
+++ b/packages/web/tests/lib/websocket-client.test.ts
@@ -282,7 +282,12 @@ describe('WebSocketClient reconnectWithUrl', () => {
 describe('WebSocketClient ping/pong liveness (#662 review)', () => {
   test('replies with pong when the server sends a protocol ping', async () => {
     const received: ProtocolMessage[] = [];
-    let pingSent: PingMessage | null = null;
+    // `= null as PingMessage | null`, not `= null`: a bare `null`
+    // initializer keeps this narrowed to the literal `null` type at every
+    // read in this function, including after the WebSocket `open` handler
+    // below reassigns it (TS does not widen `let` narrowing back out for
+    // closure-only writes).
+    let pingSent: PingMessage | null = null as PingMessage | null;
 
     const server = Bun.serve({
       port: 0,
@@ -332,7 +337,10 @@ describe('WebSocketClient ping/pong liveness (#662 review)', () => {
     // guards against a reply that only fires on the FIRST ping.
     const pingIds: string[] = [];
     const pongIdsSeen = new Set<string>();
-    let serverWs: Bun.ServerWebSocket<unknown> | null = null;
+    // See the `pingSent` declaration above for why this is `as
+    // Bun.ServerWebSocket<unknown> | null` rather than a bare `null`.
+    let serverWs: Bun.ServerWebSocket<unknown> | null =
+      null as Bun.ServerWebSocket<unknown> | null;
 
     const server = Bun.serve({
       port: 0,

--- a/packages/web/tsconfig.test.json
+++ b/packages/web/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "types": ["bun", "vite/client"],
+    // Some tests import daemon source directly for two-sided conformance
+    // (ADR 0014), and those files use constructor parameter properties.
+    // `src` keeps this on for Vite/esbuild's transpile-only dev pipeline;
+    // tests run under `bun test`, which has no such constraint.
+    "erasableSyntaxOnly": false
+  },
+  "include": ["tests"]
+}


### PR DESCRIPTION
## Summary

Closes #946. 44 TypeScript files were typechecked by nothing:

- `packages/web/tests/**` (30 files) -- root `tsconfig.json` excludes `packages/web/**`, and `typecheck:web` uses `tsconfig.app.json` whose `include` is `["src"]` only.
- `packages/signaling/**` (14 files) -- excluded from root, and no `typecheck:signaling` script was wired into CI even though the package has its own `typecheck` entry.

`packages/signaling` is the Cloudflare Worker relay: shipped code on the remote transport, not test scaffolding. Given #543/#881's history on that exact component, an undetected type error there is the more serious half of this gap.

## What changed

- `packages/web/tsconfig.test.json` (new): separate config for `packages/web/tests/**`, not a widened/merged `tsconfig.app.json`. Tests run under `bun test` (`types: ["bun", "vite/client"]`) where `src` runs under Vite; tests also import daemon source directly for ADR 0014 two-sided conformance tests, which uses constructor parameter properties incompatible with `src`'s `erasableSyntaxOnly` (needed for Vite/esbuild's transpile-only dev pipeline, not for `bun test`). No exclusions -- all 30 files typecheck clean.
- `package.json`: added `typecheck:web-tests` and `typecheck:signaling` (the signaling script already existed at `packages/signaling/package.json`; nothing called it).
- `.github/workflows/ci.yml`: both new commands added to the `Type Check` job, alongside the existing `typecheck` / `typecheck:web`.

## Real errors found and fixed (the gate had never run)

**`packages/daemon` (pulled in transitively by ADR 0014 conformance tests, which import daemon source directly and get checked under `packages/web`'s laxer `exactOptionalPropertyTypes: false`):**
- `BulletEngine.sessionId` was stored in a private field but never read anywhere in the class -- dead since the file's initial commit. Removed the field; kept the constructor parameter (renamed `_sessionId`) to avoid a signature change across 9 call sites for what's otherwise a no-op cleanup.
- `Connection.config`'s type intersected `Required<ConnectionConfig>` with an explicit `authenticator: Authenticator | undefined` override. Under `exactOptionalPropertyTypes: false` (web's setting; root's is `true`, so this file alone never showed it), `Required<>` collapses an already-optional-with-undefined field to plain non-undefined before the intersection runs, so the override collapses back and rejects the assignment. Fixed with `Omit<Required<ConnectionConfig>, 'authenticator'> & {...}` so the override isn't fighting anything, regardless of the flag.

**`packages/signaling` (first-ever typecheck):**
- `types.ts`: `obj.type` accessed with dot notation on a `Record<string, unknown>` -- disallowed under `noPropertyAccessFromIndexSignature`. Switched to bracket notation.
- `index.ts`: the APNS payload builder assigned `data`/`category` explicitly as `undefined` when absent; both fields are optional-without-`| undefined` on `ApnsPayload`, which `exactOptionalPropertyTypes` rejects. Switched to the same conditional-spread pattern already used two lines below for `mutableContent`/`collapseId`/`dismiss` -- identical runtime behavior (no key either way when absent).

**`packages/web/tests` (first-ever typecheck):**
- `push-answer-relay.test.ts`: 6 `relayAnswerDirect()` calls passed `sealRequired`, a field that only exists on `SignalingRelayInput` (a different interface, used by the OTHER relay function in the same file) -- the same "test references a field the interface doesn't have" shape as #945's `isQuestionLive`. Removed from all 6 call sites; `relayAnswerDirect` never seals anything.
- `question-merge.test.ts`: imported `UUID` from `../../src/types`, which imports `UUID` from `@remi/shared` but never re-exports it. Fixed to import from `@remi/shared` directly, matching every other file in the package.
- `session-dedup.test.ts`: compared a branded `ConnectionId` field against plain string literals. Added the same `cid()` helper already used in `connection-id.test.ts` / `session-display.test.ts`.
- `port-discovery.test.ts`: `Bun.serve()`'s `.port` is `number | undefined` (a unix-socket server has none); every server in this file binds a TCP port so it's always defined in practice, but that was never proven to the type checker (23 read sites). Added one `requirePort()` narrowing helper at the 4 bind sites, plus one `found === null` guard.
- `push-answer-relay.test.ts`, `websocket-client.test.ts`: `let x: T | null = null` narrows to the literal `null` type for the rest of the function and is never widened back out when a closure elsewhere reassigns it -- every read afterward, even past a runtime null guard, sees `never` once optional-chained (a general TS control-flow limitation, reproduced and confirmed in isolation, not specific to this repo). Fixed by casting the initializer itself (`null as T | null`) at 5 call sites so the declared narrowing starts at the full union.
- `client-to-daemon-conformance.test.ts`: added a throw-guard for a `describe.each`-filtered lookup TS can't see through (matches the file's own existing "unreachable" idiom), and added the test `NO_EVENT_TYPES` was written to enable but that nothing ever wired up -- its own doc comment describes a completeness invariant ("every c2d type is covered by EXPECTED_EVENT or NO_EVENT_TYPES") that had no assertion. A future c2d type added without a mapping now fails loudly.
- `message-dispatch-conformance.test.ts`, `question-store-conformance.test.ts`: updated stale comments claiming `packages/web/tests/**` is exempt from both typecheck gates -- it no longer is.

No `any`, `@ts-ignore`, or config loosening anywhere in this diff.

## Test plan

- [x] `bunx biome check .` -- exit 0 (48 pre-existing warnings, unrelated to this diff; 0 errors)
- [x] `bun run typecheck` -- exit 0
- [x] `bun run typecheck:web` -- exit 0
- [x] `bun run typecheck:web-tests` -- exit 0 (new, all 30 files)
- [x] `bun run typecheck:signaling` -- exit 0 (new, all 14 files)
- [x] `bun test packages/daemon/tests/` -- 3583 pass, 0 fail
- [x] `bun test` in `packages/web` -- 507 pass, 0 fail
- [x] `bun test` in `packages/signaling` -- 98 pass, 0 fail
- [x] Proved both new gates actually fire: injected a deliberate type error into a `packages/web/tests` file and into `packages/signaling/src`, confirmed each failed its own new command (`typecheck:web-tests` / `typecheck:signaling`) while passing unnoticed under the existing `typecheck`/`typecheck:web`, then reverted both.
