### PR TITLE
fix: match engine models by HuggingFace id too (#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **A model configured by its HuggingFace id is no longer reported missing**
+  (#971). The engine keys inventory rows by nickname (`yooz-instruct-4b`) and
+  carries the repo id alongside in `huggingFaceID`; `config.toml`'s `model`
+  holds the repo id, which is the shipped default. `pullModel` compared `id` to
+  `id` only, so its "already on disk" short-circuit missed a model that was
+  cached AND loaded, dispatched a redundant download, then polled `/v1/state` —
+  which missed for the same reason — for the full 30 minutes before logging
+  "Could not fetch ... auto-approve will escalate until it is present".
+
+  That warning was false: evaluations worked the whole time, because the engine
+  DOES resolve a repo id on `/v1/llm/generate`, just not on the inventory
+  routes. It fired 15 times in one user's log, once per daemon start.
+
+  Matching now goes through `model-identity.ts`'s `findModel` (#843), which
+  already existed for exactly this and which these two call sites had never
+  adopted. `/v1/state` rows carry only `id`, so the configured name is
+  translated to the canonical engine id through the inventory before probing —
+  and re-translated mid-download, since the row appears only once the fetch is
+  under way. An engine predating `huggingFaceID` (pre-0.7.8) still pulls by the
+  configured name exactly as before.
+
+  Verified against the live engine: `pullModel` for the repo id now returns in
+  **45ms** where it previously threw after 1800s.
 - **The auto-approve pill no longer sticks on "evaluating"** (#970). A cancelled
   eval was the one gate end path that told clients nothing: `onEvalStart` moves
   the pill to `evaluating`, `onHandled` moves it to `approved`, `onEscalate`

--- a/packages/daemon/src/auto-approve/engine-models.ts
+++ b/packages/daemon/src/auto-approve/engine-models.ts
@@ -62,6 +62,8 @@
 
 import { errorToString } from '@remi/shared';
 
+import { findModel } from './model-identity.ts';
+
 /** One model in the engine's catalogue (`LLMModelInfo`). `sizeBytes` and
  *  `latencyHintMs` are optional on the wire so future backends can omit them;
  *  treat them as hints, never as invariants. */
@@ -560,8 +562,16 @@ export async function pullModel(
   const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
 
   // Already on disk: nothing to fetch. Cheap, and it makes `pull` idempotent.
+  //
+  // #971: matched under EITHER name. `model` comes from config, whose shipped
+  // default is the repo id (`YoozLabs/...`), while the inventory row's `id` is
+  // the engine nickname (`yooz-instruct-4b`) and carries the repo id in
+  // `huggingFaceID`. Comparing `id` to `id` alone reported a cached, loaded,
+  // working model as missing — so this short-circuit never fired, a redundant
+  // download was dispatched, and the poll below ran to its full 30-minute
+  // timeout on every daemon start.
   const before = await listManagedModels(baseUrl).catch(() => [] as readonly ManagedModel[]);
-  if (before.some((m) => m.id === model && m.cached)) return;
+  if (findModel(before, model)?.cached) return;
 
   // Deliberately NOT wrapped: an unknown model id is a 400 from the engine and
   // must fail immediately with that message, not enter the poll loop.
@@ -572,8 +582,16 @@ export async function pullModel(
   let firstFraction: number | undefined;
   let sawInFlight = false;
   let consecutiveUnreachable = 0;
+  // The id to probe `/v1/state` with (#971). Unlike the inventory, state rows
+  // carry ONLY `id` — no `huggingFaceID` — so a repo-shaped configured name has
+  // to be translated through the inventory or every probe misses and the loop
+  // observes nothing until it times out. Falls back to `model` itself when the
+  // inventory does not (yet) name it: correct for an engine that predates the
+  // alias field, and self-correcting once the row appears (refreshed at the
+  // bottom of the loop).
+  let probeId = findModel(before, model)?.id ?? model;
   for (;;) {
-    const row = await getModelState(baseUrl, model).catch(() => undefined);
+    const row = await getModelState(baseUrl, probeId).catch(() => undefined);
     if (row === undefined) {
       // Distinguish "engine went away" from "slow download" — otherwise a
       // crash mid-pull is indistinguishable from progress for 30 minutes.
@@ -614,7 +632,13 @@ export async function pullModel(
     const inventory = await listManagedModels(baseUrl).catch(
       () => undefined as readonly ManagedModel[] | undefined,
     );
-    if (inventory?.some((m) => m.id === model && m.cached)) return;
+    // #971: same either-name match as the short-circuit above.
+    const inventoryRow = inventory === undefined ? undefined : findModel(inventory, model);
+    if (inventoryRow?.cached) return;
+    // The row can appear mid-download (the engine registers it once the fetch
+    // is under way), which is the point at which a repo-shaped configured name
+    // becomes translatable — so adopt the canonical id for the next probe.
+    if (inventoryRow !== undefined) probeId = inventoryRow.id;
 
     if (now() >= deadline) {
       throw new Error(

--- a/packages/daemon/tests/auto-approve/engine-models.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-models.test.ts
@@ -306,6 +306,159 @@ describe('pullModel', () => {
       }),
     ).rejects.toThrow(/remi model cancel/);
   });
+
+  // #971. The shipped default `model` is a HuggingFace repo id, but the engine
+  // keys its rows by nickname and carries the repo id alongside. Every fixture
+  // above omits `huggingFaceID`, which is why the old `m.id === model` matching
+  // looked correct here while failing on every real install.
+  //
+  // Shape taken from a live `GET /v1/models` (engine 0.7.8 on :19924).
+  const aliased = (over: Record<string, unknown> = {}) => ({
+    id: 'yooz-instruct-4b',
+    module: 'llm',
+    displayName: 'yooz-instruct-4b',
+    sizeBytes: 2_387_349_504,
+    cached: true,
+    loaded: true,
+    isActive: false,
+    deletable: true,
+    huggingFaceID: 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx',
+    ...over,
+  });
+
+  test('#971 a cached model configured by its HuggingFace id downloads nothing', async () => {
+    // The regression. Before the fix this dispatched a download for a model
+    // already on disk, then polled to the full timeout and reported it missing.
+    const server = engineServer((path) => {
+      if (path === '/v1/models') return Response.json({ models: [aliased()] });
+      return Response.json({});
+    });
+    stop = server.stop;
+
+    await pullModel(server.url, 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx', { sleep: noSleep });
+
+    expect(server.seen.some((s) => s.path.endsWith('/download'))).toBe(false);
+  });
+
+  test('#971 the same model configured by its engine nickname still downloads nothing', async () => {
+    // Either name resolves; the fix must not trade one for the other.
+    const server = engineServer((path) => {
+      if (path === '/v1/models') return Response.json({ models: [aliased()] });
+      return Response.json({});
+    });
+    stop = server.stop;
+
+    await pullModel(server.url, 'yooz-instruct-4b', { sleep: noSleep });
+
+    expect(server.seen.some((s) => s.path.endsWith('/download'))).toBe(false);
+  });
+
+  test('#971 a genuinely absent model still downloads (no false short-circuit)', async () => {
+    // The fix widens matching, so the opposite failure — treating an absent
+    // model as present and never fetching it — has to be excluded explicitly.
+    let polls = 0;
+    const server = engineServer((path) => {
+      if (path.endsWith('/download')) return new Response(null, { status: 202 });
+      if (path === '/v1/state') {
+        return Response.json({
+          modules: [
+            {
+              module: 'llm',
+              models: [{ id: 'yooz-instruct-4b', loadState: 'available', downloadProgress: 0.006 }],
+            },
+          ],
+        });
+      }
+      return Response.json({ models: [aliased({ cached: polls++ >= 1 })] });
+    });
+    stop = server.stop;
+
+    await pullModel(server.url, 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx', { sleep: noSleep });
+
+    expect(server.seen.some((s) => s.path.endsWith('/download'))).toBe(true);
+  });
+
+  test('#971 polls /v1/state by the ENGINE id when configured by repo id', async () => {
+    // `/v1/state` rows carry only `id` — no `huggingFaceID` (verified against
+    // the live endpoint) — so probing with the repo id matches nothing and the
+    // loop observes no progress at all until it times out. The configured name
+    // has to be translated through the inventory first.
+    let sawInFlight = false;
+    let polls = 0;
+    const server = engineServer((path) => {
+      if (path.endsWith('/download')) return new Response(null, { status: 202 });
+      if (path === '/v1/state') {
+        // Keyed by the engine id ONLY, exactly like the real endpoint.
+        return Response.json({
+          modules: [
+            {
+              module: 'llm',
+              models: [{ id: 'yooz-instruct-4b', loadState: 'available', downloadProgress: 0.006 }],
+            },
+          ],
+        });
+      }
+      return Response.json({ models: [aliased({ cached: polls++ >= 1 })] });
+    });
+    stop = server.stop;
+
+    await pullModel(server.url, 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx', {
+      sleep: noSleep,
+      // A progress callback fires only when a state row was actually FOUND, so
+      // this observes the translation rather than just the happy exit.
+      onProgress: (p) => {
+        if (p.fraction !== undefined) sawInFlight = true;
+      },
+    });
+
+    expect(sawInFlight).toBe(true);
+  });
+
+  test('#971 an engine with no huggingFaceID at all still pulls by the configured name', async () => {
+    // `huggingFaceID` arrived in engine 0.7.8 and remi attaches to whatever
+    // engine holds the port, so a row set without the field is a live case.
+    // There the configured repo id is untranslatable and must be used as-is —
+    // the pre-#971 behavior, preserved.
+    let polls = 0;
+    const server = engineServer((path) => {
+      if (path.endsWith('/download')) return new Response(null, { status: 202 });
+      if (path === '/v1/state') {
+        return Response.json({
+          modules: [
+            {
+              module: 'llm',
+              models: [
+                {
+                  id: 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx',
+                  loadState: 'available',
+                  downloadProgress: 0.006,
+                },
+              ],
+            },
+          ],
+        });
+      }
+      return Response.json({
+        models: [
+          {
+            id: 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx',
+            module: 'llm',
+            displayName: 'legacy',
+            sizeBytes: 1,
+            cached: polls++ >= 1,
+            loaded: false,
+            isActive: false,
+            deletable: true,
+          },
+        ],
+      });
+    });
+    stop = server.stop;
+
+    await pullModel(server.url, 'YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx', { sleep: noSleep });
+
+    expect(server.seen.some((s) => s.path.endsWith('/download'))).toBe(true);
+  });
 });
 
 describe('disk inventory', () => {


### PR DESCRIPTION
Closes #971.

## The bug

The engine keys inventory rows by its own nickname and carries the repo id
alongside. From the live engine on :19924:

```json
{"id":"yooz-instruct-4b",
 "huggingFaceID":"YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx",
 "cached":true,"loaded":true}
```

`config.toml`'s `model` holds the **repo id** — that is the shipped default and
what the config's own comment uses. Both lookups compared `id` to `id` only:

- `engine-models.ts:564` — the "already on disk, nothing to fetch" short-circuit
- `engine-models.ts:476` — `getModelState`, the poll-loop probe

So the short-circuit missed a model that was cached AND loaded, a redundant
download went out, the poll loop probed `/v1/state` and missed for the same
reason, and it ran the full 30 minutes before throwing. Result, 15 times in one
user's log:

```
[AutoApprove] Could not fetch YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx
(auto-approve will escalate until it is present): timed out after 1800s ...
```

**The warning was false.** Evaluations worked throughout, because the engine
resolves a repo id on the generate route even though the inventory routes do
not:

```
$ curl -X POST :19924/v1/llm/generate -d '{"model":"YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx",...}'
{"model":"yooz-instruct-4b","text":"ok","processingTimeMs":210}
```

## The fix

Matching goes through **`model-identity.ts`'s `findModel`** — which already
existed for precisely this (#843, "Comparing `id` to `id` alone reports a
present, working model as missing") and which these two call sites had simply
never adopted. No new matching logic.

`/v1/state` is the wrinkle: its rows carry only `id`, no `huggingFaceID`
(verified against the live endpoint). So the configured name is translated to
the canonical engine id via the inventory before probing, and re-translated at
the bottom of the poll loop — the row appears only once the fetch is under way,
which is exactly when a not-yet-present model becomes translatable.

An engine predating `huggingFaceID` (pre-0.7.8) has nothing to translate
through, so it falls back to the configured name and behaves exactly as before.
remi attaches to whatever engine holds the port, so that is a live case, not a
migration window.

## Testing

- Full suite: **4533 pass, 0 fail**.
- Five new `pullModel` tests, all against an alias-aware inventory shaped from
  the real `GET /v1/models` payload: cached-by-repo-id, cached-by-nickname,
  genuinely-absent-still-downloads (the opposite failure the widened match could
  introduce), state-probed-by-engine-id, and no-huggingFaceID-at-all.
- Mutation-verified: restoring the `id`-only short-circuit turns one red;
  probing `/v1/state` with the untranslated name turns one red.
- **Verified against the live engine**: `pullModel` for the repo id returns in
  **45ms**, where it previously threw after 1800s.

Worth noting why the existing tests never caught this: every fixture in
`engine-models.test.ts` omitted `huggingFaceID`, so they agreed with the buggy
code. The new fixture is copied from a real payload instead.