### PR TITLE
fix: broadcast a terminal status when an eval is cancelled (#970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **The auto-approve pill no longer sticks on "evaluating"** (#970). A cancelled
+  eval was the one gate end path that told clients nothing: `onEvalStart` moves
+  the pill to `evaluating`, `onHandled` moves it to `approved`, `onEscalate`
+  relies on the question path's `waiting` — and `onCancelled` broadcast nothing
+  at all. It self-healed only when a later `Stop`/`SessionEnd` `idle` or a
+  `PreToolUse` happened to follow, and none arrives when the eval is cancelled
+  at end-of-turn or during a disconnect, which is exactly when it was seen stuck
+  in the field.
+
+  The terminal statusline never had this bug: its `inFlight` count is decremented
+  by every end path, which is why `status-writer.ts` can claim the cue "can never
+  get stuck". The client cue had no equivalent property, and now does — asserted
+  by a test enumerated over the verdicts, so a future end path that forgets the
+  terminal half fails there instead of silently joining the hole.
+
+  The correction broadcasts the session's CURRENT status from the registry rather
+  than a chosen constant. Nothing was approved, denied, or escalated, so any fixed
+  value would be a guess, and a wrong status is the same class of bug as a stuck one.
+
+  Also pins the routing fact the fix rests on: a subagent eval never shows the pill
+  and cannot reach this cue, because `arbitrateParkedRender` sends a `cancelled`
+  verdict to `escalateRenderedParked()` rather than to `onCancelled`. An earlier
+  draft added an `isSubagent` guard here; it was dead code (always `false`), and
+  the test written for it passed with the guard deleted. Both were dropped in
+  favor of asserting the real routing.
+
 ### Changed
 - **The auto-approve prompt's default guidelines now follow `level`** (#966).
   `level` selects which groups are approved deterministically, but whatever no

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -400,7 +400,17 @@ export interface AutoApproveGateDeps {
    *  -- the terminal cue above still fires either way. */
   onHandled?: (ctx: { isSubagent: boolean }) => void;
   /** Called when the eval ended without a verdict (cancelled — the user already
-   *  advanced past the prompt). Drives the terminal cue back to idle. #513. */
+   *  advanced past the prompt). Drives the terminal cue back to idle. #513.
+   *
+   *  Deliberately carries NO `ctx.isSubagent`, unlike `onEvalStart` /
+   *  `onEscalate` / `onHandled`: this cue is reachable only from MAIN-context
+   *  evals. `resolvePermission` returns early for an `agent_id` event before any
+   *  eval (#807), and the post-render subagent path
+   *  (`arbitrateParkedRender`) routes a `cancelled` verdict to
+   *  `escalateRenderedParked()` — i.e. to `onEscalate`, not here. A ctx
+   *  parameter would therefore be `false` at every call site, and a
+   *  subagent guard built on it would be untestable dead code (#970, asserted
+   *  by "a cancelled parked render escalates" in the gate tests). */
   onCancelled?: () => void;
   /**
    * Called when a HELD question resolved WITHOUT the user answering it through

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -601,6 +601,43 @@ export function setupHookBridge(
     }
   };
 
+  /**
+   * Return clients to the session's REAL status after an eval ended without a
+   * verdict (#970).
+   *
+   * Because `broadcastAutoApproveStatus` is client-only by design (see the note
+   * above), the daemon holds no record that clients are showing `evaluating` —
+   * the pill is fire-and-forget display state, and only another broadcast or a
+   * later hook can move it off. That made the client cue NOT total over the
+   * gate's end paths, unlike the terminal one, whose own invariant
+   * (`status-writer.ts`: "the count returns to 0 and the 'evaluating' cue can
+   * never get stuck") holds precisely because every end path decrements it:
+   *
+   *   onHandled   -> 'approved' broadcast          (covered)
+   *   onEscalate  -> the question path's 'waiting' (covered, indirectly)
+   *   onCancelled -> NOTHING                       (the hole this closes)
+   *
+   * A cancelled verdict self-healed only when a later `Stop`/`SessionEnd`
+   * `idle` or a `PreToolUse` `executing` happened to follow. None is guaranteed
+   * — and by construction none arrives when the eval was cancelled at the end
+   * of a turn or during a disconnect, which is exactly when it was observed
+   * stuck.
+   *
+   * Broadcasts the registry's CURRENT status rather than a chosen constant. The
+   * gate does not know what the session became (nothing was approved, denied,
+   * or escalated), so any fixed value would be a guess, and a wrong status is
+   * the same class of bug as a stuck one. Reading the status the daemon already
+   * tracks is honest by construction: "stop showing evaluating; here is what
+   * this session actually is."
+   */
+  const broadcastCurrentStatus = (): void => {
+    const current = sessionRegistry.getSession(sessionId)?.currentStatus;
+    // No session (torn down mid-eval): nothing to correct, and inventing a
+    // status for a session that no longer exists would be worse than silence.
+    if (current === undefined) return;
+    broadcastAutoApproveStatus(current);
+  };
+
   // Auto-approve control plane (#453 phase 1): owns the PermissionRequest eval +
   // inject + escalate + cancelStale. Constructed after the bridge + handlers so it
   // can wrap the two outward couplings (isInSubagentContext, onPermissionRequest) as
@@ -693,7 +730,20 @@ export function setupHookBridge(
         // #711: same subagent skip as onEvalStart above -- see that comment.
         if (!ctx.isSubagent) broadcastAutoApproveStatus('approved');
       },
-      onCancelled: () => deps.statusWriter?.autoApproveEnd('cancelled', Date.now()),
+      onCancelled: () => {
+        deps.statusWriter?.autoApproveEnd('cancelled', Date.now());
+        // #970: the client pill was moved to 'evaluating' by onEvalStart and
+        // this was the only end path that never moved it back. See
+        // `broadcastCurrentStatus` for why it re-broadcasts the real status
+        // instead of picking one.
+        //
+        // Unconditional, with no `isSubagent` skip like onEvalStart/onHandled
+        // have: this cue is reachable only from a MAIN-context eval, which is
+        // exactly the case that DID broadcast 'evaluating'. See the cue's own
+        // doc on `AutoApproveGateDeps` for why the subagent path cannot reach
+        // it (a cancelled parked render escalates instead).
+        broadcastCurrentStatus();
+      },
       // #585: a held question that resolves without a user answer (Part-B late
       // verdict / hold timeout / cancelStale) tells the daemon to dismiss the
       // pushed card on every client. Forwarded with this session's id.

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -3676,6 +3676,56 @@ describe('AutoApproveGate parked-render arbitration (#814)', () => {
     g.cancelStaleForAgent('agent-1', 'SubagentStop');
     expect(resolvedLog).toHaveLength(0);
   });
+
+  test('#970 a cancelled verdict on a parked render ESCALATES; onCancelled is never reached', async () => {
+    // Pins the routing fact that lets `onCancelled` stay ctx-free. The setup
+    // layer's client status correction (#970) fires unconditionally on that
+    // cue, which is only safe because the cue cannot be reached by a subagent
+    // eval — a subagent eval never broadcasts 'evaluating', so correcting one
+    // would emit the phantom pill #711/#807 removed.
+    //
+    // The subagent path reaches a cancelled verdict ONLY here: a plain
+    // `agent_id` PermissionRequest is parked and never evaluated (#807), so the
+    // hook-bridge harness cannot drive this at all. And arbitration routes
+    // `cancelled` to `escalateRenderedParked()` rather than the cancelled cue.
+    // If that ever changes, this test fails and the ctx-free assumption above
+    // must be revisited in the same change.
+    const cancelledCues: number[] = [];
+    const escalateCues: Array<{ isSubagent: boolean }> = [];
+    const g = new AutoApproveGate(
+      {
+        service: { evaluate: async () => cancelled, cancel: () => true },
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: () => generateId(),
+        parkForPTY: () => {
+          const id = generateId() as UUID;
+          parkedIds.push(id);
+          return id;
+        },
+        onCancelled: () => cancelledCues.push(1),
+        onEscalate: (ctx) => escalateCues.push(ctx),
+      },
+      SID,
+    );
+
+    // Park it (never evaluated at hook time), then render it so the gate
+    // arbitrates — which is where a subagent permission is actually evaluated.
+    expect(await g.resolvePermission(pr())).toBe('passthrough');
+    const escalatesAtPark = escalateCues.length;
+
+    const r = rendered(generateId() as UUID);
+    promptOnScreen(r);
+    await g.arbitrateParkedRender(parkedIds[0] as UUID, r, screen(r));
+
+    // The claim: the cancelled verdict produced an ESCALATE, not a cancelled
+    // cue. Measured as growth past the park-time escalate rather than a total,
+    // so the park path's own cue does not have to be counted here.
+    expect(cancelledCues).toHaveLength(0);
+    expect(escalateCues.length).toBeGreaterThan(escalatesAtPark);
+    expect(escalateCues.every((c) => c.isSubagent)).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -3355,6 +3355,158 @@ describe('setupHookBridge', () => {
       expect(statuses).not.toContain('approved');
     });
 
+    test('#970 a CANCELLED eval broadcasts a terminal status, never leaving the pill on "evaluating"', async () => {
+      // The regression. `onEvalStart` moves the client pill to 'evaluating';
+      // before #970 the cancelled path was the ONE end path that broadcast
+      // nothing, so the pill sat there until some later hook happened to move
+      // it -- and none arrives when the eval is cancelled at end-of-turn or
+      // during a disconnect, which is when it was observed stuck in the field.
+      const sendLog: ProtocolMessage[] = [];
+      build({
+        autoApprove: true,
+        autoApproveDecision: 'cancelled',
+        autoApproveDelayMs: 10,
+        sendLog,
+      });
+
+      hookServer.fire('Notification', {
+        session_id: 'claude-aa-cancelled',
+        hook_event_name: 'Notification',
+        transcript_path: path.join(tmpDir, 'aa-cancelled.jsonl'),
+        notification_type: 'auth_success',
+        message: '',
+      });
+
+      const decision = await hookServer.firePermission({
+        session_id: 'claude-aa-cancelled',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+      });
+      expect(decision).toBe('passthrough');
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      // The eval ran, so the pill WAS moved to 'evaluating'...
+      expect(statuses).toContain('evaluating');
+      // ...and the LAST thing clients were told must not be 'evaluating'.
+      // Asserting on the tail rather than "contains something else" is what
+      // makes this a real stuck-state test: an extra 'evaluating' emitted
+      // after the correction would still leave the pill wrong.
+      expect(statuses.at(-1)).not.toBe('evaluating');
+      // Nothing was approved -- claiming otherwise is the opposite lie.
+      expect(statuses).not.toContain('approved');
+    });
+
+    test('#807/#970 a SUBAGENT permission is parked, so no pill is shown and none needs correcting', async () => {
+      // Not a test of the #970 correction — a subagent permission is PARKED and
+      // never evaluated here, so `onCancelled` fires zero times regardless of
+      // what the correction does. (Confirmed by mutation: deleting the
+      // correction entirely leaves this green.) It pins the precondition that
+      // lets that correction run unconditionally: this path shows no pill at
+      // all. The cue's actual unreachability from a subagent eval is asserted
+      // where it is real — "a cancelled parked render ESCALATES" in
+      // auto-approve-gate.test.ts.
+      const sendLog: ProtocolMessage[] = [];
+      build({
+        autoApprove: true,
+        autoApproveDecision: 'cancelled',
+        autoApproveDelayMs: 10,
+        sendLog,
+      });
+
+      hookServer.fire('Notification', {
+        session_id: 'claude-aa-cancel-sub',
+        hook_event_name: 'Notification',
+        transcript_path: path.join(tmpDir, 'aa-cancel-sub.jsonl'),
+        notification_type: 'auth_success',
+        message: '',
+      });
+
+      await hookServer.firePermission({
+        session_id: 'claude-aa-cancel-sub',
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls' },
+        agent_id: 'teammate-1',
+        agent_type: 'general-purpose',
+      });
+
+      const statuses = sessionUpdateStatuses(sendLog);
+      expect(statuses).not.toContain('evaluating');
+      expect(statuses).not.toContain('approved');
+    });
+
+    // TOTALITY, enumerated over the verdicts rather than asserted case by case:
+    // a new gate end path that broadcasts 'evaluating' and forgets the terminal
+    // half fails HERE instead of silently joining the hole. The terminal cue has
+    // this property by construction (status-writer.ts's inFlight count); this is
+    // the client-side equivalent, and its absence is exactly what #970 was.
+    //
+    // Each verdict declares WHICH channel carries its terminal signal, because
+    // there are two and they are not interchangeable:
+    //   - `broadcast`: the auto-approve client-only `session_update`
+    //     (`broadcastAutoApproveStatus` -> sendAndRecord).
+    //   - `statusPath`: the ordinary status path (`messageApi.handleStatusChange`),
+    //     which the REAL MessageAPI broadcasts to clients. `onEscalate`
+    //     deliberately emits nothing of its own and relies on this, to avoid
+    //     double-emitting alongside the question's own 'waiting'.
+    // Asserting only on `sendLog` would call escalate a stuck pill when it is
+    // not one -- the fake MessageAPI here simply does not forward.
+    //
+    // One `test()` per verdict, not one loop: `build()` registers a session and
+    // the registry allows only one per daemon, so a loop inside a single test
+    // throws on the second iteration.
+    const TERMINAL_CHANNEL = {
+      approve: 'broadcast',
+      deny: 'broadcast',
+      escalate: 'statusPath',
+      cancelled: 'broadcast',
+    } as const satisfies Record<string, 'broadcast' | 'statusPath'>;
+
+    for (const [verdict, channel] of Object.entries(TERMINAL_CHANNEL) as Array<
+      [keyof typeof TERMINAL_CHANNEL, 'broadcast' | 'statusPath']
+    >) {
+      test(`#970 a ${verdict} verdict leaves the pill off "evaluating" (via ${channel})`, async () => {
+        const sendLog: ProtocolMessage[] = [];
+        build({
+          autoApprove: true,
+          autoApproveDecision: verdict,
+          autoApproveDelayMs: 10,
+          sendLog,
+        });
+
+        const claudeId = `claude-aa-total-${verdict}`;
+        hookServer.fire('Notification', {
+          session_id: claudeId,
+          hook_event_name: 'Notification',
+          transcript_path: path.join(tmpDir, `aa-total-${verdict}.jsonl`),
+          notification_type: 'auth_success',
+          message: '',
+        });
+
+        await hookServer.firePermission({
+          session_id: claudeId,
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+        });
+
+        // The eval ran, so the pill WAS moved to 'evaluating' in every case.
+        expect(sessionUpdateStatuses(sendLog)).toContain('evaluating');
+
+        if (channel === 'broadcast') {
+          // Whatever clients were told LAST on this channel must not be
+          // 'evaluating'. Asserting on the TAIL, not "contains something else":
+          // an 'evaluating' emitted after the correction still leaves it stuck.
+          expect(sessionUpdateStatuses(sendLog).at(-1)).not.toBe('evaluating');
+        } else {
+          // The ordinary status path carried a real, non-evaluating status out.
+          const terminal = messageApiLog.statusCalls.filter((s) => s !== 'evaluating');
+          expect(terminal.length).toBeGreaterThan(0);
+        }
+      });
+    }
+
     test('a status-broadcast send error never propagates into the gate decision', async () => {
       // The broadcast helper wraps its own send in try/catch so a throwing
       // sendAndRecord cannot break the allow/deny decision or the buffer path.


### PR DESCRIPTION
Closes #970.

## The bug

`broadcastAutoApproveStatus` sends a **client-only** `session_update` — its own
comment says it deliberately does not touch the StatusWriter or the hook-driven
`onStatusChange` path. So the daemon holds no record that clients are showing
`evaluating`; the pill is fire-and-forget display state, and only another
broadcast or a later hook can move it off.

That made the client cue NOT total over the gate's end paths:

| Gate end path | StatusWriter (terminal) | Client broadcast |
|---|---|---|
| `onEvalStart` | `autoApproveStart` (+1) | `'evaluating'` |
| `onHandled` | `autoApproveEnd('approved')` | `'approved'` |
| `onEscalate` | `autoApproveEnd('escalated')` | none — the question path emits `'waiting'` |
| `onCancelled` | `autoApproveEnd('cancelled')` | **nothing** |

The terminal cue is total by construction, and `status-writer.ts` says so:
"every gate end-path calls this exactly once, the count returns to 0 and the
'evaluating' cue can never get stuck." The client cue had no such property and
no equivalent of `status-bar.ts`'s 600s leak cap.

A cancelled verdict therefore self-healed only when a later `Stop`/`SessionEnd`
`idle` or a `PreToolUse` `executing` happened to follow. None is guaranteed —
and by construction none arrives when the eval is cancelled at end-of-turn or
during a disconnect, which is exactly the field report.

Live evidence (`~/.remi/remi.log`): `Held hook 943aa431 timed out -> passthrough`
preceded by ~40 lines of relay churn (`Connection code has expired`, code
rotating every ~30s).

## The fix

`onCancelled` now broadcasts the session's **current** status from the registry.

Not a chosen constant: nothing was approved, denied, or escalated, so any fixed
value would be a guess, and a wrong status is the same class of bug as a stuck
one. Reading the status the daemon already tracks is honest by construction —
"stop showing evaluating; here is what this session actually is." A torn-down
session broadcasts nothing rather than inventing a status for a session that no
longer exists.

## A wrong turn worth recording

The first version threaded `ctx: {isSubagent}` through `onCancelled`, mirroring
`onEvalStart` / `onHandled` / `onEscalate`, and guarded the correction with it.
Mutation testing killed it: **deleting the guard left every test green.**

The reason is a routing fact I had assumed rather than checked —
`arbitrateParkedRender` sends a `cancelled` verdict to `escalateRenderedParked()`,
i.e. to `onEscalate`, not to `onCancelled`. Combined with #807's early return
for `agent_id` events, `onCancelled` is reachable ONLY from main-context evals,
so the ctx parameter was `false` at every call site and the guard was dead code.
The test I wrote for it passed because a subagent permission is parked and never
evaluated at all — coverage of nothing.

Both were removed. The correction is unconditional (its only caller is the case
that DID show the pill), and the routing fact is now asserted rather than
assumed, in the one place it is real: "a cancelled parked render ESCALATES;
onCancelled is never reached" (`auto-approve-gate.test.ts`). If that routing ever
changes, that test fails and the unconditional call has to be revisited in the
same change.

The subagent test in `hook-bridge-setup.test.ts` was renamed and re-commented to
say what it actually pins (the precondition: this path shows no pill at all),
with the mutation result recorded in it, rather than continuing to claim
coverage it does not have.

## Testing

- Full suite: **4491 pass, 0 fail** across daemon + shared + signaling.
- New: a `cancelled`-verdict regression asserting the TAIL of the broadcast
  sequence is not `evaluating` (not merely "contains something else" — an
  `evaluating` emitted after the correction would still leave it stuck).
- New: totality enumerated over `approve` / `deny` / `escalate` / `cancelled`,
  each declaring which of the two channels carries its terminal signal.
  `escalate`'s goes out via `messageApi.handleStatusChange`, not
  `sendAndRecord`, so asserting only on the send log would have called it a
  stuck pill when it is not one.
- Mutation-verified: removing the correction turns 2 tests red; restoring is green.
- `bunx biome check` clean, `bun run typecheck` clean.