### PR TITLE
Resolve open questions on full teardown, not silent clear (#948)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,44 @@ All notable changes to Remi are documented here.
   newly-registered events as unregistered.
 
 ### Fixed
+- **A full teardown (`SessionEnd`, `remi unstick`) now resolves every
+  still-open escalation instead of silently dropping its bookkeeping**
+  (#948). `AutoApproveGate.cancelStale`'s mainOnly `Stop` sweep already
+  routed each survivor through `resolveSupersededQuestion` so
+  `question_resolved` + the APNS dismiss + the live-sessions mirror all
+  fire — its own comment named this explicitly as "not a silent
+  bookkeeping-only delete." The non-mainOnly branch (`SessionEnd`) and the
+  separate `forceRelease` (`remi unstick`) did exactly that anyway: a bare
+  `openQuestionSignatures.clear()` + `parkedInputs.clear()`. A PASSTHROUGH
+  escalation — multi-choice/design, e.g. `AskUserQuestion` or
+  `ExitPlanMode`, tracked only in `openQuestionSignatures` (never held) —
+  had its bookkeeping dropped while its card stayed in the store with
+  nothing left to resolve it. Reproduced: firing a `SessionEnd` with no
+  intervening `Stop` (a session killed or dropped mid-prompt) left the
+  card count at 1 before and 1 after. Every captured corpus session that
+  reaches `SessionEnd` also has an earlier `Stop`, which already clears
+  the card via the mainOnly sweep — the reason #949's replay never caught
+  it.
+
+  Both teardown paths now share a new `resolveAllOpenQuestions`, which
+  resolves EVERY survivor through the same funnel — deliberately, unlike
+  the mainOnly sweep, WITHOUT its `isSubagent` skip: that skip exists
+  because a `Stop` means only the lead agent finished while a teammate may
+  still be mid-turn, and a full teardown has no such survivor left to
+  protect (`cancelStale`'s own docstring already said so). `parkedInputs`
+  needed no separate clear call: every parked entry is registered under
+  the same question id as its `openQuestionSignatures` counterpart
+  (`parkSubagentForPTY` sets both together), and `releaseHeld` — reached
+  by every `resolveSupersededQuestion` call — already deletes both maps'
+  entries for a resolved qid unconditionally, before anything downstream
+  can throw, so the loop retires every parked entry as a side effect of
+  retiring its signature. Checked the neighboring
+  `evalIdByQuestion.clear()` in `forceRelease` for the same defect:
+  unaffected — that map is unrelated GPU-eval-cancellation bookkeeping
+  with no card or notification duty of its own, and `forceRelease`'s
+  subsequent untargeted `service.cancel(reason)` already aborts whatever
+  eval is running regardless of which question it belonged to.
+
 - **Every opt-in debug sink now stamps provenance on each record, so a
   synthetic test write is distinguishable from a real one by data** (#934).
   `REMI_HOOK_DEBUG=1` (`hook-diag.jsonl`) and `REMI_QUESTION_TRACE=1`

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -540,14 +540,20 @@ export class AutoApproveGate {
    *     `cancelStale`'s mainOnly Stop sweep (#799) use), and `releaseAllHolds`
    *     (#799 -- so the mainOnly Stop sweep below never re-finds and double
    *     -resolves a qid it just released via a held hook).
-   * `cancelStale` (non-mainOnly) / `forceRelease` wholesale-clear the whole
-   * map (session end / force-release — nothing tracked is relevant after
-   * either). A stale entry is harmless (a signature match just triggers a
-   * redundant, idempotent cleanup), but MUST NOT be able to accumulate
-   * indefinitely: an un-deleted entry from a timed-out/cancelled hold would
-   * sit for the rest of the process lifetime and could fire a spurious
-   * `notifyResolved` for a question dead for hours on a much-later,
-   * unrelated duplicate of the same command.
+   * `cancelStale` (non-mainOnly) / `forceRelease` (#948) route every survivor
+   * through `resolveSupersededQuestion` too, via the shared
+   * `resolveAllOpenQuestions` -- session end / force-release means nothing
+   * tracked is relevant after either, but that funnel (not a wholesale
+   * `.clear()`) is what fires `question_resolved` + the APNS dismiss + the
+   * live-sessions mirror for a survivor whose card is still sitting in the
+   * store (#948: a PASSTHROUGH escalation, e.g. AskUserQuestion, is tracked
+   * ONLY here — a bare `.clear()` dropped its bookkeeping with nothing left
+   * to resolve its card). A stale entry is harmless regardless (a signature
+   * match just triggers a redundant, idempotent cleanup), but MUST NOT be
+   * able to accumulate indefinitely: an un-deleted entry from a timed-out/
+   * cancelled hold would sit for the rest of the process lifetime and could
+   * fire a spurious `notifyResolved` for a question dead for hours on a
+   * much-later, unrelated duplicate of the same command.
    */
   private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
 
@@ -561,8 +567,9 @@ export class AutoApproveGate {
    * Entries are deleted the moment an arbitration consumes one (exactly one
    * evaluation per park), and by every resolution path that retires the
    * matching `openQuestionSignatures` entry (`releaseHeld`, `resolveHeld`,
-   * `cancelStale`'s wholesale clear, `forceRelease`), so a permission whose
-   * prompt never renders cannot linger. `MAX_PARKED_INPUTS` is the backstop
+   * and — via `resolveAllOpenQuestions`, #948 — `cancelStale`'s teardown
+   * branch and `forceRelease`), so a permission whose prompt never renders
+   * cannot linger. `MAX_PARKED_INPUTS` is the backstop
    * for the one shape none of those cover: an agent that parks repeatedly and
    * never advances, ends, or renders — oldest-first eviction bounds the map at
    * a size far above any real fleet's concurrent parks.
@@ -610,11 +617,13 @@ export class AutoApproveGate {
     // -- their hooks are still blocked in a still-running teammate and remain
     // answerable via `resolveHeld`.
     this.releaseAllHolds('passthrough', reason, mainOnly);
-    // #673 / #711: every OPEN escalation this gate has tracked (held above, or
-    // a passthrough one with no hold) is moot on a full teardown -- wholesale
-    // clear, as before. On a mainOnly Stop, only the MAIN-tagged entries are
-    // moot; a teammate's is not (its hold, if any, was just spared above, and
-    // its signature must stay trackable for external-resolution cancellation).
+    // #673 / #711 / #948: every OPEN escalation this gate has tracked (held
+    // above, or a passthrough one with no hold) is moot on a full teardown --
+    // resolved through the SAME funnel a tool-signature match uses, below,
+    // never a silent bookkeeping-only delete. On a mainOnly Stop, only the
+    // MAIN-tagged entries are moot; a teammate's is not (its hold, if any,
+    // was just spared above, and its signature must stay trackable for
+    // external-resolution cancellation).
     if (mainOnly) {
       // #799: a MAIN-tagged signature STILL open here was never held (a held
       // one was already released + unregistered by releaseAllHolds above) --
@@ -628,16 +637,28 @@ export class AutoApproveGate {
       // never catch (a deny produces no PreToolUse to match against). Route
       // each survivor through the SAME funnel a tool-signature match uses
       // (not a silent bookkeeping-only delete), so question_resolved + APNS
-      // dismiss + the live-sessions mirror all fire for it too.
+      // dismiss + the live-sessions mirror all fire for it too. Skip
+      // subagent-tagged entries: a Stop means only the LEAD agent finished,
+      // and a teammate may still be mid-turn -- its still-open escalation is
+      // not moot yet (that agent's own eventual `SubagentStop` resolves it
+      // via `cancelStaleForAgent`).
       for (const [qid, sig] of [...this.openQuestionSignatures]) {
         if (sig.isSubagent) continue;
         this.resolveSupersededQuestion(qid, reason, sig.toolName);
       }
     } else {
-      this.openQuestionSignatures.clear();
-      // #814: a full teardown retires every parked permission too — none of
-      // them can render on a PTY that is going away.
-      this.parkedInputs.clear();
+      // #948: a full teardown has no still-running teammate to protect (see
+      // this method's own docstring above: "there is no 'the rest of the
+      // team is still going' case once the session has ended"), so EVERY
+      // survivor is resolved here -- main OR subagent -- unlike the mainOnly
+      // sweep's `isSubagent` skip just above. This used to be a silent
+      // `openQuestionSignatures.clear()` + `parkedInputs.clear()`: exactly
+      // the "bookkeeping-only delete" the mainOnly branch's own comment
+      // warns against, and it left a passthrough escalation's card (e.g.
+      // AskUserQuestion / ExitPlanMode, tracked only in
+      // `openQuestionSignatures`) sitting in the store with nothing left to
+      // resolve it (#948).
+      this.resolveAllOpenQuestions(reason);
     }
     if (this.deps.service === null) return;
     // #730 (BUG 1 fix): drop THIS session's own QUEUED evals first -- work a
@@ -674,6 +695,39 @@ export class AutoApproveGate {
     }
     if (cancelledCount > 0) {
       log(`[AutoApprove] Cancelled ${cancelledCount} stale MAIN-context LLM eval(s): ${reason}`);
+    }
+  }
+
+  /**
+   * #948: resolve EVERY currently-open escalation (main or subagent) through
+   * `resolveSupersededQuestion` instead of a silent bookkeeping-only delete.
+   * The shared implementation for the two REAL teardown paths, where nothing
+   * tracked can possibly still be relevant afterward: `cancelStale`'s
+   * non-mainOnly branch (`SessionEnd`) and `forceRelease` (`remi unstick`).
+   *
+   * Deliberately does NOT filter by `sig.isSubagent` the way the mainOnly
+   * `Stop` sweep in `cancelStale` does -- that filter exists because a `Stop`
+   * means only the LEAD agent finished while a teammate may still be
+   * mid-turn (see `cancelStale`'s own docstring); neither teardown path has
+   * such a survivor to protect.
+   *
+   * `parkedInputs` needs no separate clear call here. Every parked entry is
+   * registered under the SAME question id as its `openQuestionSignatures`
+   * counterpart (`parkSubagentForPTY` sets both together in one call), and
+   * the only two ways a `parkedInputs` entry is ever removed WITHOUT its
+   * signature counterpart also being removed are `arbitrateParkedRender`
+   * consuming it (the signature survives, now tracking an actual pushed
+   * card -- correctly still open) and `rememberParkedInput`'s
+   * `MAX_PARKED_INPUTS` eviction (same). Neither direction lets a
+   * `parkedInputs` entry outlive its signature. `releaseHeld` -- reached by
+   * every `resolveSupersededQuestion` call below -- unconditionally deletes
+   * BOTH maps' entries for the qid it processes, before anything downstream
+   * can throw, so this loop retires every parked entry as a side effect of
+   * retiring its signature.
+   */
+  private resolveAllOpenQuestions(reason: string): void {
+    for (const [qid, sig] of [...this.openQuestionSignatures]) {
+      this.resolveSupersededQuestion(qid, reason, sig.toolName);
     }
   }
 
@@ -742,10 +796,13 @@ export class AutoApproveGate {
     const holds = this.pendingHolds.size;
     this.releaseAllHolds('passthrough', reason);
     this.evalIdByQuestion.clear();
-    // #673: mirrors cancelStale's wholesale clear -- a force-release is at
-    // least as final as a session end for bookkeeping purposes.
-    this.openQuestionSignatures.clear();
-    this.parkedInputs.clear(); // #814, same finality
+    // #673 / #948: mirrors cancelStale's non-mainOnly teardown branch -- a
+    // force-release is at least as final as a session end, so every
+    // remaining survivor (main or subagent) is resolved through the SAME
+    // funnel a tool-signature match uses, not a silent bookkeeping-only
+    // delete (see `resolveAllOpenQuestions`'s own docstring for why
+    // `parkedInputs` needs no separate clear call).
+    this.resolveAllOpenQuestions(reason);
     const service = this.deps.service;
     if (service === null) return { holds, cancelled: false, drained: 0 };
     const cancelled = service.cancel(reason);

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -2814,6 +2814,251 @@ describe('AutoApproveGate Stop resolves a still-open MAIN passthrough question (
 });
 
 // ---------------------------------------------------------------------------
+// #948: `cancelStale`'s non-mainOnly (SessionEnd) branch, and `forceRelease`,
+// used to be a silent `openQuestionSignatures.clear()` + `parkedInputs.clear()`
+// -- exactly the "bookkeeping-only delete" the mainOnly Stop sweep's own
+// comment (above) warns against. A PASSTHROUGH escalation (multi-choice /
+// design, e.g. AskUserQuestion) is tracked ONLY in `openQuestionSignatures`,
+// so a session that ends with no intervening `Stop` (e.g. killed or dropped
+// mid-prompt) left its card sitting in the store with nothing left to
+// resolve it. These tests exercise the fix: every survivor -- main OR
+// subagent, unlike the mainOnly sweep -- is now routed through
+// `resolveSupersededQuestion`, and prove the mainOnly Stop path is unchanged.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate full teardown resolves ALL survivors (#948)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let lastQuestionId: UUID | undefined;
+  let parkedIds: UUID[];
+
+  function gate(
+    opts: {
+      onResolved?: (
+        questionId: UUID,
+        reason: 'auto_approved' | 'auto_denied' | 'cancelled',
+      ) => void;
+    } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    return new AutoApproveGate(
+      {
+        service: null,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => undefined),
+        isInSubagentContext: () => false,
+        escalate: () => {
+          lastQuestionId = generateId();
+          return lastQuestionId;
+        },
+        parkForPTY: () => {
+          const id = generateId() as UUID;
+          parkedIds.push(id);
+          return id;
+        },
+        holdMs: 60_000,
+        alwaysEscalateTools: new Set(['AskUserQuestion']),
+        ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+      },
+      SID,
+    );
+  }
+
+  /** AskUserQuestion is in `alwaysEscalateTools` -> design -> escalates as a
+   *  PASSTHROUGH, never held -- the exact #948 repro shape. */
+  function askUserQuestionPr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'AskUserQuestion',
+      tool_input: { question: 'Which approach?' },
+    };
+  }
+
+  function subagentPr(agentId: string): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      agent_id: agentId,
+      agent_type: 'general-purpose',
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    lastQuestionId = undefined;
+    parkedIds = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('the exact #948 repro: SessionEnd with NO Stop in between resolves a still-open MAIN AskUserQuestion card', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(askUserQuestionPr())).toBe('passthrough');
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'Which approach?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+    expect(registry.getQuestion(SID, qid)).not.toBeNull(); // store size 1 before
+
+    g.cancelStale('SessionEnd'); // no mainOnly, no prior Stop -- real teardown
+
+    expect(registry.getQuestion(SID, qid)).toBeNull(); // store size 0 after
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+
+  test('a still-open SUBAGENT passthrough card is ALSO resolved on SessionEnd', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(subagentPr('agent-1'))).toBe('passthrough');
+    const subagentQid = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: subagentQid,
+      text: 'ls?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+    expect(registry.getQuestion(SID, subagentQid)).not.toBeNull();
+
+    g.cancelStale('SessionEnd');
+
+    expect(registry.getQuestion(SID, subagentQid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid: subagentQid, reason: 'cancelled' }]);
+  });
+
+  test('Stop(mainOnly) still spares a subagent survivor exactly as before; a LATER SessionEnd then resolves it', async () => {
+    // This is the regression guard: the fix must resolve every survivor on a
+    // REAL teardown WITHOUT turning a mainOnly Stop into one.
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+
+    expect(await g.resolvePermission(subagentPr('agent-1'))).toBe('passthrough');
+    const subagentQid = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: subagentQid,
+      text: 'ls?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+
+    expect(await g.resolvePermission(askUserQuestionPr())).toBe('passthrough');
+    const mainQid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: mainQid,
+      text: 'Which approach?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    g.cancelStale('Stop', { mainOnly: true });
+    expect(registry.getQuestion(SID, mainQid)).toBeNull(); // MAIN: resolved
+    expect(registry.getQuestion(SID, subagentQid)).not.toBeNull(); // subagent: still spared
+    expect(resolvedLog).toEqual([{ qid: mainQid, reason: 'cancelled' }]);
+
+    // The teammate never fires its own SubagentStop; the session just ends.
+    g.cancelStale('SessionEnd');
+    expect(registry.getQuestion(SID, subagentQid)).toBeNull(); // now resolved too
+    expect(resolvedLog).toEqual([
+      { qid: mainQid, reason: 'cancelled' },
+      { qid: subagentQid, reason: 'cancelled' },
+    ]);
+  });
+
+  test('question_resolved fires once per resolved survivor -- one main, two subagent -- on a full teardown', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+
+    expect(await g.resolvePermission(askUserQuestionPr())).toBe('passthrough');
+    const mainQid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: mainQid,
+      text: 'q1',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    expect(await g.resolvePermission(subagentPr('agent-1'))).toBe('passthrough');
+    const subagentQid1 = parkedIds[0] as UUID;
+    registry.addQuestion(SID, {
+      id: subagentQid1,
+      text: 'q2',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-1',
+    });
+
+    expect(await g.resolvePermission(subagentPr('agent-2'))).toBe('passthrough');
+    const subagentQid2 = parkedIds[1] as UUID;
+    registry.addQuestion(SID, {
+      id: subagentQid2,
+      text: 'q3',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+      agentId: 'agent-2',
+    });
+
+    g.cancelStale('SessionEnd');
+
+    expect(registry.getQuestion(SID, mainQid)).toBeNull();
+    expect(registry.getQuestion(SID, subagentQid1)).toBeNull();
+    expect(registry.getQuestion(SID, subagentQid2)).toBeNull();
+    expect(resolvedLog).toHaveLength(3);
+    const resolvedQids = resolvedLog.map((r) => r.qid);
+    expect(resolvedQids).toContain(mainQid);
+    expect(resolvedQids).toContain(subagentQid1);
+    expect(resolvedQids).toContain(subagentQid2);
+    expect(resolvedLog.every((r) => r.reason === 'cancelled')).toBe(true);
+  });
+
+  test('forceRelease (remi unstick) also resolves a still-open passthrough survivor, mirroring the teardown branch', async () => {
+    const resolvedLog: Array<{ qid: UUID; reason: string }> = [];
+    const g = gate({ onResolved: (qid, reason) => resolvedLog.push({ qid, reason }) });
+    expect(await g.resolvePermission(askUserQuestionPr())).toBe('passthrough');
+    const qid = lastQuestionId as UUID;
+    registry.addQuestion(SID, {
+      id: qid,
+      text: 'Which approach?',
+      options: [],
+      allowsFreeText: false,
+      isAnswered: false,
+    });
+
+    g.forceRelease('remi unstick');
+
+    expect(registry.getQuestion(SID, qid)).toBeNull();
+    expect(resolvedLog).toEqual([{ qid, reason: 'cancelled' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #799 part 2, subagent mirror: cancelStaleForAgent, wired from SubagentStop.
 // ---------------------------------------------------------------------------
 describe('AutoApproveGate cancelStaleForAgent (#799 part 2, subagent)', () => {


### PR DESCRIPTION
## Summary

`AutoApproveGate.cancelStale`'s `SessionEnd` branch and the separate
`forceRelease` (`remi unstick`) wholesale-cleared
`openQuestionSignatures`/`parkedInputs` instead of routing every survivor
through `resolveSupersededQuestion` — the funnel the `mainOnly` `Stop` sweep
already uses, with its own comment explicitly warning against "a silent
bookkeeping-only delete." A PASSTHROUGH escalation (multi-choice/design, e.g.
`AskUserQuestion` or `ExitPlanMode`) is tracked ONLY in
`openQuestionSignatures` (never held), so its card was left sitting in the
store with nothing left to resolve it.

Reproduced per the issue: fire a MAIN `AskUserQuestion` `PermissionRequest`,
then `SessionEnd` with no intervening `Stop`. Store size 1 before, 1 after
(pre-fix) / 0 after (post-fix). Every corpus-captured session that reaches
`SessionEnd` also has an earlier `Stop`, which already clears the card via
the `mainOnly` sweep — that is why #949's replay never caught this.

Both teardown paths now share a new `resolveAllOpenQuestions`, which
resolves every survivor through the same funnel a tool-signature match uses.

## Determinations requested in the brief

**Subagent scoping on teardown.** Yes — `resolveAllOpenQuestions` resolves
ALL survivors, main or subagent, deliberately WITHOUT the `mainOnly` sweep's
`if (sig.isSubagent) continue`. Checked this against `releaseAllHolds`'s own
`mainOnly` handling before implementing: `releaseAllHolds('passthrough',
reason, mainOnly)` already scopes HELD hooks the same way — `mainOnly` skips
subagent-tagged holds because a `Stop` means only the lead agent finished
while a teammate may still be mid-turn (its hold stays answerable via
`resolveHeld`), and a full teardown (`SessionEnd`/`forceRelease`) has no such
survivor to protect. `cancelStale`'s own docstring already said this in
prose ("there is no 'the rest of the team is still going' case once the
session has ended") — the non-mainOnly branch's `openQuestionSignatures`
handling just hadn't been made to match it. Confirmed behaviorally by a
regression test that fires a `Stop(mainOnly)` first (subagent entry spared,
exactly as before) and then a `SessionEnd` on the same gate (the previously
-spared entry now resolves).

**`parkedInputs.clear()`.** NOT the same defect — verified, not assumed
symmetric. Two independent reasons:

1. It has no card/notification duty of its own. A `parkedInputs` entry is
   the raw hook input for a subagent permission `parkSubagentForPTY` parked
   for later evaluation; ADR 0004 (parking is "hook passed through, no
   push") means no card exists in the session registry for it yet.
   `arbitrateParkedRender` deletes the `parkedInputs` entry synchronously the
   moment arbitration starts (`auto-approve-gate.ts`, `parkedInputs.delete`
   right after reading `input`), strictly BEFORE any push could happen — so
   a live `parkedInputs` entry never coexists with a pushed card. Clearing it
   drops no `question_resolved`/APNS obligation.
2. It is a provable subset. Every `parkedInputs` entry is created together
   with its `openQuestionSignatures` counterpart in one call
   (`parkSubagentForPTY`), and the only two ways an entry leaves
   `parkedInputs` WITHOUT its signature counterpart also being removed
   (`arbitrateParkedRender` consuming it, or `rememberParkedInput`'s
   `MAX_PARKED_INPUTS` eviction) never go the other direction. `releaseHeld`
   — reached by every `resolveSupersededQuestion` call — unconditionally
   deletes BOTH maps' entries for a resolved qid before anything downstream
   can throw. So once `resolveAllOpenQuestions` resolves every
   `openQuestionSignatures` survivor, `parkedInputs` is already empty as a
   side effect; the old explicit `.clear()` calls were provably redundant
   even before being wrong, and are removed rather than kept as dead
   defensive code.

Also checked the literal sibling defect the issue named directly:
`forceRelease` had its OWN copy of the identical `openQuestionSignatures
.clear()` / `parkedInputs.clear()` shape (it does not call `cancelStale` —
it's a separate method for `remi unstick`), with a comment explicitly
claiming it "mirrors cancelStale's wholesale clear." Fixed identically via
the shared `resolveAllOpenQuestions`, since leaving it unfixed would have
left that comment's claim newly false and the exact bug live behind a
different entry point.

## Constraints respected

- ADR 0004 surface untouched beyond what the fix required: no changes to
  `arbitrateParkedRender`, `isPromptCurrent`, tracker pending/awaitingPTY
  pairing, or `mainEvalsInFlight`.
- `resolveSupersededQuestion`'s four-call/per-step-try-catch shape is
  untouched — reused as-is via the new shared loop, not restructured.
- PR #941's single-card-map-mutator and 19-container-classification tests,
  and #949's corpus replay, all still green (see gates below) — no field was
  added/renamed/removed, only a private method.

## Mutation proof (neuter → red → restore → green)

1. Reverted the src fix only (tests kept): all 5 new `#948` tests failed —
   `expect(registry.getQuestion(...)).toBeNull()` received the still-live
   card, for both the `SessionEnd` repro and the `forceRelease` case. `5
   fail, 0 pass`.
2. Restored the fix: same 5 tests green (`5 pass, 0 fail`).
3. Separately mutated `resolveAllOpenQuestions` to copy the `mainOnly`
   sweep's `if (sig.isSubagent) continue` verbatim (simulating the exact
   copy-paste mistake the brief warned against): 3 of the 5 `#948` tests
   failed (the ones asserting a subagent survivor resolves), the 2
   main-only-only tests still passed — proving the subagent-inclusion
   assertions are load-bearing, not vacuous.
4. Restored; re-confirmed green.
5. Mutated the `mainOnly` sweep itself (removed ITS `isSubagent` skip, i.e.
   made `Stop` behave like a teardown): both the new regression test
   ("Stop(mainOnly) still spares a subagent survivor...") and the
   pre-existing `#799` test ("never fires ambiguously: Stop(mainOnly) does
   not touch a still-open SUBAGENT question") failed correctly. Restored;
   green again.

## Test plan

- [x] `bunx biome check` — 0 errors (48 pre-existing warnings elsewhere,
      none in touched files)
- [x] `bun run typecheck` — clean
- [x] `bun test packages/daemon/tests/auto-approve/ packages/daemon/tests/hooks/ packages/daemon/tests/session/`
      — 1162 pass, 0 fail, run in the foreground (~5 min, live-engine tests
      included)
- [x] Mutation proof above for every new assertion