### PR TITLE
fix: close held-hook status pill gaps (#970)

### DIFF
--- a/.context/decisions/0020-client-status-cue-totality.md
+++ b/.context/decisions/0020-client-status-cue-totality.md
@@ -32,7 +32,8 @@ enumerating the gate's end paths against what each one broadcasts:
 | `onHandled` (silent approve) | `autoApproveEnd('approved')` | `'approved'` |
 | `onEscalate` | `autoApproveEnd('escalated')` | none (relies on the question path's own `'waiting'`) |
 | `onCancelled` | `autoApproveEnd('cancelled')` | **none** |
-| `releaseHeld` (hold timeout, `part-b-cancelled`) | already ended at escalate | **none**, and `resolveHeld` skips `markHandled` too |
+| `resolveHeld` (Part-B late `allow`/`deny`) | already ended at escalate | `'approved'`, via `markHandled` — **already covered**, see below |
+| `releaseHeld` (hold timeout, `part-b-cancelled`) | already ended at escalate | hold-timeout: none needed (`'waiting'` still correct); `part-b-cancelled`: **none** until this ADR's follow-up fix |
 
 `onCancelled` left the pill on `'evaluating'` with nothing scheduled to clear
 it; it "self-healed" only incidentally, when a later `Stop`/`SessionEnd`
@@ -56,20 +57,41 @@ escalated, so guessing a value would just trade one wrong status for another.
 
 Easier: a client that reconnects or is watching live no longer has the pill
 stuck on `'evaluating'` after a cancelled eval — the most commonly hit case
-(disconnect mid-hold, hold-timeout under a flaky relay).
+(disconnect mid-hold, hold-timeout under a flaky relay) — nor after a HELD
+hold's Part-B `cancelled` late verdict, the same failure mode one layer down
+(see below).
 
-**Harder, and the reason this ADR exists as a warning, not a closed
-success story: the fix is partial, and #970 is still open.** `resolveHeld`
-does not call `markHandled` either (verified by grep — `releaseHeld` is the
-sole owner of the per-hold teardown, and neither the hold-timeout path nor
-`resolveHeld`'s own late-verdict path calls `broadcastCurrentStatus` or any
-equivalent). That means a Part B late verdict — the user's answer arriving
-after the hold already timed out and handed off, or a `part-b-cancelled`
-reconciliation — still emits **no** client status update. The pill sits on
-`'waiting'` after a slow eval silently auto-approves. "The cue is now total"
-describes the *intent* PR #973 pursued, not the current coverage table; a
-future reader should re-run the enumeration above against the live code
-before treating this as closed, and #970 should stay open until it does.
+**Correction to this ADR's own first draft.** The paragraph originally here
+claimed "`resolveHeld` does not call `markHandled` either... neither the
+hold-timeout path nor `resolveHeld`'s own late-verdict path calls
+`broadcastCurrentStatus` or any equivalent," and left #970 open on that
+basis. That claim did not survive a grep: `resolveHeld` has called
+`this.markHandled(hold.isSubagent)` unconditionally since #711 (commit
+`d1b3c5e2`, 2026-07-06 — a month before this ADR was written), which routes
+through `onHandled` -> `broadcastAutoApproveStatus('approved')` exactly like
+a silent primary-eval decision. A Part-B late `allow`/`deny` verdict
+(`reconcileLateVerdict` -> `resolveHeld`) was therefore **already total**
+before this ADR's own follow-up work started. This is exactly the failure
+[ADR 0011](./0011-verify-before-you-describe.md) exists to catch, caught by
+this ADR itself: a security/correctness description believed without
+checking the call site, which reads as "handled" and stops anyone from
+looking again.
+
+**What was actually still open, and is now closed:** `releaseHeld` (a
+*different* method — no `markHandled`, ever) is what a HELD hold's
+`cancelled` late verdict (`reconcileLateVerdict`'s `part-b-cancelled`
+branch) calls. That path genuinely emitted nothing: the pill sat wherever
+`onEscalate`'s `'waiting'` left it, stale the moment the session moved on to
+something else during the slow eval. A new `onHeldCancelled` cue on
+`AutoApproveGateDeps`, wired to the SAME `broadcastCurrentStatus()`
+`onCancelled` uses, closes it. The other `releaseHeld` callers
+(hold-timeout/undelivered fail-open, `cancelStale`'s Stop/SessionEnd
+teardown, `cancelStaleForAgent`, and PreToolUse/PostToolUse
+external-resolution) were each checked against this same question and
+deliberately left without a broadcast — see the `#970 totality note` comments
+at each call site in `auto-approve-gate.ts` for the specific reasoning
+(either the pill is already correct, or the driving hook event already
+carries its own status update in the same synchronous handler).
 
 The specific wrong "cleanup" this ADR exists to head off: treating the
 client pill as harmless decoration because it is explicitly *not* wired into
@@ -77,9 +99,10 @@ client pill as harmless decoration because it is explicitly *not* wired into
 blast radius (a stuck pill cannot re-enter the decision/buffer path,
 unlike the gate's own internal state), but it does not make a stuck cue
 harmless to the user, who is being told to expect a decision that already
-happened. Closing #970 means finishing the same enumeration this ADR
-performed, against `releaseHeld` and `resolveHeld`, not declaring victory at
-`onCancelled`.
+happened. A second wrong cleanup this update adds to the warning list:
+trusting an ADR's own prior enumeration without re-running it against the
+live code, which is precisely how the `resolveHeld` claim above survived
+across a whole PR review undetected.
 
 ## Alternatives considered
 
@@ -100,14 +123,27 @@ performed, against `releaseHeld` and `resolveHeld`, not declaring victory at
 - `packages/daemon/src/cli/status-writer.ts:118-124` — the terminal
   invariant's own stated proof ("every gate end-path calls this exactly
   once")
-- `packages/daemon/src/cli/session-phases/hook-bridge-setup.ts:582-745` —
+- `packages/daemon/src/cli/session-phases/hook-bridge-setup.ts` —
   `broadcastAutoApproveStatus`, `broadcastCurrentStatus`, and the
-  `onEvalStart`/`onHandled`/`onCancelled` wiring
-- `packages/daemon/src/auto-approve/auto-approve-gate.ts:847-931` —
-  `resolveHeld`, `releaseHeld`; grep confirms neither calls
-  `broadcastCurrentStatus` or `markHandled` on the late-verdict/hold-timeout
-  path — the still-uncovered end paths this ADR flags
-- #970 (issue, OPEN as of 2026-08-01 — the enumeration table above and the
-  live-log evidence), PR #973 (MERGED 2026-08-01, `onCancelled` only)
-- #576 (introduced the client pill), #711 (`isSubagent` skip), #573
-  (Part B early push+hold, whose timeout path is the still-uncovered case)
+  `onEvalStart`/`onHandled`/`onCancelled`/`onHeldCancelled` wiring (the
+  function's own docstring carries the corrected, full enumeration table)
+- `packages/daemon/src/auto-approve/auto-approve-gate.ts` — `resolveHeld`
+  (calls `markHandled` unconditionally since #711's `d1b3c5e2`, contra this
+  ADR's original claim — see the `#970 note` on its docstring), `releaseHeld`
+  (never calls `markHandled`; each of its five call sites carries its own
+  `#970 totality note` explaining whether it needs a cue), and the new
+  `onHeldCancelled` dep + its wiring in `reconcileLateVerdict`'s cancelled
+  branch
+- `packages/daemon/tests/auto-approve/auto-approve-gate.test.ts` — describe
+  block `#970 held-hook client status cue totality`: direct cue-level proof
+  for Part-B allow/deny (`onHandled`), Part-B cancelled (`onHeldCancelled`),
+  and hold-timeout (neither cue fires)
+- `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` —
+  describe block `#970 held-hook (Model B / Part B) totality`: the same four
+  scenarios exercised end-to-end through the real hook wiring
+- #970 (issue, closed by the follow-up PR to #973), PR #973 (MERGED
+  2026-08-01, `onCancelled` only — the primary-eval half), the follow-up PR
+  (held-hook half: `onHeldCancelled` + the `resolveHeld` correction above)
+- #576 (introduced the client pill), #711 (`isSubagent` skip; also the PR
+  that quietly made `resolveHeld`'s coverage already-total), #573 (Part B
+  early push+hold)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,25 @@ All notable changes to Remi are documented here.
   draft added an `isSubagent` guard here; it was dead code (always `false`), and
   the test written for it passed with the guard deleted. Both were dropped in
   favor of asserting the real routing.
+- **The auto-approve pill's held-hook (Model B / Part B, #573) end paths finish
+  the #970 totality pass.** The previous fix covered the primary eval loop only;
+  a HELD escalation's own end paths are a separate set, enumerated fresh against
+  the live code rather than trusted from the prior pass: a Part-B late `allow`/
+  `deny` verdict (`reconcileLateVerdict` -> `resolveHeld`) turned out to be
+  ALREADY total — `resolveHeld` calls `markHandled` unconditionally, so it
+  already broadcast `approved`. The genuine gap was Part-B's `cancelled` late
+  verdict (`reconcileLateVerdict` -> `releaseHeld`), which calls neither
+  `markHandled` nor any cue and left the pill on a stale `waiting` with nothing
+  to correct it once the session moved on to something else. A new `onHeldCancelled`
+  cue closes it, reusing the same `broadcastCurrentStatus()` the `cancelled` fix
+  above introduced rather than guessing a value.
+
+  Hold-timeout fail-open and the Stop/SessionEnd/external-resolution teardown
+  paths were checked and deliberately left alone: each already has its own
+  status coverage (the hold's own `waiting`, or the driving hook event's own
+  status update in the same synchronous handler) — adding a broadcast there
+  would risk trading a stuck pill for a wrong one, the same failure mode
+  ADR 0020 warns against.
 ### Added
 - **Separate in-app toggles for question and turn-complete notifications**
   (#968). Settings now has "Question alerts" and "Turn complete" instead of one

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -413,6 +413,30 @@ export interface AutoApproveGateDeps {
    *  by "a cancelled parked render escalates" in the gate tests). */
   onCancelled?: () => void;
   /**
+   * Called when a HELD hook's Part-B late verdict resolved to 'cancelled' --
+   * `reconcileLateVerdict` found Claude had already advanced past the prompt
+   * while the early push+hold (#573) was showing, and released the hold to
+   * passthrough. The held-path sibling of `onCancelled` above, closing the
+   * SAME class of gap #970 found there: the client pill was moved off
+   * 'evaluating' to 'waiting' when the hold was created (`onEscalate` ->
+   * the question path's own broadcast), but nothing moved it again when the
+   * verdict turned out to be "nothing to decide" -- the pill would sit on a
+   * now-stale 'waiting' regardless of what the session actually became in
+   * the meantime.
+   *
+   * Deliberately NOT folded into `onCancelled` itself: that cue fires from
+   * `resolvePermission`'s own eval loop and `releaseHeld` is a completely
+   * different exit (a HELD hook's late-verdict reconciliation), so sharing
+   * one callback would make a caller's cue handler guess which path it is
+   * in. Also carries no `ctx.isSubagent`, for the same reason `onCancelled`
+   * does not: Part B (`maybePushOnSlowEval`) refuses to arm at all for a
+   * subagent-tagged input or while `isInSubagentContext()` is true, so this
+   * cue is unreachable from anywhere but a MAIN-context hold -- a ctx
+   * parameter would be `false` at every call site and an isSubagent guard
+   * built on it would be untestable dead code, exactly as documented on
+   * `onCancelled`. */
+  onHeldCancelled?: () => void;
+  /**
    * Called when a HELD question resolved WITHOUT the user answering it through
    * the WebSocket/relay answer path (#585, P7): a Part-B slow-eval verdict landed
    * after the early push (auto_approved/auto_denied), the hold timed out, or
@@ -833,6 +857,17 @@ export class AutoApproveGate {
    * Clears the hold's timer and marks the permission handled so the #484 buffer
    * + #513 cue close exactly as for a silent auto-decision.
    *
+   * #970 note: `markHandled` below ALSO fires the #576 client status broadcast
+   * (`onHandled` -> `broadcastAutoApproveStatus('approved')`), so a Part-B late
+   * verdict reconciled through here (`reconcileLateVerdict`'s allow/deny
+   * branches, which call this method) was ALREADY total before the #970 fix --
+   * verified by grep AND by a regression test in hook-bridge-setup.test.ts,
+   * because an earlier pass at this same enumeration (ADR 0020) claimed
+   * otherwise without checking this call site. The one late-verdict outcome
+   * that genuinely reached no cue was the CANCELLED branch, which calls
+   * `releaseHeld` (a separate method, no `markHandled`) -- see `onHeldCancelled`
+   * on `AutoApproveGateDeps` for that fix.
+   *
    * `suggestionIndex` (#718): present when the user picked a suggestion-derived
    * "Yes, always allow: ..." option. `decision` is still `'allow'` in that case
    * (the caller maps isNo -> deny, everything else it can express -> allow);
@@ -896,6 +931,12 @@ export class AutoApproveGate {
    * prompt. Returns true iff a hold for `questionId` existed. Public wrapper over
    * the private `releaseHeld(qid, 'passthrough')`; no markHandled (the user is
    * about to answer the native prompt, not a silent auto-decision).
+   *
+   * #970 totality note: no client status cue needed. This path only runs
+   * because a client JUST answered (input-events.ts), so the answering
+   * client already knows the outcome, and the PTY inject that follows
+   * triggers the normal PreToolUse -> 'executing' status update for every
+   * OTHER connected client, same as `onEscalate` relies on elsewhere.
    */
   releaseHeldAsPassthrough(questionId: UUID): boolean {
     // #673: openQuestionSignatures cleanup lives in the private releaseHeld
@@ -913,7 +954,14 @@ export class AutoApproveGate {
    *  cleanup is never duplicated here -- #799's mainOnly Stop sweep in
    *  `cancelStale` depends on `releaseHeld` having already dropped this qid's
    *  `openQuestionSignatures` entry, or it would re-find it and double-fire
-   *  `notifyResolved`. */
+   *  `notifyResolved`.
+   *
+   *  #970 totality note: no client status cue fires here either. Both callers
+   *  (`Stop` mainOnly, `SessionEnd`) are hook events the setup layer ALSO
+   *  drives through the ordinary status path in the same synchronous handler,
+   *  immediately after `cancelStale` returns (`onStatusChange('idle')` for
+   *  both) -- the same "the question path's own status already covers it"
+   *  reasoning `onEscalate` relies on, not a new exception. */
   private releaseAllHolds(decision: PermissionDecision, reason: string, mainOnly = false): void {
     const targets = mainOnly
       ? [...this.pendingHolds].filter(([, hold]) => !hold.isSubagent)
@@ -1023,6 +1071,15 @@ export class AutoApproveGate {
    * and resolve the hook so Claude renders its native prompt and the local
    * terminal can take over. No-op when the hold is already gone (answered, Part-B
    * verdict, cancelled) so it never double-resolves.
+   *
+   * #970 totality note: this deliberately fires NO client status cue. Every
+   * path into a hold (immediate binary escalation or Part B's early push)
+   * already moved the pill to 'waiting' via `onEscalate` before a hold could
+   * ever exist, and failing open here does not change what the client is
+   * actually waiting on -- the SAME permission is still unanswered, just
+   * rendered in the terminal now instead of held on the hook. 'waiting'
+   * stays true; broadcasting anything else here would be the wrong-status
+   * failure mode ADR 0020 warns is as bad as a stuck one.
    */
   private failOpenHeld(qid: UUID, logMessage: string): void {
     if (!this.pendingHolds.has(qid)) return;
@@ -1584,6 +1641,13 @@ export class AutoApproveGate {
       this.deps.tracker.clearPending();
       this.notifyResolved(qid, 'cancelled');
       this.releaseHeld(qid, 'passthrough', 'part-b-cancelled');
+      // #970: releaseHeld (unlike resolveHeld) never calls markHandled, so
+      // nothing else on this branch tells the client the pill is stale. The
+      // pill was moved to 'waiting' when the hold was created (onEscalate)
+      // and nothing has corrected it since -- the exact gap onCancelled closed
+      // for the non-held path. See onHeldCancelled's own doc for why this is a
+      // separate cue rather than reusing onCancelled.
+      this.safeCue('onHeldCancelled', this.deps.onHeldCancelled);
     }
     // escalate / pick: already pushed + holding; no double-push, leave as-is.
   }
@@ -2265,6 +2329,20 @@ export class AutoApproveGate {
    * `toolName` (#808), when the caller knows it (a signature match or a
    * tracked `ToolSignature` both carry it), is carried onto the
    * question-lifecycle trace record for this removal.
+   *
+   * #970 totality note: no client status cue fires here. All three callers
+   * already have their own status coverage:
+   *   - `cancelExternallyResolved` (PreToolUse/PostToolUse/PermissionDenied
+   *     match) runs INSIDE the same synchronous hook handler that also drives
+   *     `handlers.onPreToolUse` etc. -> `onStatusChange('executing', ...)` for
+   *     the identical event, so the pill is corrected in the same tick.
+   *   - `cancelStale`'s mainOnly Stop sweep runs before `handlers.onStop`'s
+   *     own `onStatusChange('idle')` in that same Stop handler -- see the
+   *     note on `releaseAllHolds` above.
+   *   - `cancelStaleForAgent` (SubagentStop) only ever matches a
+   *     `sig.isSubagent` entry, and #711 never broadcasts the MAIN client
+   *     pill for a subagent/team-member eval or hold in the first place --
+   *     there is nothing to correct.
    */
   private resolveSupersededQuestion(qid: UUID, reason: string, toolName?: string): void {
     log(

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -611,17 +611,30 @@ export function setupHookBridge(
    * later hook can move it off. That made the client cue NOT total over the
    * gate's end paths, unlike the terminal one, whose own invariant
    * (`status-writer.ts`: "the count returns to 0 and the 'evaluating' cue can
-   * never get stuck") holds precisely because every end path decrements it:
+   * never get stuck") holds precisely because every end path decrements it.
+   * The full enumeration, corrected against the live code (an earlier pass at
+   * this table, ADR 0020, asserted two rows below without checking their call
+   * sites — see the #970 note on `AutoApproveGate.resolveHeld`):
    *
-   *   onHandled   -> 'approved' broadcast          (covered)
-   *   onEscalate  -> the question path's 'waiting' (covered, indirectly)
-   *   onCancelled -> NOTHING                       (the hole this closes)
+   *   onHandled                    -> 'approved' broadcast (covered)
+   *   onEscalate                   -> the question path's 'waiting' (covered, indirectly)
+   *   onCancelled                  -> NOTHING                (closed by this function, PR #973)
+   *   resolveHeld (Part-B allow/deny) -> markHandled -> onHandled -> 'approved' (ALREADY covered;
+   *                                    resolveHeld calls markHandled unconditionally, #711)
+   *   releaseHeld, hold-timeout / undelivered fail-open -> NOTHING NEEDED ('waiting' from
+   *                                    the hold's own onEscalate is still accurate: same
+   *                                    permission, now rendered in the terminal instead)
+   *   releaseHeld, Part-B cancelled -> NOTHING            (closed by onHeldCancelled below)
+   *   releaseHeld, Stop/SessionEnd/external-resolve/SubagentStop -> NOTHING NEEDED (the
+   *                                    driving hook event's own onStatusChange covers it,
+   *                                    or — SubagentStop — no MAIN pill was ever moved)
    *
    * A cancelled verdict self-healed only when a later `Stop`/`SessionEnd`
    * `idle` or a `PreToolUse` `executing` happened to follow. None is guaranteed
    * — and by construction none arrives when the eval was cancelled at the end
    * of a turn or during a disconnect, which is exactly when it was observed
-   * stuck.
+   * stuck. The same reasoning applies to a HELD hook's Part-B cancelled
+   * branch, which is why `onHeldCancelled` reuses this exact function.
    *
    * Broadcasts the registry's CURRENT status rather than a chosen constant. The
    * gate does not know what the session became (nothing was approved, denied,
@@ -744,6 +757,16 @@ export function setupHookBridge(
         // it (a cancelled parked render escalates instead).
         broadcastCurrentStatus();
       },
+      // #970 (follow-up to the onCancelled fix above): the HELD-hook sibling
+      // gap ADR 0020 left open. `reconcileLateVerdict`'s cancelled branch
+      // (Part B: the slow eval decides Claude already advanced past the
+      // prompt while the early push+hold was showing) calls `releaseHeld`,
+      // never `markHandled` -- so unlike a Part-B ALLOW/DENY late verdict
+      // (which already broadcasts 'approved' via `onHandled`, see the note on
+      // `AutoApproveGate.resolveHeld`), nothing corrected the pill here before
+      // this cue existed. Same fix as `onCancelled`: re-broadcast whatever the
+      // registry's CURRENT status actually is, not a guessed constant.
+      onHeldCancelled: () => broadcastCurrentStatus(),
       // #585: a held question that resolves without a user answer (Part-B late
       // verdict / hold timeout / cancelStale) tells the daemon to dismiss the
       // pushed card on every client. Forwarded with this session's id.

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -2115,6 +2115,8 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
         questionId: UUID,
         reason: 'auto_approved' | 'auto_denied' | 'cancelled',
       ) => void;
+      onHandled?: (ctx: { isSubagent: boolean }) => void;
+      onHeldCancelled?: () => void;
     } = {},
   ): AutoApproveGate {
     registry.registerSession(SID, '/d', fakePTY([]), {
@@ -2137,6 +2139,8 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
         pushHoldMs: opts.pushHoldMs ?? 0,
         alwaysEscalateTools: new Set(),
         ...(opts.onResolved ? { onResolved: opts.onResolved } : {}),
+        ...(opts.onHandled ? { onHandled: opts.onHandled } : {}),
+        ...(opts.onHeldCancelled ? { onHeldCancelled: opts.onHeldCancelled } : {}),
       },
       SID,
     );
@@ -2436,6 +2440,87 @@ describe('AutoApproveGate external-resolution cancel (#673)', () => {
       expect(resolvedLog).toHaveLength(1); // no spurious re-fire for the dead entry
       expect(g.resolveHeld(lastQuestionId as UUID, 'allow')).toBe(true);
       expect(await pendingSecond).toBe('allow');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #970: the client status-pill cue must be total over the HELD hook's own
+  // end paths, not just the primary eval loop's (#973 closed that half via
+  // onCancelled). Enumerated in ADR 0020 -- corrected here against the live
+  // code, since the ADR's own "resolveHeld skips markHandled too" claim did
+  // not survive a grep (see the #970 note on `AutoApproveGate.resolveHeld`).
+  // ---------------------------------------------------------------------------
+  describe('#970 held-hook client status cue totality', () => {
+    test('Part-B ALLOW late verdict fires onHandled -- already total before #970 (resolveHeld calls markHandled unconditionally)', async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service, release } = multiDeferredEvaluator(cancelLog);
+      const handledLog: Array<{ isSubagent: boolean }> = [];
+      const heldCancelledLog: number[] = [];
+      const g = gate(service, {
+        holdMs: 60_000,
+        pushHoldMs: 10,
+        onHandled: (ctx) => handledLog.push(ctx),
+        onHeldCancelled: () => heldCancelledLog.push(1),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20)); // early push + hold fires
+
+      release({ command: 'git push' }, approve);
+      expect(await pending).toBe('allow');
+      expect(handledLog).toEqual([{ isSubagent: false }]);
+      expect(heldCancelledLog).toHaveLength(0); // wrong cue must not also fire
+    });
+
+    test('Part-B DENY late verdict fires onHandled -- same coverage as ALLOW', async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service, release } = multiDeferredEvaluator(cancelLog);
+      const handledLog: Array<{ isSubagent: boolean }> = [];
+      const g = gate(service, {
+        holdMs: 60_000,
+        pushHoldMs: 10,
+        onHandled: (ctx) => handledLog.push(ctx),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+
+      release({ command: 'git push' }, deny);
+      expect(await pending).toBe('deny');
+      expect(handledLog).toEqual([{ isSubagent: false }]);
+    });
+
+    test('Part-B CANCELLED late verdict fires onHeldCancelled (the actual #970 gap)', async () => {
+      const cancelLog: Array<{ reason: string; evalId: number | undefined }> = [];
+      const { service, release } = multiDeferredEvaluator(cancelLog);
+      const handledLog: Array<{ isSubagent: boolean }> = [];
+      const heldCancelledLog: number[] = [];
+      const g = gate(service, {
+        holdMs: 60_000,
+        pushHoldMs: 10,
+        onHandled: (ctx) => handledLog.push(ctx),
+        onHeldCancelled: () => heldCancelledLog.push(1),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      await new Promise((r) => setTimeout(r, 20));
+
+      release({ command: 'git push' }, cancelled);
+      expect(await pending).toBe('passthrough');
+      expect(heldCancelledLog).toHaveLength(1);
+      expect(handledLog).toHaveLength(0); // wrong cue must not also fire
+    });
+
+    test('hold-timeout fail-open fires NEITHER onHandled NOR onHeldCancelled (the pill is already "waiting" and stays correct)', async () => {
+      const handledLog: Array<{ isSubagent: boolean }> = [];
+      const heldCancelledLog: number[] = [];
+      const g = gate(evaluator(escalate), {
+        holdMs: 20, // short timeout so the hold fails open quickly
+        onHandled: (ctx) => handledLog.push(ctx),
+        onHeldCancelled: () => heldCancelledLog.push(1),
+      });
+      const pending = g.resolvePermission(pr({ tool_input: { command: 'git push' } }));
+      expect(await pending).toBe('passthrough'); // resolves once the hold times out
+
+      expect(handledLog).toHaveLength(0);
+      expect(heldCancelledLog).toHaveLength(0);
     });
   });
 

--- a/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
+++ b/packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts
@@ -206,6 +206,18 @@ describe('setupHookBridge', () => {
       autoApprovePickIndex?: number;
       autoApproveDelayMs?: number;
       autoApproveThrows?: boolean;
+      /** Seconds to hold a binary main-context escalation open (Model B, #573).
+       *  Absent/0 keeps the pre-existing default (holding disabled, escalate
+       *  returns 'passthrough' immediately). Combine with `autoApproveDecision:
+       *  'escalate'` for an immediate hold, or with a slower
+       *  `autoApproveDelayMs` + `pushHoldTimeoutSec` for a Part-B early
+       *  push+hold that a late verdict then reconciles (#970). */
+      holdTimeoutSec?: number;
+      /** Seconds before a still-running eval triggers Part B's early push+hold
+       *  (#573). Needs `holdTimeoutSec > 0` too (Part B reuses the same hold
+       *  primitive). Set smaller than `autoApproveDelayMs` so the timer wins
+       *  the race and the eval's late verdict reconciles into the hold. */
+      pushHoldTimeoutSec?: number;
       /** Capture every evaluate() call's positional args (#893: used to assert
        *  the authority text the gate threads through reaches the service).
        *  Defaults to undefined (not recorded, matches every pre-#893 test). */
@@ -353,6 +365,8 @@ describe('setupHookBridge', () => {
         autoApproveService,
         currentPort: () => 8765,
         transcriptDiscovery: new TranscriptDiscovery(),
+        ...(opts.holdTimeoutSec ? { holdTimeoutSec: opts.holdTimeoutSec } : {}),
+        ...(opts.pushHoldTimeoutSec ? { pushHoldTimeoutSec: opts.pushHoldTimeoutSec } : {}),
         ...(opts.subagentViews ? { subagentViews: opts.subagentViews } : {}),
         ...(opts.broadcastResolvedLog
           ? {
@@ -3506,6 +3520,153 @@ describe('setupHookBridge', () => {
         }
       });
     }
+
+    // #970 follow-up: the primary-eval verdicts above are all total (PR #973
+    // closed `cancelled`). The HELD hook (Model B / Part B, #573) is a
+    // SEPARATE set of end paths with its own totality question -- ADR 0020's
+    // enumeration, corrected here (see the #970 note on
+    // `AutoApproveGate.resolveHeld`): a Part-B late ALLOW/DENY verdict was
+    // ALREADY total (resolveHeld calls markHandled unconditionally); the
+    // still-open gap was Part-B's CANCELLED late verdict, which calls
+    // `releaseHeld` (no markHandled) and left the pill on a stale 'waiting'.
+    describe('#970 held-hook (Model B / Part B) totality', () => {
+      test('a Part-B ALLOW late verdict broadcasts "approved" end-to-end (pre-existing coverage via onHandled)', async () => {
+        const sendLog: ProtocolMessage[] = [];
+        build({
+          autoApprove: true,
+          autoApproveDecision: 'approve',
+          autoApproveDelayMs: 50, // eval settles AFTER the push-hold timer
+          pushHoldTimeoutSec: 0.01, // 10ms: timer wins, early push+hold fires
+          holdTimeoutSec: 5, // long enough that the hold itself never times out
+          sendLog,
+        });
+
+        hookServer.fire('Notification', {
+          session_id: 'claude-aa-heldb-allow',
+          hook_event_name: 'Notification',
+          transcript_path: path.join(tmpDir, 'aa-heldb-allow.jsonl'),
+          notification_type: 'auth_success',
+          message: '',
+        });
+
+        const decision = await hookServer.firePermission({
+          session_id: 'claude-aa-heldb-allow',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+        });
+        expect(decision).toBe('allow');
+
+        const statuses = sessionUpdateStatuses(sendLog);
+        expect(statuses).toContain('evaluating');
+        expect(statuses.at(-1)).toBe('approved');
+      });
+
+      test('a Part-B DENY late verdict also broadcasts "approved" (onHandled does not distinguish allow/deny -- pre-existing, out of #970 scope)', async () => {
+        const sendLog: ProtocolMessage[] = [];
+        build({
+          autoApprove: true,
+          autoApproveDecision: 'deny',
+          autoApproveDelayMs: 50,
+          pushHoldTimeoutSec: 0.01,
+          holdTimeoutSec: 5,
+          sendLog,
+        });
+
+        hookServer.fire('Notification', {
+          session_id: 'claude-aa-heldb-deny',
+          hook_event_name: 'Notification',
+          transcript_path: path.join(tmpDir, 'aa-heldb-deny.jsonl'),
+          notification_type: 'auth_success',
+          message: '',
+        });
+
+        const decision = await hookServer.firePermission({
+          session_id: 'claude-aa-heldb-deny',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+        });
+        expect(decision).toBe('deny');
+
+        const statuses = sessionUpdateStatuses(sendLog);
+        expect(statuses).toContain('evaluating');
+        // Not stuck on 'evaluating' -- the actual totality property under test.
+        expect(statuses.at(-1)).not.toBe('evaluating');
+      });
+
+      test('#970 a Part-B CANCELLED late verdict broadcasts a terminal status via onHeldCancelled, never leaving the pill on "evaluating"', async () => {
+        // The regression this PR fixes: before onHeldCancelled existed, this
+        // path called releaseHeld (no markHandled, no cue) and left the pill
+        // wherever onEscalate's 'waiting' put it -- stale the moment the
+        // session moved on to something else.
+        const sendLog: ProtocolMessage[] = [];
+        build({
+          autoApprove: true,
+          autoApproveDecision: 'cancelled',
+          autoApproveDelayMs: 50,
+          pushHoldTimeoutSec: 0.01,
+          holdTimeoutSec: 5,
+          sendLog,
+        });
+
+        hookServer.fire('Notification', {
+          session_id: 'claude-aa-heldb-cancelled',
+          hook_event_name: 'Notification',
+          transcript_path: path.join(tmpDir, 'aa-heldb-cancelled.jsonl'),
+          notification_type: 'auth_success',
+          message: '',
+        });
+
+        const decision = await hookServer.firePermission({
+          session_id: 'claude-aa-heldb-cancelled',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+        });
+        expect(decision).toBe('passthrough');
+
+        const statuses = sessionUpdateStatuses(sendLog);
+        expect(statuses).toContain('evaluating');
+        expect(statuses.at(-1)).not.toBe('evaluating');
+        expect(statuses).not.toContain('approved'); // nothing was approved
+      });
+
+      test('a hold-timeout fail-open broadcasts NOTHING new -- the pill is already "waiting" (via the ordinary status path) and stays correct', async () => {
+        const sendLog: ProtocolMessage[] = [];
+        build({
+          autoApprove: true,
+          autoApproveDecision: 'escalate',
+          autoApproveDelayMs: 5,
+          holdTimeoutSec: 0.02, // 20ms: short so the hold fails open quickly
+          sendLog,
+        });
+
+        hookServer.fire('Notification', {
+          session_id: 'claude-aa-holdtimeout',
+          hook_event_name: 'Notification',
+          transcript_path: path.join(tmpDir, 'aa-holdtimeout.jsonl'),
+          notification_type: 'auth_success',
+          message: '',
+        });
+
+        // Resolves once the hold times out and fails open to passthrough.
+        const decision = await hookServer.firePermission({
+          session_id: 'claude-aa-holdtimeout',
+          hook_event_name: 'PermissionRequest',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' },
+        });
+        expect(decision).toBe('passthrough');
+
+        // The 'broadcast' channel (client-only pill) only ever saw 'evaluating'
+        // -- the hold's own creation moved the pill to 'waiting' through the
+        // ORDINARY status path (messageApi.handleStatusChange), asserted below,
+        // and the fail-open correctly adds nothing more to either channel.
+        expect(sessionUpdateStatuses(sendLog)).toEqual(['evaluating']);
+        expect(messageApiLog.statusCalls).toContain('waiting');
+      });
+    });
 
     test('a status-broadcast send error never propagates into the gate decision', async () => {
       // The broadcast helper wraps its own send in try/catch so a throwing


### PR DESCRIPTION
## Summary

Finishes #970. PR #973 made the client status pill total over the auto-approve
gate's *primary eval loop* end paths (`onEvalStart` / `onHandled` / `onEscalate`
/ `onCancelled`). This PR does the same enumeration for the gate's separate
*held-hook* end paths (Model B / Part B, #573: `resolveHeld` / `releaseHeld`),
which ADR 0020 flagged as still open.

## What the enumeration found

| Held-hook end path | Needs a new broadcast? | Why |
|---|---|---|
| `resolveHeld` (Part-B late `allow`/`deny`) | **No — already covered** | `resolveHeld` has called `markHandled` unconditionally since #711 (`d1b3c5e2`, a month before ADR 0020 was written). That routes through `onHandled` -> `broadcastAutoApproveStatus('approved')` exactly like a silent primary-eval decision. ADR 0020's claim that `resolveHeld` skips `markHandled` did not survive a grep — corrected in this PR (see below). |
| `releaseHeld`, Part-B `cancelled` late verdict | **Yes — the actual gap** | `releaseHeld` (a different method) never calls `markHandled`. This path left the pill on whatever `onEscalate`'s `'waiting'` set, stale the moment the session moved on to something else during the slow eval — the exact `onCancelled` failure mode, one layer down. Closed with a new `onHeldCancelled` dep, wired to the same `broadcastCurrentStatus()` PR #973 introduced. |
| `releaseHeld`, hold-timeout / undelivered fail-open | **No — deliberately** | The hold's own creation (`onEscalate`) already set the pill to `'waiting'`. Fail-open only moves the SAME permission from held-hook to terminal-render — the user is still waiting on the exact same thing, so `'waiting'` stays true. Broadcasting anything else would trade a stuck pill for a wrong one (the failure mode ADR 0020 itself warns against). Note: the original issue's suggested-fix list groups hold-timeout with `part-b-cancelled`; I looked at it specifically and concluded it doesn't need a broadcast — see the `#970 totality note` on `failOpenHeld` for the full reasoning, and the dedicated regression test proving the pill stays correct without one. |
| `releaseHeld`, Stop/SessionEnd teardown (`cancelStale` / `releaseAllHolds`) | **No** | Both hook events already drive their own `onStatusChange('idle')` in the same synchronous handler, immediately after the gate's teardown runs. |
| `releaseHeld`, external-resolution (`cancelExternallyResolved` via PreToolUse/PostToolUse/PermissionDenied) | **No** | The driving hook event fires its own status update (`'executing'`, etc.) in the same tick. |
| `releaseHeld`, `cancelStaleForAgent` (SubagentStop) | **No** | Only ever resolves `isSubagent` entries, and #711 never broadcasts the MAIN client pill for a subagent/team-member eval or hold in the first place — nothing to correct. |

## Correction to ADR 0020

The ADR (and the original #970 issue body) both claimed "`resolveHeld` does
not call `markHandled` either (verified by grep)". That did not hold up
against the live code — `resolveHeld` line ~905 calls
`this.markHandled(hold.isSubagent)` unconditionally, present since #711. I
updated ADR 0020's enumeration table and Consequences section to reflect the
corrected picture rather than carrying the error forward, per this repo's
"verify before you describe" rule (ADR 0011) — the ADR's own text is now the
receipt for why this needed checking, not just asserting.

## Mutation testing

Verified every new/changed assertion is load-bearing by neutering the
corresponding production code and confirming the exact expected tests (and
only those) go red, then restoring:

| Mutation | Tests that went red | Count |
|---|---|---|
| Removed `safeCue('onHeldCancelled', ...)` from `reconcileLateVerdict`'s cancelled branch | gate-level + hook-bridge-setup-level Part-B-cancelled tests | 2 |
| Removed the `onHeldCancelled: () => broadcastCurrentStatus()` wiring in `hook-bridge-setup.ts` | the hook-bridge-setup-level Part-B-cancelled test (wiring-specific) | 1 |
| Removed `markHandled` call from `resolveHeld` | gate-level + hook-bridge-setup-level Part-B allow/deny tests | 4 |
| Added a spurious `onHeldCancelled` broadcast inside `failOpenHeld` (hold-timeout) | both "fires NEITHER cue" negative-assertion tests | 2 |

Each mutation was restored and the suite re-confirmed green before moving to
the next. Final state: `packages/daemon/tests/auto-approve/auto-approve-gate.test.ts`
+ `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts` = 261
pass / 0 fail.

## Test plan

- [x] New gate-level cue tests: `packages/daemon/tests/auto-approve/auto-approve-gate.test.ts`,
      describe block `#970 held-hook client status cue totality` (4 tests)
- [x] New end-to-end tests through the real hook wiring:
      `packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts`,
      describe block `#970 held-hook (Model B / Part B) totality` (4 tests)
- [x] `bun test packages/daemon packages/shared packages/signaling` — full suite green (see CI)
- [x] `bunx biome check` — clean
- [x] `bun run typecheck` — clean
- [x] Mutation-verified (table above)
