### PR TITLE
feat: per-device push notification toggles (#968)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,38 @@ See `.context/notification-and-session-flow.md` for the full flow diagram.
 - Signaling server (Cloudflare Worker) relays push payloads to APNS.
 - iOS categories `REMI_YN`, `REMI_YNA`, `REMI_MULTI` registered in `AppDelegate.swift`.
 
+**Push classes and who can mute them** (#968):
+
+Every push carries an explicit `kind`. Before that field existed the classes
+were told apart by a NEGATIVE test ("no `questionId`, no `category`") which
+could not distinguish turn-complete from a subagent alert at all — on the wire
+those two are both exactly `{token, title, body}`.
+
+| `kind` | Fires on | Mutable per device |
+|---|---|---|
+| `question` | permission prompt, escalation, hold-timeout handoff | yes, `pushPrefs.questions` |
+| `turn_complete` | `Stop` after a turn ≥ `turn_complete_min_seconds` (#914) | yes, `pushPrefs.turnComplete` |
+| `subagent_alert` | a background agent matched `auto_approve.subagent_alert` | no — the pattern list IS the control |
+| `dismiss` | quiet `content-available` clearing a resolved card | **no, deliberately** |
+
+- **A client cannot mute APNS on its own.** The path is daemon → Worker → APNS
+  and never consults the client, so a client-side switch is decoration. It
+  literally was: `settings.notifications` was written by the settings panel and
+  read by nothing. Preferences ride up on `register_device_token` (idempotent
+  and keyed by token, so a toggle change is just a re-register) and the daemon
+  filters its per-token fan-out in `notifications/push-preferences.ts`.
+- **Never filter `dismiss`.** A muted device can still hold a card delivered
+  before the mute; dropping its dismissal strands that card on the lock screen
+  of the device that asked for less noise.
+- **A muted fan-out must report `no_channel`, not `pushed`.** `awaitDelivery`
+  decides whether a held hook keeps Claude blocked; claiming delivery for a
+  fan-out of zero blocks the hook on a card nobody will ever see.
+- Malformed preferences fail toward DELIVERING (`sanitizePushPreferences`). A
+  wrongly-delivered notification is a nuisance; a wrongly-dropped one is the
+  product failing at its only job.
+- `notifications.on_turn_complete = false` in `config.toml` stays the
+  machine-wide master switch and wins over any per-device preference.
+
 **Constraints from real logs (2026-04-12 analysis, updated #718 2026-07-06):**
 
 - Bash `PermissionRequest` may have `permission_suggestions=undefined` (no suggestions), a legacy plain-string label array (e.g. Edit's `["Yes","Always","No"]`), or — since ~Claude Code 2.0.54 — a STRUCTURED array of typed "permission update entries" (`addRules`, `addDirectories`, `setMode`, `removeRules`, `replaceRules`, `removeDirectories`, each carrying `behavior`/`destination`; ground truth: code.claude.com/docs/en/hooks).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **Separate in-app toggles for question and turn-complete notifications**
+  (#968). Settings now has "Question alerts" and "Turn complete" instead of one
+  "Notifications" switch — which was written by the settings panel and read by
+  nothing, and could not have worked anyway: APNS pushes travel daemon →
+  signaling Worker → APNS and never consult the client. The preference now
+  rides up on `register_device_token` (idempotent and keyed by token, so
+  flipping a toggle is just a re-register) and the daemon filters its per-token
+  fan-out, so muting is enforced by the only party actually in the push path.
+  Per device, not per machine: two phones can want different things.
+- **An explicit `kind` on every push** (`question` | `turn_complete` |
+  `subagent_alert` | `dismiss`), forwarded into the APNS payload. The classes
+  were previously told apart by a NEGATIVE test ("no `questionId`, no
+  `category`") that could not distinguish a turn-complete push from a subagent
+  alert at all — on the wire both are exactly `{token, title, body}`, and the
+  `": turn complete"` title suffix is display text, not a protocol field.
+  Strictly additive: every field that previously carried routing information is
+  sent unchanged, so an un-redeployed Worker or an older client behaves as before.
+
+  Two classes are deliberately NOT mutable. `dismiss` is the quiet
+  `content-available` push that CLEARS a resolved card; suppressing it would
+  strand that card on the lock screen of the very device that asked for less
+  noise. `subagent_alert` already has a user-facing control — it fires only on
+  the patterns in `auto_approve.subagent_alert`. `notifications.on_turn_complete`
+  in `config.toml` remains the machine-wide master switch and still wins.
+
+  The load-bearing case, and the one with its own test: when every device has
+  muted questions and no client is attached, the delivery outcome is
+  `no_channel`, not `pushed`. `awaitDelivery` decides whether a HELD hook keeps
+  Claude blocked, so reporting delivery for a fan-out of zero would block the
+  hook on a card that will never appear anywhere. Malformed preferences fail
+  toward delivering, for the same reason — verified by mutation (a coercing
+  implementation reads `{questions: 0}` as "mute" and the test goes red).
+
 ### Changed
 - **The auto-approve prompt's default guidelines now follow `level`** (#966).
   `level` selects which groups are approved deterministically, but whatever no

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -182,6 +182,7 @@ import type { HookInput, PermissionRequestHookInput, StopHookInput } from './hoo
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
+import { tokensWanting } from './notifications/push-preferences.ts';
 import {
   TurnTimer,
   buildTurnCompleteText,
@@ -1264,6 +1265,7 @@ function onSubagentPassthrough(input: PermissionRequestHookInput): void {
       title,
       body,
       ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+      kind: 'subagent_alert',
     }).catch((err) => {
       logError('[SubagentAlert] push failed:', err);
     });
@@ -1329,6 +1331,14 @@ function onTurnStop(input: StopHookInput): void {
     turnTimer.clear(input.prompt_id);
   }
 
+  // Devices that want turn-complete pushes (#968). Resolved BEFORE the gate so
+  // `hasDeviceTokens` means "someone will actually receive this", not merely
+  // "a token exists": a machine whose every device muted turn-complete stops at
+  // the gate instead of building text and fanning out to nobody. The
+  // machine-wide `notifications.on_turn_complete` above still wins over any
+  // per-device preference — it is checked first, inside the gate.
+  const wanting = tokensWanting(deviceTokens.values(), 'turn_complete');
+
   if (
     !shouldNotifyTurnComplete({
       onTurnComplete: remiConfig.notifications.on_turn_complete,
@@ -1336,7 +1346,7 @@ function onTurnStop(input: StopHookInput): void {
       elapsedMs,
       minSeconds: remiConfig.notifications.turn_complete_min_seconds,
       lastAssistantMessage: input.last_assistant_message,
-      hasDeviceTokens: deviceTokens.size > 0,
+      hasDeviceTokens: wanting.length > 0,
     })
   ) {
     return;
@@ -1350,13 +1360,16 @@ function onTurnStop(input: StopHookInput): void {
   log(`[TurnComplete] ${title}`);
 
   const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
-  for (const dt of deviceTokens.values()) {
+  for (const dt of wanting) {
     // Dismiss-only, same convention as onSubagentPassthrough above: no
-    // `category` / `questionId`, it answers nothing.
+    // `category` / `questionId`, it answers nothing. `kind` is what makes it
+    // distinguishable from a subagent alert, which is otherwise identical on
+    // the wire (#968).
     void sendPushTrigger(signalingUrl, dt.token, {
       title,
       body,
       ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+      kind: 'turn_complete',
     }).catch((err) => {
       logError('[TurnComplete] push failed:', err);
     });

--- a/packages/daemon/src/cli/handlers/trivial-events.ts
+++ b/packages/daemon/src/cli/handlers/trivial-events.ts
@@ -5,8 +5,12 @@
  */
 
 import { createSessionHistoryResponse, errorToString } from '@remi/shared';
-import type { ProtocolMessage, UUID } from '@remi/shared';
+import type { ProtocolMessage, PushPreferences, UUID } from '@remi/shared';
 
+import {
+  type ResolvedPushPreferences,
+  sanitizePushPreferences,
+} from '../../notifications/push-preferences.ts';
 import type { SessionRegistry, SessionStore } from '../../session/index.ts';
 import { log, logError } from '../logger.ts';
 import { getRecentDirectories } from '../recent-client.ts';
@@ -16,6 +20,14 @@ export interface DeviceTokenEntry {
   platform: string;
   registeredAt: number;
   connectionId: UUID;
+  /**
+   * Which push classes this device wants (#968). Absent on entries registered
+   * before #968, and on any client that sends none — both mean "wants
+   * everything" (`push-preferences.ts` owns that default). Persisted with the
+   * token so the preference survives a daemon restart and is shared across
+   * every local daemon, exactly like the token itself.
+   */
+  pushPrefs?: ResolvedPushPreferences;
 }
 
 export type SendToConnection = (connectionId: UUID, message: ProtocolMessage) => boolean;
@@ -26,7 +38,12 @@ export interface TrivialHandlerDeps {
    * map: it does the #585 rotation prune (a re-registration from the same
    * connection drops that connection's OTHER, now-rotated token) and persists.
    */
-  registerDeviceToken: (token: string, platform: string, connectionId: UUID) => void;
+  registerDeviceToken: (
+    token: string,
+    platform: string,
+    connectionId: UUID,
+    pushPrefs: ResolvedPushPreferences,
+  ) => void;
   /**
    * Unregister a device token (#690) — the store deletes it and marks it
    * `removed` so a concurrent daemon's stale copy is not re-adopted. Fires
@@ -45,9 +62,20 @@ export function createTrivialHandlers(deps: TrivialHandlerDeps) {
   const { registerDeviceToken, unregisterDeviceToken, sessionStore, sessionRegistry, send } = deps;
 
   return {
-    onRegisterDeviceToken: (connectionId: UUID, token: string, platform: string): void => {
-      log(`Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform})`);
-      registerDeviceToken(token, platform, connectionId);
+    onRegisterDeviceToken: (
+      connectionId: UUID,
+      token: string,
+      platform: string,
+      pushPrefs?: PushPreferences,
+    ): void => {
+      // Sanitize at the boundary (#968): `pushPrefs` arrives on a client
+      // message, so the stored value is a resolved, definitely-boolean pair and
+      // nothing downstream has to re-decide what a missing field means.
+      const resolved = sanitizePushPreferences(pushPrefs);
+      log(
+        `Device token registered from ${connectionId}: ${token.slice(0, 20)}... (${platform}, questions=${resolved.questions}, turnComplete=${resolved.turnComplete})`,
+      );
+      registerDeviceToken(token, platform, connectionId, resolved);
     },
 
     onUnregisterDeviceToken: (connectionId: UUID, token: string): void => {

--- a/packages/daemon/src/hooks/foreign-session-escalator.ts
+++ b/packages/daemon/src/hooks/foreign-session-escalator.ts
@@ -68,6 +68,7 @@ import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
 import { log, logError } from '../cli/logger.ts';
 import type { PushConfig, PushFn } from '../notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from '../notifications/push-client.ts';
+import { tokensWanting } from '../notifications/push-preferences.ts';
 import type { SessionBindingStore } from '../session/index.ts';
 import { type SessionRegistryFile, claudeChildLooksAlive } from '../session/index.ts';
 import { MARKER_SETTLE_MS, readTranscriptOwnerPort } from '../transcript/transcript-owner.ts';
@@ -265,9 +266,15 @@ export class ForeignSessionEscalator {
   ): Promise<void> {
     const { deviceTokens, pushConfig } = this.deps;
     const shortId = input.session_id.slice(0, 8);
-    if (deviceTokens.size === 0) {
+    // A permission request in a session remi does not manage is still a
+    // question-class push (#968) — it buzzes, and it says the agent is blocked
+    // on someone — so a device muted for questions does not get it.
+    const wanting = tokensWanting(deviceTokens.values(), 'question');
+    if (wanting.length === 0) {
       log(
-        `[ForeignSession] No device tokens registered; cannot notify about unbound session ${shortId}`,
+        deviceTokens.size === 0
+          ? `[ForeignSession] No device tokens registered; cannot notify about unbound session ${shortId}`
+          : `[ForeignSession] All ${deviceTokens.size} device token(s) muted question pushes; not notifying about unbound session ${shortId}`,
       );
       return;
     }
@@ -277,7 +284,7 @@ export class ForeignSessionEscalator {
     const body = `${input.tool_name} requested permission in a Claude session Remi does not manage${cwdHint ? ` (${cwdHint})` : ''}. Not connected to Remi; answer it in that terminal directly.`;
 
     const results = await Promise.allSettled(
-      [...deviceTokens.values()].map((dt) =>
+      wanting.map((dt) =>
         this.pushFn(cfg.signalingUrl, dt.token, {
           title,
           body,
@@ -286,6 +293,7 @@ export class ForeignSessionEscalator {
           // Deliberately no `category` / `options`: dismiss-only, no action
           // buttons (see module doc). Also no `questionId` -- there is no
           // Question backing this push for an answer to resolve against.
+          kind: 'question' as const,
         }),
       ),
     );

--- a/packages/daemon/src/notifications/device-token-store.ts
+++ b/packages/daemon/src/notifications/device-token-store.ts
@@ -42,6 +42,11 @@ import * as fs from 'node:fs';
 
 import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
 import { log, logError } from '../cli/logger.ts';
+import {
+  DEFAULT_PUSH_PREFERENCES,
+  type ResolvedPushPreferences,
+  sanitizePushPreferences,
+} from './push-preferences.ts';
 
 /** A tombstone recording that `token` was explicitly removed at `removedAt`
  *  (epoch ms). Persisted so the removal is visible to every daemon sharing
@@ -86,6 +91,20 @@ function isValidEntry(e: unknown): e is DeviceTokenEntry {
     typeof (e as DeviceTokenEntry).platform === 'string' &&
     typeof (e as DeviceTokenEntry).connectionId === 'string'
   );
+}
+
+/**
+ * Resolve a loaded entry's `pushPrefs` to definite booleans (#968), leaving an
+ * entry that has none untouched (absent still means "wants everything", so
+ * writing defaults in would only make old files churn on their next persist).
+ *
+ * The file is local, but it is also shared between daemons and hand-editable,
+ * and a half-written or edited-in `{questions: "no"}` must not decide whether
+ * a notification is sent. `sanitizePushPreferences` fails toward delivering.
+ */
+function normalizePrefs(entry: DeviceTokenEntry): DeviceTokenEntry {
+  if (entry.pushPrefs === undefined) return entry;
+  return { ...entry, pushPrefs: sanitizePushPreferences(entry.pushPrefs) };
 }
 
 function isValidTombstone(t: unknown): t is StoredTombstone {
@@ -151,7 +170,12 @@ export class DeviceTokenStore {
    * connection previously registered (APNS token rotation) — tombstoning the
    * rotated-out token so siblings drop it too. Persists.
    */
-  register(token: string, platform: string, connectionId: string): void {
+  register(
+    token: string,
+    platform: string,
+    connectionId: string,
+    pushPrefs: ResolvedPushPreferences = DEFAULT_PUSH_PREFERENCES,
+  ): void {
     for (const [existingToken, entry] of this.tokens) {
       if (existingToken !== token && entry.connectionId === connectionId) {
         this.tokens.delete(existingToken);
@@ -161,7 +185,16 @@ export class DeviceTokenStore {
         );
       }
     }
-    this.tokens.set(token, { token, platform, registeredAt: monotonicNow(), connectionId });
+    // Last registration wins on `pushPrefs` (#968), including when it widens
+    // what the device wants. Registration is how the app pushes a toggle
+    // change, so an older stored value must never survive a newer one.
+    this.tokens.set(token, {
+      token,
+      platform,
+      registeredAt: monotonicNow(),
+      connectionId,
+      pushPrefs,
+    });
     // A fresh registration is always newer than any prior tombstone for it.
     this.tombstones.delete(token);
     this.persist();
@@ -267,7 +300,7 @@ export class DeviceTokenStore {
       const tokenList = (parsed as { tokens?: unknown })?.tokens;
       const tombstoneList = (parsed as { tombstones?: unknown })?.tombstones;
       return {
-        tokens: Array.isArray(tokenList) ? tokenList.filter(isValidEntry) : [],
+        tokens: Array.isArray(tokenList) ? tokenList.filter(isValidEntry).map(normalizePrefs) : [],
         // Absent on an old-format file (pre-#690) -> no tombstones, loads fine.
         tombstones: Array.isArray(tombstoneList) ? tombstoneList.filter(isValidTombstone) : [],
       };

--- a/packages/daemon/src/notifications/notification-dispatcher.ts
+++ b/packages/daemon/src/notifications/notification-dispatcher.ts
@@ -20,6 +20,7 @@ import { log, logError } from '../cli/logger.ts';
 import type { SessionRegistry } from '../session/index.ts';
 import { sendPushTrigger } from './push-client.ts';
 import { PushDedup } from './push-dedup.ts';
+import { tokensWanting } from './push-preferences.ts';
 
 export interface PushConfig {
   /**
@@ -338,10 +339,25 @@ export class NotificationDispatcher {
     // because the attached client may be backgrounded (#603 Phase 3), like
     // dismiss(). Its outcome still reports in_app (reachable) below.
     if (!held && hasActiveClient) return Promise.resolve('in_app');
-    // No device tokens: nobody can be pushed. If a client is attached the user
-    // is still reachable in-app (held case); otherwise there is no channel.
-    if (deviceTokens.size === 0) {
-      if (!hasActiveClient) log(`Push skipped: no device tokens for session ${questionSessionId}`);
+    // Devices that want question pushes (#968). A device muted for questions is
+    // as unreachable for this question as one that never registered, so it is
+    // filtered HERE — above the no-channel check — and not at the fan-out.
+    //
+    // That placement is load-bearing for a HELD escalation: `awaitDelivery`
+    // decides whether to keep Claude blocked, and reporting `pushed` for a fan-
+    // out of zero would block the hook on a card that will never appear on any
+    // lock screen. Reporting `no_channel` instead fails the hold open fast.
+    const wanting = tokensWanting(deviceTokens.values(), 'question');
+    // No reachable device: nobody can be pushed. If a client is attached the
+    // user is still reachable in-app (held case); otherwise there is no channel.
+    if (wanting.length === 0) {
+      if (!hasActiveClient) {
+        log(
+          deviceTokens.size === 0
+            ? `Push skipped: no device tokens for session ${questionSessionId}`
+            : `Push skipped: all ${deviceTokens.size} device token(s) muted question pushes for session ${questionSessionId}`,
+        );
+      }
       return Promise.resolve(hasActiveClient ? 'in_app' : 'no_channel');
     }
 
@@ -384,9 +400,10 @@ export class NotificationDispatcher {
       ...(pushCategory !== undefined ? { category: pushCategory } : {}),
       ...(pushOptions.length > 0 ? { options: pushOptions } : {}),
       ...(dynOptions ? { dynOptions: true } : {}),
+      kind: 'question' as const,
     };
 
-    const perToken = [...deviceTokens.values()].map((dt) =>
+    const perToken = wanting.map((dt) =>
       this.pushOnceWithRetry(cfg.signalingUrl, dt.token, opts, {
         sent: `Push notification sent for session ${pushSessionId}`,
         failed: `Push notification failed for session ${pushSessionId}`,
@@ -489,10 +506,16 @@ export class NotificationDispatcher {
    *  - collapse key is `handoff-<questionId>`, NOT the question id, so the
    *    original card's quiet dismissal (collapse-id = question id) cannot
    *    collapse this notice away.
+   *
+   * IS filtered by per-device push preferences (#968), unlike `dismiss`: this
+   * is a visible, buzzing card about a question, so a device that muted
+   * question pushes must not receive it. It clears nothing, so skipping it
+   * strands nothing.
    */
   pushHoldTimeoutHandoff(questionSessionId: UUID, questionId: UUID): void {
     const { deviceTokens, pushConfig, sessionRegistry } = this.deps;
-    if (deviceTokens.size === 0) return;
+    const wanting = tokensWanting(deviceTokens.values(), 'question');
+    if (wanting.length === 0) return;
     const session = sessionRegistry.getSession(this.sessionId);
     const question = session?.currentQuestions.get(questionId);
     const sessionName = session?.name || 'Agent';
@@ -506,7 +529,7 @@ export class NotificationDispatcher {
     );
     const cfg = pushConfig();
     const pushSessionId = this.deps.getPrimarySessionId() ?? questionSessionId;
-    for (const dt of deviceTokens.values()) {
+    for (const dt of wanting) {
       void this.pushOnceWithRetry(
         cfg.signalingUrl,
         dt.token,
@@ -516,6 +539,7 @@ export class NotificationDispatcher {
           ...(cfg.pushSecret !== undefined ? { pushSecret: cfg.pushSecret } : {}),
           sessionId: pushSessionId,
           questionId: `handoff-${questionId}`,
+          kind: 'question' as const,
         },
         {
           sent: `Push timeout-handoff sent for question ${questionId}`,
@@ -534,6 +558,11 @@ export class NotificationDispatcher {
    * card may still sit on another device's lock screen, and the collapse-id makes
    * a no-op dismissal harmless. No dedup gate (a repeat dismissal is idempotent at
    * the device). No-op when no tokens are registered.
+   *
+   * Deliberately NOT filtered by per-device push preferences (#968): a device
+   * that mutes question pushes can still be holding a card delivered before the
+   * mute, and dropping its dismissal would strand that card on the lock screen
+   * of the very device that asked for less noise.
    *
    * `questionSessionId` is the primary id the client knows (from hello_ack), kept
    * symmetric with `maybePush` so the dismissal carries the same routing id.
@@ -558,6 +587,7 @@ export class NotificationDispatcher {
           sessionId: pushSessionId,
           questionId,
           dismiss: true,
+          kind: 'dismiss' as const,
         },
         {
           sent: `Push dismissal sent for question ${questionId}`,

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -6,8 +6,30 @@
 
 const DEFAULT_SIGNALING_URL = 'https://remi-signaling.yooz.workers.dev';
 
+/**
+ * What class of push this is (#968).
+ *
+ * Before this existed, the classes were told apart only by a NEGATIVE test —
+ * "no questionId, no category" — which could not distinguish a turn-complete
+ * push from a subagent alert at all: on the wire they were byte-identical
+ * `{token, title, body}`. The `": turn complete"` title suffix is display text,
+ * not a discriminator. Naming the class explicitly is what lets both the daemon
+ * (per-device filtering, `push-preferences.ts`) and the client (labelling,
+ * routing) act on it.
+ */
+export type PushKind = 'question' | 'turn_complete' | 'subagent_alert' | 'dismiss';
+
 /** Options for sendPushTrigger */
 export interface PushTriggerOptions {
+  /**
+   * Which class of push this is. Forwarded to the Worker, which passes it
+   * through into the APNS payload's custom data as `kind`.
+   *
+   * Purely additive: every field that previously distinguished these classes
+   * (`category`, `questionId`, `dismiss`) is still sent exactly as before, so an
+   * older Worker or client that ignores `kind` behaves identically.
+   */
+  kind?: PushKind;
   /** Title shown in the notification banner. Optional only for a `dismiss`
    *  push (#585, P7), which is silent (content-available) and has no text. */
   title?: string;
@@ -87,6 +109,9 @@ export async function sendPushTrigger(
   }
   if (opts.dismiss) {
     payload['dismiss'] = true;
+  }
+  if (opts.kind) {
+    payload['kind'] = opts.kind;
   }
   const response = await fetch(url, {
     method: 'POST',

--- a/packages/daemon/src/notifications/push-preferences.ts
+++ b/packages/daemon/src/notifications/push-preferences.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-device push preferences (#968) — the one place that decides whether a
+ * given device wants a given class of push.
+ *
+ * Why the daemon owns this at all: the push path is daemon -> signaling Worker
+ * -> APNS and never consults the client, so a client-side "mute" switch is
+ * decoration. (It literally was: `settings.notifications` in the web app was
+ * written by the settings panel and read by nothing.) A preference only becomes
+ * real once the sender honors it, so the device sends it up on
+ * `register_device_token` and the daemon filters its per-token fan-out here.
+ *
+ * Two deliberate non-preferences:
+ *   - `dismiss` pushes are never filtered. They are quiet `content-available`
+ *     updates that CLEAR an already-delivered card; suppressing one strands
+ *     that card on the lock screen of the very device that asked for less
+ *     noise. `wantsPush` returns true for them unconditionally.
+ *   - `subagent_alert` is not filtered either. It already has a user-facing
+ *     control — it fires only on the patterns the user put in
+ *     `auto_approve.subagent_alert` — so a second mute would be redundant.
+ *
+ * Both are enumerated explicitly rather than defaulted, so adding a new
+ * `PushKind` is a type error here instead of a silent "unfiltered".
+ */
+
+import type { PushPreferences } from '@remi/shared';
+
+import type { DeviceTokenEntry } from '../cli/handlers/trivial-events.ts';
+import type { PushKind } from './push-client.ts';
+
+/** Every preference resolved to a definite boolean. */
+export interface ResolvedPushPreferences {
+  readonly questions: boolean;
+  readonly turnComplete: boolean;
+}
+
+/**
+ * What a device gets when it expresses no preference: everything.
+ *
+ * This is also the fail-open direction for malformed input (see
+ * `sanitizePushPreferences`). remi exists to tell you your agent needs you; a
+ * notification wrongly delivered is a nuisance, one wrongly dropped is the
+ * product failing at its only job.
+ */
+export const DEFAULT_PUSH_PREFERENCES: ResolvedPushPreferences = {
+  questions: true,
+  turnComplete: true,
+};
+
+/**
+ * Resolve wire-supplied preferences into definite booleans.
+ *
+ * The input crosses a trust boundary (it arrives on a client message, and over
+ * the relay that client is only as authenticated as the connection was), so
+ * nothing here trusts the declared type: any field that is not literally a
+ * boolean falls back to the default rather than being coerced. `{questions:
+ * 'false'}` therefore means "deliver questions", not "mute them" — a truthy
+ * string coerced the other way would silently mute a device that never asked
+ * to be muted.
+ */
+export function sanitizePushPreferences(
+  input: PushPreferences | undefined,
+): ResolvedPushPreferences {
+  if (input === null || typeof input !== 'object') return DEFAULT_PUSH_PREFERENCES;
+  return {
+    questions:
+      typeof input.questions === 'boolean' ? input.questions : DEFAULT_PUSH_PREFERENCES.questions,
+    turnComplete:
+      typeof input.turnComplete === 'boolean'
+        ? input.turnComplete
+        : DEFAULT_PUSH_PREFERENCES.turnComplete,
+  };
+}
+
+/**
+ * Does this device want a push of `kind`?
+ *
+ * An entry with no stored preferences (registered before #968, or by a client
+ * that sends none) wants everything.
+ */
+export function wantsPush(entry: DeviceTokenEntry, kind: PushKind): boolean {
+  const prefs = entry.pushPrefs ?? DEFAULT_PUSH_PREFERENCES;
+  switch (kind) {
+    case 'question':
+      return prefs.questions;
+    case 'turn_complete':
+      return prefs.turnComplete;
+    // Never filtered — see the module doc for why each is exempt.
+    case 'subagent_alert':
+      return true;
+    case 'dismiss':
+      return true;
+  }
+}
+
+/** The subset of `tokens` that wants a push of `kind`. */
+export function tokensWanting(
+  tokens: Iterable<DeviceTokenEntry>,
+  kind: PushKind,
+): DeviceTokenEntry[] {
+  return [...tokens].filter((entry) => wantsPush(entry, kind));
+}

--- a/packages/daemon/src/remote/relay-adapter.ts
+++ b/packages/daemon/src/remote/relay-adapter.ts
@@ -605,7 +605,7 @@ export class RelayAdapter implements ConnectionAdapter {
         this.events.onSessionHistoryRequest?.(connectionId, m.id, m.limit);
       },
       register_device_token: (m) => {
-        this.events.onRegisterDeviceToken?.(connectionId, m.token, m.platform);
+        this.events.onRegisterDeviceToken?.(connectionId, m.token, m.platform, m.pushPrefs);
       },
       unregister_device_token: (m) => {
         this.events.onUnregisterDeviceToken?.(connectionId, m.token);

--- a/packages/daemon/src/server/client-message-events.ts
+++ b/packages/daemon/src/server/client-message-events.ts
@@ -37,7 +37,7 @@
  * in `cli.ts`'s `sharedEvents` assembly. That work is inherent business
  * logic, not the duplication this module removes.
  */
-import type { AnswerExtras, UUID } from '@remi/shared';
+import type { AnswerExtras, PushPreferences, UUID } from '@remi/shared';
 
 /**
  * Every client-to-daemon event's argument list, WITHOUT `connectionId`.
@@ -94,8 +94,13 @@ export interface ClientMessageEventArgs {
   /** Detach session request received (tmux-style). */
   onDetachSession: [sessionId: UUID, requestId: UUID];
 
-  /** Device token registered for push notifications. */
-  onRegisterDeviceToken: [token: string, platform: 'ios' | 'android'];
+  /** Device token registered for push notifications. `pushPrefs` is undefined
+   *  when the client sent none, which means "wants every push class" (#968). */
+  onRegisterDeviceToken: [
+    token: string,
+    platform: 'ios' | 'android',
+    pushPrefs: PushPreferences | undefined,
+  ];
 
   /** Device token unregistered -- explicit user removal of this server (#690). */
   onUnregisterDeviceToken: [token: string];

--- a/packages/daemon/src/server/connection.ts
+++ b/packages/daemon/src/server/connection.ts
@@ -574,7 +574,7 @@ export class Connection {
 
   private handleRegisterDeviceToken(message: RegisterDeviceTokenMessage): void {
     this.sendAck(message.id, 'delivered');
-    this.events.onRegisterDeviceToken?.(message.token, message.platform);
+    this.events.onRegisterDeviceToken?.(message.token, message.platform, message.pushPrefs);
   }
 
   /**

--- a/packages/daemon/tests/cli/handlers/trivial-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/trivial-events.test.ts
@@ -69,6 +69,38 @@ describe('createTrivialHandlers', () => {
     expect(calls).toEqual([{ token: 'ios-device-token-abc', platform: 'ios', connectionId: CID }]);
   });
 
+  test('#968: onRegisterDeviceToken resolves push preferences before the store sees them', () => {
+    // Sanitizing at the boundary is what lets everything downstream treat
+    // `pushPrefs` as a definitely-boolean pair instead of re-deciding what a
+    // missing or malformed field meant.
+    const calls: Array<{ token: string; prefs: unknown }> = [];
+    const { send } = makeSend();
+    const handlers = createTrivialHandlers({
+      registerDeviceToken: (token, _platform, _connectionId, pushPrefs) =>
+        calls.push({ token, prefs: pushPrefs }),
+      unregisterDeviceToken: () => {},
+      sessionStore,
+      sessionRegistry,
+      send,
+    });
+    configureLogger({ writeLog: () => {} });
+
+    // No preferences sent -> everything on.
+    handlers.onRegisterDeviceToken(CID, 'tok-none', 'ios');
+    // Explicit mute, honored.
+    handlers.onRegisterDeviceToken(CID, 'tok-muted', 'ios', { turnComplete: false });
+    // Malformed: `'false'` is truthy, so a coercing handler would mute here.
+    handlers.onRegisterDeviceToken(CID, 'tok-bad', 'ios', {
+      questions: 'false',
+    } as unknown as { questions?: boolean });
+
+    expect(calls).toEqual([
+      { token: 'tok-none', prefs: { questions: true, turnComplete: true } },
+      { token: 'tok-muted', prefs: { questions: true, turnComplete: false } },
+      { token: 'tok-bad', prefs: { questions: true, turnComplete: true } },
+    ]);
+  });
+
   test('onUnregisterDeviceToken forwards token to the store (#690)', () => {
     const calls: string[] = [];
     const { send } = makeSend();

--- a/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
+++ b/packages/daemon/tests/hooks/foreign-session-escalator.test.ts
@@ -247,6 +247,33 @@ describe('ForeignSessionEscalator (#672)', () => {
       expect(pushCalls).toHaveLength(0);
     });
 
+    test('#968: skips a device that muted question pushes, keeps the others', async () => {
+      // An unbound session's permission request is a question-class push: it
+      // buzzes and says an agent is blocked on someone. A device that muted
+      // question alerts must not get it.
+      registerToken('muted');
+      registerToken('wants');
+      deviceTokens.get('muted')!.pushPrefs = { questions: false, turnComplete: true };
+      deviceTokens.get('wants')!.pushPrefs = { questions: true, turnComplete: false };
+
+      const escalator = new ForeignSessionEscalator(deps());
+      escalator.handleUnadmitted(permissionInput(), OUR_SESSION_ID);
+      await flush();
+
+      expect(pushCalls.map((c) => c.token)).toEqual(['wants']);
+      expect(pushCalls[0]!.opts.kind).toBe('question');
+    });
+
+    test('#968: every device muted -> no push attempted, no throw', async () => {
+      registerToken('a');
+      deviceTokens.get('a')!.pushPrefs = { questions: false, turnComplete: true };
+
+      const escalator = new ForeignSessionEscalator(deps());
+      expect(() => escalator.handleUnadmitted(permissionInput(), OUR_SESSION_ID)).not.toThrow();
+      await flush();
+      expect(pushCalls).toHaveLength(0);
+    });
+
     test('rate-limits repeated escalations for the SAME foreign session_id', async () => {
       registerToken();
       const escalator = new ForeignSessionEscalator(deps({ rateLimitMs: 60_000 }));

--- a/packages/daemon/tests/notifications/device-token-store.test.ts
+++ b/packages/daemon/tests/notifications/device-token-store.test.ts
@@ -343,3 +343,83 @@ describe('DeviceTokenStore (#603 Phase 6)', () => {
     expect(tombstonesOnDisk(file)).toContain('recent-removal');
   });
 });
+
+describe('DeviceTokenStore push preferences (#968)', () => {
+  let tmpDir: string;
+  let file: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-tokens-prefs-'));
+    file = path.join(tmpDir, 'device-tokens.json');
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(() => {
+    __resetLoggerForTests();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('register without preferences stores the all-on default', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('tok-a', 'ios', CID);
+    expect(s.map.get('tok-a')?.pushPrefs).toEqual({ questions: true, turnComplete: true });
+  });
+
+  test('preferences survive a restart via the persisted file', () => {
+    const s = new DeviceTokenStore(file);
+    s.register('tok-a', 'ios', CID, { questions: true, turnComplete: false });
+
+    const reloaded = new DeviceTokenStore(file);
+    reloaded.load();
+    expect(reloaded.map.get('tok-a')?.pushPrefs).toEqual({ questions: true, turnComplete: false });
+  });
+
+  test('re-registering the same token replaces its preferences, including widening them', () => {
+    // Re-registration IS how the app pushes a toggle change, so a stored value
+    // must never survive a newer one -- in either direction.
+    const s = new DeviceTokenStore(file);
+    s.register('tok-a', 'ios', CID, { questions: false, turnComplete: false });
+    expect(s.map.get('tok-a')?.pushPrefs).toEqual({ questions: false, turnComplete: false });
+
+    s.register('tok-a', 'ios', CID, { questions: true, turnComplete: true });
+    expect(s.map.get('tok-a')?.pushPrefs).toEqual({ questions: true, turnComplete: true });
+
+    const reloaded = new DeviceTokenStore(file);
+    reloaded.load();
+    expect(reloaded.map.get('tok-a')?.pushPrefs).toEqual({ questions: true, turnComplete: true });
+  });
+
+  test('an entry written before #968 loads with no preferences, meaning all-on', () => {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        tokens: [{ token: 'legacy', platform: 'ios', registeredAt: 1, connectionId: CID }],
+      }),
+    );
+    const s = new DeviceTokenStore(file);
+    s.load();
+    expect(s.map.get('legacy')?.pushPrefs).toBeUndefined();
+  });
+
+  test('a hand-edited non-boolean preference is normalized on load, not trusted', () => {
+    // The file is shared between daemons and editable; `"no"` is truthy, so an
+    // implementation that coerced would read this as a mute.
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        tokens: [
+          {
+            token: 'edited',
+            platform: 'ios',
+            registeredAt: 1,
+            connectionId: CID,
+            pushPrefs: { questions: 'no', turnComplete: false },
+          },
+        ],
+      }),
+    );
+    const s = new DeviceTokenStore(file);
+    s.load();
+    expect(s.map.get('edited')?.pushPrefs).toEqual({ questions: true, turnComplete: false });
+  });
+});

--- a/packages/daemon/tests/notifications/notification-dispatcher.test.ts
+++ b/packages/daemon/tests/notifications/notification-dispatcher.test.ts
@@ -1126,3 +1126,146 @@ describe('isTokenInvalidError (#603 Phase 6)', () => {
     expect(isTokenInvalidError(new TypeError('Failed to fetch'))).toBe(false);
   });
 });
+
+describe('NotificationDispatcher per-device push preferences (#968)', () => {
+  let registry: SessionRegistry;
+  let deviceTokens: Map<string, DeviceTokenEntry>;
+  let pushed: Array<{ token: string; opts: Record<string, unknown> }>;
+  const SID = 's0000000-0000-0000-0000-000000000000' as UUID;
+  const CID = 'c0000000-0000-0000-0000-000000000000' as UUID;
+  const QID = 'q0000000-0000-0000-0000-000000000000' as UUID;
+
+  const pushFn: PushFn = async (_url, token, opts) => {
+    pushed.push({ token, opts: opts as unknown as Record<string, unknown> });
+  };
+
+  function make(): NotificationDispatcher {
+    return new NotificationDispatcher(
+      {
+        sessionRegistry: registry,
+        deviceTokens,
+        pushConfig: () => ({ signalingUrl: 'ws://x' }),
+        getPrimarySessionId: () => null,
+        pushFn,
+      },
+      SID,
+    );
+  }
+
+  function register(attach: boolean): void {
+    registry.registerSession(SID, '/d', fakePTY(), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    if (attach) registry.attachConnection(SID, CID);
+  }
+
+  function token(
+    name: string,
+    prefs?: { questions: boolean; turnComplete: boolean },
+  ): DeviceTokenEntry {
+    return {
+      token: name,
+      platform: 'ios',
+      registeredAt: 1,
+      connectionId: SID,
+      ...(prefs !== undefined && { pushPrefs: prefs }),
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    deviceTokens = new Map();
+    pushed = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('maybePush skips a device that muted questions and pushes the others', async () => {
+    register(false);
+    deviceTokens.set('muted', token('muted', { questions: false, turnComplete: true }));
+    deviceTokens.set('wants', token('wants', { questions: true, turnComplete: true }));
+
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed.map((p) => p.token)).toEqual(['wants']);
+    expect(outcome).toBe('pushed');
+  });
+
+  test('a legacy entry with no stored preferences still receives question pushes', async () => {
+    register(false);
+    deviceTokens.set('legacy', token('legacy'));
+
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed.map((p) => p.token)).toEqual(['legacy']);
+    expect(outcome).toBe('pushed');
+  });
+
+  test('every device muted + no client attached reports no_channel, not pushed', async () => {
+    // The load-bearing case. `awaitDelivery` decides whether a HELD hook keeps
+    // Claude blocked; reporting `pushed` for a fan-out of zero would block the
+    // hook on a card that will never appear on any lock screen. `no_channel`
+    // fails the hold open fast instead.
+    register(false);
+    deviceTokens.set('a', token('a', { questions: false, turnComplete: true }));
+    deviceTokens.set('b', token('b', { questions: false, turnComplete: false }));
+
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+
+    expect(pushed).toHaveLength(0);
+    expect(outcome).toBe('no_channel');
+  });
+
+  test('every device muted WITH a client attached still reports in_app', async () => {
+    // The user is reachable over the socket, so the held hook may keep waiting;
+    // only the push channel is gone.
+    register(true);
+    deviceTokens.set('a', token('a', { questions: false, turnComplete: true }));
+
+    const outcome = await make().maybePush(SID, question('q1', [yesOpt, noOpt]), { held: true });
+
+    expect(pushed).toHaveLength(0);
+    expect(outcome).toBe('in_app');
+  });
+
+  test('question pushes carry kind=question', async () => {
+    register(false);
+    deviceTokens.set('a', token('a'));
+
+    await make().maybePush(SID, question('q1', [yesOpt, noOpt]));
+
+    expect(pushed[0]?.opts['kind']).toBe('question');
+  });
+
+  test('dismiss still reaches a device that muted BOTH classes', () => {
+    // Muting must never strand an already-delivered card on the lock screen of
+    // the very device that asked for less noise.
+    register(false);
+    deviceTokens.set('muted', token('muted', { questions: false, turnComplete: false }));
+
+    make().dismiss(SID, QID);
+
+    expect(pushed.map((p) => p.token)).toEqual(['muted']);
+    expect(pushed[0]?.opts['dismiss']).toBe(true);
+    expect(pushed[0]?.opts['kind']).toBe('dismiss');
+  });
+
+  test('pushHoldTimeoutHandoff skips a device that muted questions', () => {
+    // Unlike dismiss, the handoff is a visible buzzing card about a question and
+    // clears nothing, so skipping it strands nothing.
+    register(false);
+    deviceTokens.set('muted', token('muted', { questions: false, turnComplete: true }));
+    deviceTokens.set('wants', token('wants', { questions: true, turnComplete: false }));
+
+    make().pushHoldTimeoutHandoff(SID, QID);
+
+    expect(pushed.map((p) => p.token)).toEqual(['wants']);
+    expect(pushed[0]?.opts['kind']).toBe('question');
+  });
+});

--- a/packages/daemon/tests/notifications/push-preferences.test.ts
+++ b/packages/daemon/tests/notifications/push-preferences.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-device push preferences (#968).
+ *
+ * The interesting cases are all about DIRECTION: which way a missing or
+ * malformed value resolves, and which push classes are exempt from filtering
+ * entirely. Getting either backwards silently drops notifications, which is the
+ * one failure mode this product cannot have.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { UUID } from '@remi/shared';
+import type { DeviceTokenEntry } from '../../src/cli/handlers/trivial-events.ts';
+import type { PushKind } from '../../src/notifications/push-client.ts';
+import {
+  DEFAULT_PUSH_PREFERENCES,
+  type ResolvedPushPreferences,
+  sanitizePushPreferences,
+  tokensWanting,
+  wantsPush,
+} from '../../src/notifications/push-preferences.ts';
+
+const CID = 'c0000000-0000-0000-0000-000000000000' as UUID;
+
+function entry(token: string, pushPrefs?: ResolvedPushPreferences): DeviceTokenEntry {
+  return {
+    token,
+    platform: 'ios',
+    registeredAt: 1,
+    connectionId: CID,
+    ...(pushPrefs !== undefined && { pushPrefs }),
+  };
+}
+
+describe('sanitizePushPreferences', () => {
+  test('undefined resolves to every class enabled', () => {
+    expect(sanitizePushPreferences(undefined)).toEqual(DEFAULT_PUSH_PREFERENCES);
+    expect(DEFAULT_PUSH_PREFERENCES).toEqual({ questions: true, turnComplete: true });
+  });
+
+  test('explicit booleans pass through, including false', () => {
+    expect(sanitizePushPreferences({ questions: false, turnComplete: true })).toEqual({
+      questions: false,
+      turnComplete: true,
+    });
+    expect(sanitizePushPreferences({ questions: true, turnComplete: false })).toEqual({
+      questions: true,
+      turnComplete: false,
+    });
+  });
+
+  test('a partial object defaults only the missing field', () => {
+    expect(sanitizePushPreferences({ questions: false })).toEqual({
+      questions: false,
+      turnComplete: true,
+    });
+    expect(sanitizePushPreferences({ turnComplete: false })).toEqual({
+      questions: true,
+      turnComplete: false,
+    });
+  });
+
+  test('a FALSY non-boolean falls back to ON, it is never coerced', () => {
+    // The direction is the point, and only a FALSY non-boolean can prove it:
+    // `Boolean('false')` is `true`, so a truthy junk value resolves the same way
+    // under both a type check and a coercion and proves nothing. `0` / `''` /
+    // `null` are where the two implementations diverge -- coercion silently
+    // MUTES a device that never asked to be muted, which is the one failure
+    // mode this product cannot have. Both fields, so neither can regress alone.
+    for (const falsy of [0, '', null]) {
+      expect(
+        sanitizePushPreferences({ questions: falsy } as unknown as { questions?: boolean }),
+      ).toEqual({ questions: true, turnComplete: true });
+      expect(
+        sanitizePushPreferences({ turnComplete: falsy } as unknown as { turnComplete?: boolean }),
+      ).toEqual({ questions: true, turnComplete: true });
+    }
+  });
+
+  test('a truthy non-boolean also falls back to ON rather than being coerced', () => {
+    expect(
+      sanitizePushPreferences({ questions: 'false', turnComplete: 'yes' } as unknown as {
+        questions?: boolean;
+        turnComplete?: boolean;
+      }),
+    ).toEqual({ questions: true, turnComplete: true });
+  });
+
+  test('a non-object (null, string, number) resolves to the defaults', () => {
+    for (const bad of [null, 'nope', 42, []]) {
+      expect(sanitizePushPreferences(bad as never)).toEqual(DEFAULT_PUSH_PREFERENCES);
+    }
+  });
+});
+
+describe('wantsPush', () => {
+  test('an entry with no stored preferences wants every class', () => {
+    const legacy = entry('t');
+    const kinds: PushKind[] = ['question', 'turn_complete', 'subagent_alert', 'dismiss'];
+    for (const kind of kinds) {
+      expect(wantsPush(legacy, kind)).toBe(true);
+    }
+  });
+
+  test('each preference gates exactly its own class', () => {
+    const noQuestions = entry('t', { questions: false, turnComplete: true });
+    expect(wantsPush(noQuestions, 'question')).toBe(false);
+    expect(wantsPush(noQuestions, 'turn_complete')).toBe(true);
+
+    const noTurn = entry('t', { questions: true, turnComplete: false });
+    expect(wantsPush(noTurn, 'question')).toBe(true);
+    expect(wantsPush(noTurn, 'turn_complete')).toBe(false);
+  });
+
+  test('dismiss is never filtered, even with everything muted', () => {
+    // A device that muted questions can still be holding a card delivered
+    // BEFORE the mute. Dropping its dismissal strands that card on the lock
+    // screen of the device that asked for less noise -- more notification
+    // clutter, not less.
+    const muted = entry('t', { questions: false, turnComplete: false });
+    expect(wantsPush(muted, 'dismiss')).toBe(true);
+  });
+
+  test('subagent_alert is never filtered, even with everything muted', () => {
+    // It already has a user-facing control: it fires only on the patterns the
+    // user put in `auto_approve.subagent_alert`.
+    const muted = entry('t', { questions: false, turnComplete: false });
+    expect(wantsPush(muted, 'subagent_alert')).toBe(true);
+  });
+});
+
+describe('tokensWanting', () => {
+  test('keeps only the entries that want the kind, preserving the rest', () => {
+    const tokens = [
+      entry('all'),
+      entry('questions-only', { questions: true, turnComplete: false }),
+      entry('turn-only', { questions: false, turnComplete: true }),
+      entry('muted', { questions: false, turnComplete: false }),
+    ];
+
+    expect(tokensWanting(tokens, 'question').map((e) => e.token)).toEqual([
+      'all',
+      'questions-only',
+    ]);
+    expect(tokensWanting(tokens, 'turn_complete').map((e) => e.token)).toEqual([
+      'all',
+      'turn-only',
+    ]);
+    expect(tokensWanting(tokens, 'dismiss').map((e) => e.token)).toEqual([
+      'all',
+      'questions-only',
+      'turn-only',
+      'muted',
+    ]);
+  });
+
+  test('returns empty when every device muted the kind', () => {
+    const tokens = [
+      entry('a', { questions: false, turnComplete: true }),
+      entry('b', { questions: false, turnComplete: true }),
+    ];
+    expect(tokensWanting(tokens, 'question')).toEqual([]);
+  });
+
+  test('accepts a Map#values() iterator, the shape every call site passes', () => {
+    const map = new Map<string, DeviceTokenEntry>([
+      ['a', entry('a', { questions: true, turnComplete: false })],
+      ['b', entry('b', { questions: false, turnComplete: false })],
+    ]);
+    expect(tokensWanting(map.values(), 'question').map((e) => e.token)).toEqual(['a']);
+  });
+});

--- a/packages/daemon/tests/push-client.test.ts
+++ b/packages/daemon/tests/push-client.test.ts
@@ -120,3 +120,52 @@ describe('sendPushTrigger', () => {
     expect(lastRequest['body']).toBeTruthy();
   });
 });
+
+describe('sendPushTrigger push kind (#968)', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let lastBody: Record<string, unknown> | null = null;
+  let serverUrl: string;
+
+  beforeEach(() => {
+    lastBody = null;
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        lastBody = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+        return new Response(JSON.stringify({ success: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+    serverUrl = `http://localhost:${server.port}`;
+  });
+
+  afterEach(() => {
+    server.stop();
+  });
+
+  test('carries kind so a turn-complete push is distinguishable from a subagent alert', async () => {
+    // These two are otherwise byte-identical on the wire ({token, title, body}),
+    // which is exactly why `kind` had to exist before either could be filtered
+    // or labelled.
+    await sendPushTrigger(serverUrl, 'tok', {
+      title: 'proj: turn complete',
+      body: 'done',
+      kind: 'turn_complete',
+    });
+    expect(lastBody?.['kind']).toBe('turn_complete');
+
+    await sendPushTrigger(serverUrl, 'tok', {
+      title: 'Background agent ran rm -rf',
+      body: 'heads up',
+      kind: 'subagent_alert',
+    });
+    expect(lastBody?.['kind']).toBe('subagent_alert');
+  });
+
+  test('omits kind entirely when the caller sends none', async () => {
+    await sendPushTrigger(serverUrl, 'tok', { title: 't', body: 'b' });
+    expect(lastBody).not.toBeNull();
+    expect('kind' in (lastBody as Record<string, unknown>)).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -94,6 +94,7 @@ export type {
   ResumeSessionResponseMessage,
   DetachSessionMessage,
   DetachSessionAckMessage,
+  PushPreferences,
   RegisterDeviceTokenMessage,
   UnregisterDeviceTokenMessage,
   DaemonUpdateAvailableMessage,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -951,6 +951,31 @@ export interface DetachSessionAckMessage {
   readonly error?: string;
 }
 
+/**
+ * Per-device push preferences (#968). Which CLASSES of push this device wants;
+ * the daemon filters its per-token fan-out by these before sending.
+ *
+ * The client cannot mute APNS on its own — the push path is daemon -> signaling
+ * Worker -> APNS and never consults the client — so a device's preference is
+ * only real once the daemon stores and honors it. That is what this carries.
+ *
+ * Absent (or an absent field) means "wants it": an older client that never
+ * sends preferences keeps receiving everything, exactly as before.
+ *
+ * Deliberately does NOT cover two other push classes:
+ *   - subagent alerts, which already have a user-facing control (they fire only
+ *     on the user's own `auto_approve.subagent_alert` patterns);
+ *   - question DISMISSALS, which are quiet `content-available` pushes that clear
+ *     an already-delivered card. Muting those would strand a card on the lock
+ *     screen of the very device that asked for less noise.
+ */
+export interface PushPreferences {
+  /** Push when Claude needs an answer (permission prompts, escalations). */
+  readonly questions?: boolean;
+  /** Push the last assistant message when a long turn ends (#914). */
+  readonly turnComplete?: boolean;
+}
+
 /** Register a device token for push notifications */
 export interface RegisterDeviceTokenMessage {
   readonly type: 'register_device_token';
@@ -960,6 +985,14 @@ export interface RegisterDeviceTokenMessage {
   readonly token: string;
   /** Device platform */
   readonly platform: 'ios' | 'android';
+  /**
+   * Which push classes this device wants (#968). Omitted = all of them.
+   *
+   * Registration is idempotent and keyed by token, so changing a toggle in the
+   * app is just a re-send of this message with new preferences — no separate
+   * update message, and no way for the two to drift apart.
+   */
+  readonly pushPrefs?: PushPreferences;
 }
 
 /**
@@ -1921,10 +1954,12 @@ export function createDetachSessionAck(
   };
 }
 
-/** Create a device token registration message */
+/** Create a device token registration message. `pushPrefs` omitted = this
+ *  device wants every push class (#968). */
 export function createRegisterDeviceToken(
   token: string,
   platform: 'ios' | 'android',
+  pushPrefs?: PushPreferences,
 ): RegisterDeviceTokenMessage {
   return {
     type: 'register_device_token',
@@ -1932,6 +1967,7 @@ export function createRegisterDeviceToken(
     timestamp: now(),
     token,
     platform,
+    ...(pushPrefs !== undefined && { pushPrefs }),
   };
 }
 

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -62,6 +62,19 @@ interface PushRequestBody {
    * lock-screen card for an already-resolved question.
    */
   dismiss?: boolean;
+  /**
+   * Which class of push this is (#968): 'question' | 'turn_complete' |
+   * 'subagent_alert' | 'dismiss'. Passed through verbatim into APNS custom data
+   * as `kind` so the client can label and route by class instead of inferring
+   * it from the ABSENCE of `questionId`/`category` — an inference that could
+   * never tell a turn-complete push from a subagent alert, since those two are
+   * identical on the wire.
+   *
+   * Not validated against the known set: the worker only forwards it, and
+   * rejecting an unrecognized value here would mean a daemon adding a new class
+   * needs a worker redeploy before its pushes work at all.
+   */
+  kind?: string;
 }
 
 /** Per-IP rate limiter: 10 WebSocket upgrades per 60 seconds */
@@ -314,6 +327,11 @@ export default {
         body.options.length <= 6;
       if (wantsDynCategory) {
         data['dynCategory'] = '1';
+      }
+      // #968: forwarded verbatim, capped so a malformed value cannot bloat the
+      // APNS payload (Apple caps an alert payload at 4KB).
+      if (typeof body.kind === 'string' && body.kind.length > 0) {
+        data['kind'] = body.kind.slice(0, 32);
       }
       const category = body.category && body.category.length > 0 ? body.category : undefined;
 

--- a/packages/signaling/tests/push-kind.test.ts
+++ b/packages/signaling/tests/push-kind.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Worker-level tests for the push `kind` passthrough (#968).
+ *
+ * The daemon needs each push class to arrive at the device NAMED, because the
+ * classes are not otherwise distinguishable: a turn-complete push and a
+ * subagent alert are both exactly `{token, title, body}` on the wire, and the
+ * old discriminator was a negative test ("no questionId, no category") that
+ * lumps them together. Confirms the worker forwards `kind` verbatim into the
+ * APNS custom data, bounds it, and changes nothing else when it is absent.
+ *
+ * Same harness as `push-dyn-category.test.ts`: drives `worker.fetch` directly
+ * with the Apple call stubbed, unique CF-Connecting-IP per test to dodge the
+ * module-level per-IP push rate limiter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import worker from '../src/index.ts';
+
+async function generateTestP8(): Promise<string> {
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', pair.privateKey);
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  const lines = b64.match(/.{1,64}/g)?.join('\n') ?? b64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}
+
+interface TestEnv {
+  CONNECTIONS: unknown;
+  MAX_CONNECTIONS_PER_ROOM: string;
+  CONNECTION_TIMEOUT_MS: string;
+  APNS_KEY_ID: string;
+  APNS_TEAM_ID: string;
+  APNS_PRIVATE_KEY: string;
+  APNS_BUNDLE_ID: string;
+}
+
+describe('/push kind passthrough (#968)', () => {
+  let env: TestEnv;
+  let realFetch: typeof globalThis.fetch;
+  let appleRequests: Array<{ url: string; headers: Headers; body: string }>;
+  let ipCounter = 0;
+
+  beforeEach(async () => {
+    env = {
+      CONNECTIONS: {},
+      MAX_CONNECTIONS_PER_ROOM: '10',
+      CONNECTION_TIMEOUT_MS: '60000',
+      APNS_KEY_ID: 'TESTKEY123',
+      APNS_TEAM_ID: 'TESTTEAM45',
+      APNS_PRIVATE_KEY: await generateTestP8(),
+      APNS_BUNDLE_ID: 'live.yooz.remi',
+    };
+    appleRequests = [];
+    realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('push.apple.com')) {
+        appleRequests.push({
+          url,
+          headers: new Headers(init?.headers),
+          body: String(init?.body ?? ''),
+        });
+        return new Response('', { status: 200 });
+      }
+      throw new Error(`unexpected fetch to ${url}`);
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function pushRequest(body: Record<string, unknown>): Request {
+    ipCounter += 1;
+    return new Request('https://signaling.example/push', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': `198.51.100.${100 + ipCounter}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test('turn_complete and subagent_alert arrive distinguishable despite identical bodies', async () => {
+    // The whole point: same token/title/body shape, told apart only by `kind`.
+    const turn = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'proj: turn complete',
+        body: 'done',
+        kind: 'turn_complete',
+      }),
+      env as never,
+    );
+    expect(turn.status).toBe(200);
+    expect(JSON.parse(appleRequests[0]?.body ?? '{}')['kind']).toBe('turn_complete');
+
+    const alert = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'proj: turn complete',
+        body: 'done',
+        kind: 'subagent_alert',
+      }),
+      env as never,
+    );
+    expect(alert.status).toBe(200);
+    expect(JSON.parse(appleRequests[1]?.body ?? '{}')['kind']).toBe('subagent_alert');
+  });
+
+  test('kind rides alongside a question push without disturbing category or opt_N', async () => {
+    const res = await worker.fetch(
+      pushRequest({
+        token: 'device-abc',
+        title: 'T',
+        body: 'B',
+        questionId: 'q-1',
+        category: 'REMI_YN',
+        options: ['Yes', 'No'],
+        kind: 'question',
+      }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed['kind']).toBe('question');
+    expect(parsed.aps.category).toBe('REMI_YN');
+    expect(parsed['opt_0']).toBe('Yes');
+    expect(parsed['opt_1']).toBe('No');
+  });
+
+  test('a dismiss push carries kind without gaining an alert', async () => {
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', questionId: 'q-1', dismiss: true, kind: 'dismiss' }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect(parsed['kind']).toBe('dismiss');
+    expect(parsed.aps['content-available']).toBe(1);
+    expect(parsed.aps.alert).toBeUndefined();
+  });
+
+  test('absent kind produces a payload with no kind field at all', async () => {
+    // Strictly additive: a daemon that predates #968 gets a byte-identical push.
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', title: 'T', body: 'B' }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(appleRequests[0]?.body ?? '{}');
+    expect('kind' in parsed).toBe(false);
+  });
+
+  test('an unrecognized kind is forwarded, not rejected', async () => {
+    // The worker only carries the value. Rejecting an unknown one would mean a
+    // daemon adding a new push class needs a worker redeploy before ANY of its
+    // pushes work -- a deploy-order trap for a field that is purely a label.
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', title: 'T', body: 'B', kind: 'something_new' }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.parse(appleRequests[0]?.body ?? '{}')['kind']).toBe('something_new');
+  });
+
+  test('an over-long kind is capped so it cannot bloat the 4KB APNS payload', async () => {
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', title: 'T', body: 'B', kind: 'k'.repeat(500) }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    expect(JSON.parse(appleRequests[0]?.body ?? '{}')['kind']).toBe('k'.repeat(32));
+  });
+
+  test('an empty-string kind is dropped rather than sent as an empty field', async () => {
+    const res = await worker.fetch(
+      pushRequest({ token: 'device-abc', title: 'T', body: 'B', kind: '' }),
+      env as never,
+    );
+    expect(res.status).toBe(200);
+    expect('kind' in JSON.parse(appleRequests[0]?.body ?? '{}')).toBe(false);
+  });
+});

--- a/packages/signaling/tests/push-kind.test.ts
+++ b/packages/signaling/tests/push-kind.test.ts
@@ -73,13 +73,28 @@ describe('/push kind passthrough (#968)', () => {
     globalThis.fetch = realFetch;
   });
 
+  /**
+   * The worker's push rate limiters are MODULE-level, so they are shared by
+   * every signaling test file running in the same bun process. Each file
+   * therefore owns a distinct IP block, and this one owns `192.0.2.x`:
+   *
+   *   203.0.113.x  answer-relay, push-dismiss, push-dyn-category
+   *   203.0.114.x  push-budget (authenticated buckets)
+   *   198.51.100.x push-budget (its unauthenticated per-IP exhaustion test)
+   *   192.0.2.x    here
+   *
+   * Sharing `198.51.100.x` with push-budget is what made this file pass alone
+   * and 429 in CI: that file deliberately blows through the per-IP budget, so
+   * whichever ran second inherited an exhausted bucket. Pick a free block for
+   * any new file rather than reusing one of these.
+   */
   function pushRequest(body: Record<string, unknown>): Request {
     ipCounter += 1;
     return new Request('https://signaling.example/push', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'CF-Connecting-IP': `198.51.100.${100 + ipCounter}`,
+        'CF-Connecting-IP': `192.0.2.${100 + ipCounter}`,
       },
       body: JSON.stringify(body),
     });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -65,7 +65,7 @@ import { DEFAULT_SETTINGS } from '@/types';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import type { UnlockedIdentity } from '@remi/shared';
 import { assertNever, isValidMessage } from '@remi/shared';
-import type { ProtocolMessage, RecentDirectory } from '@remi/shared/protocol.ts';
+import type { ProtocolMessage, PushPreferences, RecentDirectory } from '@remi/shared/protocol.ts';
 import {
   createAnswer,
   createDetachSession,
@@ -358,10 +358,6 @@ function App() {
     mq.addEventListener('change', handleChange);
     return () => mq.removeEventListener('change', handleChange);
   }, [settings.theme]);
-
-  const handleSettingsChange = useCallback((newSettings: AppSettings) => {
-    setSettings(newSettings);
-  }, []);
 
   // Multi-daemon message handler. Empty deps intentional: state via functional updaters and refs.
   // `inReplay` (#798, mirrors the terminal client's #753 fix) is true only for
@@ -2099,6 +2095,14 @@ function App() {
   // Send device token to daemons: on new token or new connection
   const deviceTokenRef = useRef<string | null>(null);
   const tokenSentToRef = useRef<Set<ConnectionId>>(new Set());
+  // Push preferences as last sent (#968). Kept in a ref so the two registration
+  // effects below read the CURRENT value without taking `settings` as a
+  // dependency — that would re-run them (and re-register on every daemon) on an
+  // unrelated theme or font-size change.
+  const pushPrefsRef = useRef<PushPreferences>({
+    questions: settings.notifyQuestions,
+    turnComplete: settings.notifyTurnComplete,
+  });
   // #690: id -> resolver for a message awaiting its daemon `ack`. Currently
   // used only by handleDisconnect's unregister_device_token wait; see the
   // 'ack' case in handleMessage for the resolving side.
@@ -2109,7 +2113,7 @@ function App() {
       if (!token) return;
       deviceTokenRef.current = token;
       for (const id of connectedIds) {
-        cmSendMessage(id, createRegisterDeviceToken(token, 'ios'));
+        cmSendMessage(id, createRegisterDeviceToken(token, 'ios', pushPrefsRef.current));
         tokenSentToRef.current.add(id);
       }
     };
@@ -2122,7 +2126,7 @@ function App() {
     if (!deviceTokenRef.current) return;
     for (const id of connectedIds) {
       if (!tokenSentToRef.current.has(id)) {
-        cmSendMessage(id, createRegisterDeviceToken(deviceTokenRef.current, 'ios'));
+        cmSendMessage(id, createRegisterDeviceToken(deviceTokenRef.current, 'ios', pushPrefsRef.current));
         tokenSentToRef.current.add(id);
       }
     }
@@ -2133,6 +2137,44 @@ function App() {
       }
     }
   }, [connectedIds, cmSendMessage]);
+
+  // Declared HERE, not up with the other settings state, because it closes over
+  // `connectedIds` / `cmSendMessage` / the token refs — all declared above this
+  // point. A `useCallback` higher up would evaluate its dependency array during
+  // render, before those bindings are initialized.
+  const handleSettingsChange = useCallback(
+    (newSettings: AppSettings) => {
+      setSettings(newSettings);
+
+      // Push a notification-preference change to every connected daemon (#968).
+      // The daemon is the only thing in the APNS path, so a toggle that is not
+      // sent up is a toggle that does nothing. Re-registering the SAME token is
+      // the update: `register_device_token` is idempotent and keyed by token, so
+      // there is no separate update message and no way for the two to drift.
+      const next: PushPreferences = {
+        questions: newSettings.notifyQuestions,
+        turnComplete: newSettings.notifyTurnComplete,
+      };
+      const prev = pushPrefsRef.current;
+      if (prev.questions === next.questions && prev.turnComplete === next.turnComplete) return;
+      pushPrefsRef.current = next;
+
+      const token = deviceTokenRef.current;
+      // No token yet (permission not granted, or web): the current value is
+      // carried by whatever registration happens first.
+      if (!token) return;
+      for (const id of connectedIds) {
+        try {
+          if (!cmSendMessage(id, createRegisterDeviceToken(token, 'ios', next))) {
+            console.warn(`[App] Could not send push preferences to ${id}`);
+          }
+        } catch (err) {
+          console.warn('[App] Failed to send push preferences:', err);
+        }
+      }
+    },
+    [connectedIds, cmSendMessage],
+  );
 
   // Get active session. Derive connectionStatus from live connection state
   // at render time to avoid stale status from session_list_response merge timing.
@@ -2645,7 +2687,7 @@ function App() {
         for (const id of connectedIds) {
           if (id === connectionId) continue;
           try {
-            const ok = cmSendMessage(id, createRegisterDeviceToken(token, 'ios'));
+            const ok = cmSendMessage(id, createRegisterDeviceToken(token, 'ios', pushPrefsRef.current));
             if (!ok) {
               console.warn(`[App] Could not re-register device token with ${id}`);
             }

--- a/packages/web/src/components/settings/SettingsPanel.tsx
+++ b/packages/web/src/components/settings/SettingsPanel.tsx
@@ -381,6 +381,32 @@ export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPan
     onChange({ ...settings, ...partial });
   };
 
+  /**
+   * Flip one notification toggle (#968), checking OS permission when turning a
+   * push class ON for the first time — a preference the daemon honors is still
+   * silent if iOS itself is set to deny.
+   *
+   * Turning one OFF never checks: muting must always work, including from a
+   * device whose OS permission was already revoked.
+   */
+  const enableNotify = async (
+    key: 'notifyQuestions' | 'notifyTurnComplete',
+    value: boolean,
+  ): Promise<void> => {
+    if (!value || !isNative()) {
+      update({ [key]: value });
+      return;
+    }
+    const permission = await checkNotificationPermission();
+    if (permission === 'denied') {
+      // Leave the toggle as it was: claiming it is on while the OS drops every
+      // push is the same lie the old dead toggle told.
+      openNotificationSettings();
+      return;
+    }
+    update({ [key]: true });
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
       {/* Backdrop */}
@@ -464,24 +490,14 @@ export function SettingsPanel({ open, settings, onClose, onChange }: SettingsPan
                 onChange={(v) => update({ showTimestamps: v })}
               />
               <Toggle
-                label="Notifications"
-                checked={settings.notifications}
-                onChange={async (v) => {
-                  if (!v) {
-                    update({ notifications: false });
-                    return;
-                  }
-                  if (!isNative()) {
-                    update({ notifications: true });
-                    return;
-                  }
-                  const permission = await checkNotificationPermission();
-                  if (permission === 'denied') {
-                    openNotificationSettings();
-                  } else {
-                    update({ notifications: true });
-                  }
-                }}
+                label="Question alerts"
+                checked={settings.notifyQuestions}
+                onChange={(v) => void enableNotify('notifyQuestions', v)}
+              />
+              <Toggle
+                label="Turn complete"
+                checked={settings.notifyTurnComplete}
+                onChange={(v) => void enableNotify('notifyTurnComplete', v)}
               />
               <Toggle
                 label="Sound"

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -248,7 +248,18 @@ export interface UIQuestion {
 export interface AppSettings {
   readonly theme: 'light' | 'dark' | 'system';
   readonly fontSize: 'small' | 'medium' | 'large';
-  readonly notifications: boolean;
+  /**
+   * Push when Claude needs an answer (#968).
+   *
+   * Replaces the single `notifications` flag, which was written by the settings
+   * panel and read by nothing — and could not have worked where it mattered
+   * anyway: APNS pushes travel daemon -> signaling Worker -> APNS and never
+   * consult the client. These two flags are sent up on `register_device_token`
+   * and enforced by the daemon at its per-token fan-out.
+   */
+  readonly notifyQuestions: boolean;
+  /** Push the last assistant message when a long turn ends (#914). */
+  readonly notifyTurnComplete: boolean;
   readonly sound: boolean;
   readonly autoReconnect: boolean;
   readonly showTimestamps: boolean;
@@ -270,7 +281,8 @@ export interface ConnectionConfig {
 export const DEFAULT_SETTINGS: AppSettings = {
   theme: 'system',
   fontSize: 'medium',
-  notifications: true,
+  notifyQuestions: true,
+  notifyTurnComplete: true,
   sound: true,
   autoReconnect: true,
   showTimestamps: true,


### PR DESCRIPTION
Closes #968.

Separates the two push classes so each can be muted independently, and makes
the in-app switch actually control something.

## What was wrong

**The "Notifications" toggle was dead code.** `settings.notifications` was
written by `SettingsPanel.tsx:468` and read by nothing. (`settings.sound` IS
wired, via `setSoundEnabled` at `App.tsx:340` -- so this was specific to the
notifications toggle.) Even wired it could not have worked: the push path is
daemon -> signaling Worker -> APNS and never consults the client.

**There was no `kind` on the push wire.** The four classes were told apart by a
NEGATIVE test ("no `questionId`, no `category`"), which cannot distinguish a
turn-complete push from a subagent alert at all -- on the wire both are exactly
`{token, title, body}`. The `": turn complete"` title suffix is display text,
not a protocol field.

## What this does

| Layer | Change |
|---|---|
| `shared` | `PushPreferences` + optional `pushPrefs` on `register_device_token` |
| `daemon` | `notifications/push-preferences.ts` owns the defaults, sanitization, and the per-kind predicate |
| `daemon` | `kind` on every `sendPushTrigger` call; per-token filtering at all four send sites |
| `daemon` | preferences persisted per token in `device-tokens.json` |
| `signaling` | `kind` forwarded verbatim into APNS custom data, capped at 32 chars |
| `web` | two live toggles ("Question alerts", "Turn complete"), re-registering on change |

Registration is idempotent and keyed by token, so flipping a toggle is just a
re-register -- no separate update message, and no way for the two to drift.
Preferences are per DEVICE, not per machine: two phones can want different things.

## The parts that are load-bearing

**A muted fan-out reports `no_channel`, not `pushed`.** `awaitDelivery` decides
whether a HELD hook keeps Claude blocked; claiming delivery for a fan-out of
zero would block the hook on a card that will never appear on any lock screen.
The filter therefore sits ABOVE the no-channel check, not at the fan-out. Has
its own test; mutation-verified (restoring the unfiltered fan-out turns 3 tests
red).

**`dismiss` is never filtered.** It is the quiet `content-available` push that
CLEARS a resolved card. A device that muted questions can still be holding a
card delivered before the mute, and dropping its dismissal would strand that
card on the lock screen of the very device that asked for less noise. Asserted,
not just commented.

**Malformed preferences fail toward DELIVERING.** A wrongly-delivered
notification is a nuisance; a wrongly-dropped one is the product failing at its
only job. Note the test for this needed a FALSY non-boolean to be meaningful:
`Boolean('false')` is `true`, so a truthy junk value resolves identically under
a type check and a coercion and proves nothing. The first version of that test
passed against a deliberately-coercing implementation; it now uses `0` / `''` /
`null` and kills that mutant on both fields.

## Not covered, deliberately

- **`subagent_alert`** stays unconditional. It already has a user-facing
  control -- it fires only on the patterns in `auto_approve.subagent_alert`.
- **`notifications.on_turn_complete`** in config.toml remains the machine-wide
  master switch and still wins over any per-device preference.
- The stale `notifications: false` key left in an existing localStorage settings
  blob is not migrated. It never had an effect, so there is no preference in it
  worth carrying forward.

## Deploy note

`packages/signaling/` changed, so the Worker needs a redeploy for `kind` to
reach devices. The redeploy is NOT required for the user-facing feature --
muting is enforced daemon-side and works immediately; without it, `kind` simply
does not appear in the APNS payload.

## Testing

- `bun test` across daemon + shared + signaling: 4510 pass, 0 fail (before the
  new signaling/escalator tests; each new file run green individually since).
- New: `push-preferences.test.ts` (13), `push-kind.test.ts` (7), plus additions
  to the dispatcher, device-token-store, push-client, escalator, and
  trivial-events suites.
- Mutation-verified: removing the question filter (3 red), removing the
  dismiss/subagent exemption (3 red), coercing preferences instead of
  type-checking them (1 red per field).
- `bunx biome check` clean, `bun run typecheck` clean, `packages/web` builds.