### PR TITLE
fix: cover bare git stash and stash pop (#972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **`git stash` and `git stash pop` are covered by `vcs-write`** (#972). Only
+  the explicit `git stash push` spelling was listed, so the bare form — which is
+  git's own default spelling of exactly that — and its `pop` counterpart went to
+  the LLM and escalated, despite both being purely local.
+
+  Listing bare `git stash` necessarily also prefix-matches `git stash drop` and
+  `git stash clear`, which discard stashed work irrecoverably (`clear` discards
+  every stash at once). Those are refused through the existing
+  `WRITE_GROUP_POSITIONAL_VETOES` table that already guards `git checkout .`,
+  because the matcher cannot express "exactly `git stash`" — `matchPrefix`
+  accepts the exact segment OR anything starting with `prefix + ' '`. The veto
+  matches tokenized words, so `git stash "drop"` is refused too; the raw-text
+  version of that check is the bug #960 found in `git checkout "."`.
 - **A model configured by its HuggingFace id is no longer reported missing**
   (#971). The engine keys inventory rows by nickname (`yooz-instruct-4b`) and
   carries the repo id alongside in `huggingFaceID`; `config.toml`'s `model`

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -40,6 +40,14 @@ import { hasUnsafeWriteFlag } from './write-flag-safety.ts';
  */
 const WRITE_GROUP_POSITIONAL_VETOES: ReadonlyArray<{ family: RegExp; words: readonly string[] }> = [
   { family: /^git\s+(checkout|restore)\b/, words: ['.', '--'] },
+  // #972: `git stash` is listed as a bare prefix so the plain form (which IS
+  // `git stash push`) and `git stash pop` are covered. Word-boundary prefix
+  // matching then also covers `git stash drop` and `git stash clear`, which
+  // DISCARD stashed work irrecoverably — `clear` drops every stash at once.
+  // Those two are refused here rather than by omitting the prefix, because the
+  // matcher cannot express "exactly `git stash`" (`matchPrefix` accepts the
+  // exact segment OR anything starting with `prefix + ' '`).
+  { family: /^git\s+stash\b/, words: ['drop', 'clear'] },
 ];
 
 /**
@@ -240,12 +248,19 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'git checkout',
       'git switch',
       'git merge',
-      'git stash push',
+      // #972: bare, not `git stash push`. `git stash` with no subcommand IS
+      // push (git's own default), and `git stash pop` restores — both purely
+      // local, both what this group exists to cover, and both were escalating
+      // in the field because only the explicit `push` spelling was listed.
+      // The `drop`/`clear` subcommands this necessarily also prefix-matches are
+      // refused by WRITE_GROUP_POSITIONAL_VETOES above.
+      'git stash',
       'git worktree add',
       // Excluded: `git push` (remote mutation), `git rm`, `git reset`,
       // `git clean`, `git branch -D`, `git worktree remove`. The flag vetoes
       // above catch the destructive forms of what IS listed -- `checkout .`,
-      // `checkout --`, any `--force`/`--hard`/`-D`, `commit --no-verify`.
+      // `checkout --`, any `--force`/`--hard`/`-D`, `commit --no-verify`,
+      // `stash drop`, `stash clear`.
     ],
     segmentVeto: writeGroupVeto,
   },

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -341,7 +341,14 @@ describe('vcs-write: covered', () => {
     ['git commit -m "fix: thing"', 'vcs-write:git commit'],
     ['git checkout develop', 'vcs-write:git checkout'],
     ['git switch feature/x', 'vcs-write:git switch'],
-    ['git stash push -m wip', 'vcs-write:git stash push'],
+    ['git stash push -m wip', 'vcs-write:git stash'],
+    // #972: the two forms that were escalating in the field. `git stash` with
+    // no subcommand is git's own default spelling of `git stash push`, and
+    // `pop` is its counterpart -- both purely local.
+    ['git stash', 'vcs-write:git stash'],
+    ['git stash -q -u', 'vcs-write:git stash'],
+    ['git stash pop', 'vcs-write:git stash'],
+    ['git stash pop -q', 'vcs-write:git stash'],
     ['git worktree add ../x -b feature/y', 'vcs-write:git worktree add'],
   ];
   for (const [cmd, expected] of cases) {
@@ -369,6 +376,16 @@ describe('vcs-write: MUST NOT cover', () => {
     'git commit --no-verify -m x',
     'git commit -n -m x',
     'git merge --force x',
+    // #972: the hazard the bare `git stash` prefix necessarily also matches.
+    // Both DISCARD stashed work irrecoverably, and `clear` discards every
+    // stash at once -- so widening the prefix must not widen these.
+    'git stash drop',
+    'git stash drop stash@{0}',
+    'git stash clear',
+    // Quoted, because the veto matches TOKENIZED words: the raw-text version
+    // of this check is exactly the bug #960 found in `git checkout "."`.
+    'git stash "drop"',
+    'git stash cl"ear"',
     // Writing git internals via a covered prefix.
     'git add .git/hooks/pre-commit',
     // Still subject to the global refusals.


### PR DESCRIPTION
Part of #972.

## What this fixes

`vcs-write` listed `git stash push` but not the bare `git stash` — which is
git's own default spelling of exactly that — nor `git stash pop`. Both are
purely local, both are what the group exists to cover, and both were reaching
the LLM and escalating in a live `trusted` session.

## The hazard, and why the veto rather than a narrower prefix

Listing bare `git stash` necessarily also prefix-matches `git stash drop` and
`git stash clear`, which discard stashed work irrecoverably — `clear` discards
every stash at once. The matcher cannot express "exactly `git stash`":
`matchPrefix` accepts the exact segment OR anything starting with `prefix + ' '`.

So the two destructive subcommands are refused through
`WRITE_GROUP_POSITIONAL_VETOES`, the table that already guards `git checkout .`
/ `git checkout --`. That table matches **tokenized** words, so the quoted forms
(`git stash "drop"`, `git stash cl"ear"`) are refused too — the raw-text version
of this check is precisely the bug #960 found, where `git checkout "."` sailed
through while `git checkout .` was correctly refused.

## What this does NOT fix

The rest of #972. The model's reasoning is still factually wrong when it
escalates (`git stash` called a "remote mutation"; the scratch-path rule applied
as its own opposite for `rm /tmp/pp.bak`). That is a prompt/model problem and
wants the real prompt+verdict captures the issue asks for before any wording
changes.

## A correction to my own issue analysis

Two of the three claims in the #972 body were wrong, and I have posted the
measured data as a comment. Briefly:

- **"Compound commands defeat the groups" is false.** `matchCoveredCommand`
  already splits on `&&`/`||`/`;`/`|` and a fully-covered compound passes at
  0ms — verified for `git add -A && git commit`, `cp ... && bun test`,
  `bunx biome check --write`, `bun test packages/daemon packages/shared`.
- **"The allow fast-path did not fire for `gh issue create`" is false.** It
  fires. The misses in the log were `$(...)` command substitution and a pipe
  into an uncovered `tail -2` — both correct refusals, and both artifacts of the
  command shape I was using to file issues.

The only genuine coverage gap was `git stash`, which is what this PR fixes.

## Testing

- `packages/daemon/tests/auto-approve`: **1126 pass, 0 fail**.
- New covered cases: `git stash`, `git stash -q -u`, `git stash pop`,
  `git stash pop -q` (and the existing `git stash push -m wip`, whose expected
  label changes to the new prefix).
- New MUST-NOT-COVER cases: `git stash drop`, `git stash drop stash@{0}`,
  `git stash clear`, plus the quoted `git stash "drop"` / `git stash cl"ear"`.
- Mutation-verified: removing the `drop`/`clear` veto turns **5** tests red.
- `bunx biome check` clean, `bun run typecheck` clean.