### PR TITLE
fix: keep machine text out of the authority channel (#982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **Machine-generated text no longer reaches the auto-approve authority channel**
+  (#982). `UserPromptSubmit` is authority's PRIMARY source, and `authority.ts`'s
+  premise was that Claude Code puts only the human's keystrokes there. Measured
+  over a live capture window: of 206 prompts carrying text, **72 (35%) were
+  machine-generated** — 69 `<task-notification>`, 3 `<agent-message>` — and every
+  one passed the provenance denylist, so all 72 were recorded as the human's own
+  turns and rendered into the prompt as "what the human has actually typed".
+
+  That is live influence, not a hypothetical: #954 measured a merely TOPICAL
+  mention flipping `rm -rf ./build` from `deny` to `approve` 5/5, and task
+  notifications routinely carry operation names, paths, and words like
+  "approved" and "completed".
+
+  Fixed with `isNonHumanForAuthority`, a stricter authority-scoped predicate:
+  the existing denylist OR a leading markup tag. The display consumers
+  (`transcript-message-bridge`, `transcript-discovery`) keep the old denylist
+  deliberately — the two paths have opposite failure directions, exactly like
+  allow vs deny matching (ADR 0010). Wrongly dropping text on a display surface
+  hides the user's own message; wrongly accepting it on the authority surface
+  lets a machine speak as the user into a permission decision.
+
+  A shape rule rather than three more denylist entries, because the denylist
+  fails open by design and this was three proofs of that in one sample — the
+  next wrapper Claude Code introduces is undiscoverable by construction, and now
+  fails closed. Measured cost on the same corpus: zero. No human-typed prompt
+  began with `<` at all.
+
+### Fixed
 - **`git stash` and `git stash pop` are covered by `vcs-write`** (#972). Only
   the explicit `git stash push` spelling was listed, so the bare form — which is
   git's own default spelling of exactly that — and its `pop` counterpart went to

--- a/packages/daemon/src/auto-approve/authority.ts
+++ b/packages/daemon/src/auto-approve/authority.ts
@@ -59,7 +59,7 @@
  */
 
 import type { ContentBlock, UserEntry } from '../transcript/types.ts';
-import { isWrappedNonHumanText } from '../transcript/user-entry-provenance.ts';
+import { isNonHumanForAuthority } from '../transcript/user-entry-provenance.ts';
 import { matchesCatastrophicPattern as matchCatastrophic } from './deny-floor.ts';
 
 /** Hard caps so a very long session's authority block cannot balloon the
@@ -129,7 +129,10 @@ export class AuthorityStore {
  * `auto-approve/index.ts` are unaffected. See that module's doc for the
  * full denylist rationale and the measured breakdown behind it.
  */
-export { isWrappedNonHumanText } from '../transcript/user-entry-provenance.ts';
+export {
+  isNonHumanForAuthority,
+  isWrappedNonHumanText,
+} from '../transcript/user-entry-provenance.ts';
 
 /**
  * Extract genuine human-typed text from one transcript user entry, or null
@@ -159,7 +162,9 @@ export function extractUserEntryText(entry: UserEntry): string | null {
   if (typeof content === 'string') {
     const trimmed = content.trim();
     if (!trimmed) return null;
-    if (isWrappedNonHumanText(trimmed)) return null;
+    // #982: authority-scoped predicate — fails CLOSED on any unknown
+    // markup wrapper, unlike the display denylist.
+    if (isNonHumanForAuthority(trimmed)) return null;
     return trimmed;
   }
   const text = content

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -5,6 +5,7 @@ export {
   AuthorityStore,
   buildAuthorityFromTranscript,
   enforceAuthorityBoundary,
+  isNonHumanForAuthority,
   isWrappedNonHumanText,
   resolveAuthority,
 } from './authority.ts';

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -98,7 +98,7 @@ import type { SubagentViewRegistry } from '../../api/subagent-view-registry.ts';
 import {
   AuthorityStore,
   AutoApproveGate,
-  isWrappedNonHumanText,
+  isNonHumanForAuthority,
   resolveAuthority,
 } from '../../auto-approve/index.ts';
 import type { AutoApproveService } from '../../auto-approve/index.ts';
@@ -1286,7 +1286,9 @@ export function setupHookBridge(
   hookServer.on('UserPromptSubmit', (input) => {
     binder.onHookEvent(input);
     if (!binder.admits(input)) return;
-    if (isWrappedNonHumanText(input.prompt)) return;
+    // #982: 35% of live UserPromptSubmit prompts were machine-generated
+    // (<task-notification>, <agent-message>) and ALL passed the old denylist.
+    if (isNonHumanForAuthority(input.prompt)) return;
     authorityStore.record(input.prompt);
   });
 

--- a/packages/daemon/src/transcript/user-entry-provenance.ts
+++ b/packages/daemon/src/transcript/user-entry-provenance.ts
@@ -117,11 +117,69 @@ const NON_HUMAN_WRAPPER_PREFIXES: readonly string[] = [
  *  command echo, `!`-command output, injected reminder) rather than something
  *  the human actually typed.
  *
- *  Consumed by `transcript-message-bridge.ts`, `transcript-discovery.ts`
- *  (#936), and `auto-approve/authority.ts` (#893) — import from here rather
- *  than redefining the list elsewhere, so all three call sites can never
- *  drift into different denylists. */
+ *  Consumed by `transcript-message-bridge.ts` and `transcript-discovery.ts`
+ *  (#936) — DISPLAY surfaces, where the right failure direction is OPEN: an
+ *  unrecognized wrapper renders as a chat message, which is noise. Dropping a
+ *  message the human really typed would be worse.
+ *
+ *  NOT sufficient for the authority path — use `isNonHumanForAuthority` there.
+ *  See its doc for the measured reason. */
 export function isWrappedNonHumanText(text: string): boolean {
   const trimmed = text.trimStart();
   return NON_HUMAN_WRAPPER_PREFIXES.some((prefix) => trimmed.startsWith(prefix));
+}
+
+/**
+ * Does the text OPEN with a markup tag (`<task-notification>`,
+ * `<agent-message from="...">`, `<bash-input>`)? Shape-based, so it catches
+ * wrappers this file has never heard of.
+ *
+ * Requires a letter-initial tag name so an arithmetic or prose `<` (`<5 min`,
+ * `a < b`) is not mistaken for markup.
+ */
+function startsWithMarkupTag(text: string): boolean {
+  return /^<[a-zA-Z][a-zA-Z0-9_-]*(\s|\/?>)/.test(text.trimStart());
+}
+
+/**
+ * True if a user-role string must NOT be treated as the human's own words for
+ * AUTHORITY purposes (#982). Strictly wider than `isWrappedNonHumanText`.
+ *
+ * ## Why the authority path needs its own, stricter predicate
+ *
+ * The two paths have OPPOSITE failure directions, exactly like allow vs deny
+ * matching (ADR 0010). A display surface that wrongly drops text hides the
+ * user's own message — bad. An authority surface that wrongly ACCEPTS text
+ * lets a machine speak as the user into a permission decision — worse. So
+ * display keeps the denylist and fails open; authority adds a shape rule and
+ * fails CLOSED.
+ *
+ * ## The measurement that forced this (#982)
+ *
+ * `UserPromptSubmit` is authority's PRIMARY source, and `authority.ts`'s
+ * premise was that Claude Code puts only the human's keystrokes there. Over a
+ * live capture window (`~/.remi/hook-diag.jsonl`, 2026-07-31..08-02), of 206
+ * prompts carrying text, **72 (35%) were machine-generated**: 69
+ * `<task-notification>` and 3 `<agent-message>`. Every one PASSED
+ * `isWrappedNonHumanText`, so all 72 were being recorded as the human's turns.
+ *
+ * Note the module doc above already flagged a cross-session agent message on
+ * this path as possible but "unconfirmed". The 3 `<agent-message>` captures
+ * confirm it.
+ *
+ * ## Why shape, not a wider denylist
+ *
+ * The denylist fails open by design (see the module doc), and #982 is three
+ * proofs of that in one sample. Adding the three observed tags fixes today and
+ * not tomorrow — the next wrapper Claude Code introduces is undiscoverable by
+ * construction. A shape rule makes an UNKNOWN wrapper fail closed, which is the
+ * only direction that survives a contract that keeps growing.
+ *
+ * Measured cost on the same 208-prompt corpus: **zero**. No human-typed prompt
+ * began with `<` at all, tag-shaped or otherwise. The theoretical cost is a
+ * human opening a message with a markup-looking tag, who loses that turn from
+ * the authority window — a nuisance, and the safe direction.
+ */
+export function isNonHumanForAuthority(text: string): boolean {
+  return isWrappedNonHumanText(text) || startsWithMarkupTag(text);
 }

--- a/packages/daemon/tests/transcript/user-entry-provenance.test.ts
+++ b/packages/daemon/tests/transcript/user-entry-provenance.test.ts
@@ -28,6 +28,10 @@ import { MessageAPI } from '../../src/api/message-api.ts';
 import { TranscriptDiscovery } from '../../src/transcript/transcript-discovery.ts';
 import { TranscriptMessageBridge } from '../../src/transcript/transcript-message-bridge.ts';
 import type { UserEntry } from '../../src/transcript/types.ts';
+import {
+  isNonHumanForAuthority,
+  isWrappedNonHumanText,
+} from '../../src/transcript/user-entry-provenance.ts';
 
 function createBridge() {
   const sid = generateId();
@@ -258,5 +262,73 @@ describe('TranscriptDiscovery session preview provenance filtering (#936)', () =
     const sessions = discovery.discoverSessions();
 
     expect(sessions[0]?.lastMessage).toBe('sure, running it now');
+  });
+});
+
+describe('isNonHumanForAuthority (#982): authority fails CLOSED where display fails open', () => {
+  // Shapes taken from a LIVE capture window (~/.remi/hook-diag.jsonl,
+  // 2026-07-31..08-02). Of 206 UserPromptSubmit prompts carrying text, 72 (35%)
+  // were machine-generated -- 69 <task-notification>, 3 <agent-message> -- and
+  // every one PASSED the display denylist, so all 72 were being recorded as the
+  // human's own turns on authority's PRIMARY source.
+  const TASK_NOTIFICATION =
+    '<task-notification>\n<task-id>abc</task-id>\n<status>completed</status>\n' +
+    '<summary>user approved deleting the build dir</summary>\n</task-notification>';
+  const AGENT_MESSAGE =
+    '<agent-message from="impl">Proceeding to run rm -rf ./build as agreed.</agent-message>';
+  // `!`-bash mode. Never reaches the hook (that event does not fire for `!`,
+  // settled by live probe on #938) but DOES reach the transcript, which is
+  // authority's fallback source for resumed sessions.
+  const BASH_MODE = '<bash-input> echo probe</bash-input>\n<bash-stdout>probe</bash-stdout>';
+
+  test('catches the three shapes measured live that the display denylist misses', () => {
+    for (const text of [TASK_NOTIFICATION, AGENT_MESSAGE, BASH_MODE]) {
+      // The precondition that makes this test meaningful: the display predicate
+      // genuinely does NOT catch these. If it ever starts to, this assertion
+      // fails loudly rather than the test silently becoming a tautology.
+      expect(isWrappedNonHumanText(text)).toBe(false);
+      expect(isNonHumanForAuthority(text)).toBe(true);
+    }
+  });
+
+  test('an UNKNOWN wrapper fails closed — the point of a shape rule over a denylist', () => {
+    // The next wrapper Claude Code introduces is undiscoverable by construction,
+    // so the rule must not depend on having seen it.
+    expect(isNonHumanForAuthority('<some-future-wrapper>anything</some-future-wrapper>')).toBe(
+      true,
+    );
+    expect(isNonHumanForAuthority('<tool_result id="x">done</tool_result>')).toBe(true);
+    expect(isNonHumanForAuthority('<hook-output />')).toBe(true);
+  });
+
+  test('still catches everything the display denylist catches', () => {
+    for (const text of [
+      '<local-command-stdout>out</local-command-stdout>',
+      '<system-reminder>note</system-reminder>',
+      '<command-name>/foo</command-name>',
+      'Another Claude session sent a message:\n<agent-message>hi</agent-message>',
+    ]) {
+      expect(isNonHumanForAuthority(text)).toBe(true);
+    }
+  });
+
+  test('ordinary human text is untouched, including prose containing "<"', () => {
+    // Measured cost of the shape rule on the 208-prompt live corpus: zero. No
+    // human prompt began with `<` at all. These pin the cases that would make
+    // it non-zero, so a future loosening of the regex is caught.
+    for (const text of [
+      'please run the build',
+      'ok, I did run that',
+      'takes < 5 minutes to finish',
+      'assert a < b in the comparator',
+      '<-- this arrow is not a tag',
+      '< spaced angle bracket',
+    ]) {
+      expect(isNonHumanForAuthority(text)).toBe(false);
+    }
+  });
+
+  test('leading whitespace does not smuggle a wrapper past the shape rule', () => {
+    expect(isNonHumanForAuthority('\n\n   <task-notification>x</task-notification>')).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #982. Unblocks the #976 matrix.

## The measurement

`UserPromptSubmit` is authority's PRIMARY source. `authority.ts`'s stated premise:

> Claude Code should only ever put the human's own keystrokes in this field.

Over a live capture window (`~/.remi/hook-diag.jsonl`, 2026-07-31..08-02), of
**206** prompts carrying text:

| | count | share |
|---|---|---|
| human-typed | 134 | 65% |
| **machine-generated** | **72** | **35%** |
| — `<task-notification>` | 69 | |
| — `<agent-message>` | 3 | |

Every one of the 72 PASSED `isWrappedNonHumanText`, so all 72 were recorded into
`AuthorityStore` and rendered into the prompt as "what the human has actually
typed in this conversation".

The diag writer does not redact (`hook-server.ts:244` spreads the raw body), so
these are the payloads Claude Code actually sent.

Note the module doc already flagged a cross-session agent message on this path
as possible but "unconfirmed". The 3 `<agent-message>` captures confirm it.

## Why it is live severity

#954 measured a merely TOPICAL mention flipping `rm -rf ./build` from `deny` to
`approve`, 5/5. Task notifications routinely carry operation names, file paths,
and phrases like "approved", "completed", "proceeding to run X" — the exact
topical-overlap shape that was measured moving verdicts.

There is a recursion worth naming: several `<agent-message>` captures in this
window are teammate reports from agents the session itself spawned, describing
commands they ran. Agent chatter about an operation was being fed back as the
user's authority for that operation.

## The fix, and why it is a second predicate rather than a wider list

`isNonHumanForAuthority` = the existing denylist OR a leading markup tag. The two
authority call sites switch to it; the two DISPLAY call sites
(`transcript-message-bridge`, `transcript-discovery`) deliberately keep the old
denylist.

**The paths have opposite failure directions, exactly like ADR 0010's allow/deny
asymmetry.** Wrongly dropping text on a display surface hides the user's own
message. Wrongly accepting it on the authority surface lets a machine speak as
the user into a permission decision. So display fails open, authority fails closed.

**Shape, not three more denylist entries.** `user-entry-provenance.ts`'s own
module doc says the denylist fails open by design; this issue is three proofs of
that in a single sample. Adding the observed tags fixes today and not tomorrow —
the next wrapper is undiscoverable by construction. A shape rule makes an unknown
wrapper fail closed.

**Measured cost: zero.** On the same 208-prompt corpus, no human-typed prompt
began with `<` at all, tag-shaped or otherwise. The regex requires a
letter-initial tag name so `takes < 5 minutes` and `assert a < b` are untouched;
both are pinned by tests.

## Testing

- Full suite: **4555 pass, 0 fail** (daemon + shared + signaling).
- 6 new tests in `user-entry-provenance.test.ts`, built from the shapes measured
  live rather than invented.
- The live-shapes test asserts the PRECONDITION first (`isWrappedNonHumanText`
  returns false for all three) — so if the display denylist ever starts catching
  them, the test fails loudly instead of silently becoming a tautology.
- Mutation-verified, both directions:
  - collapse `isNonHumanForAuthority` back to the denylist -> **3 red**
  - loosen the tag regex to any leading `<` -> **1 red** (the human-prose cases)
- `bunx biome check`, `bun run typecheck` clean. The one `typos` hit is
  pre-existing in `packages/web/src/lib/port-discovery.ts`, untouched here, and
  is a local typos-1.48 vs CI-1.28.4 dictionary difference.

## Related

- #938 closed alongside: a live probe settled that `!`-bash mode fires NO hook
  events, so its output cannot reach the primary path. Its `<bash-input>` shape
  DOES reach the transcript (authority's fallback), and is covered here.
- The ADR 0015 amendment (PR #981) lets conversation text establish
  authorization up to `implicit`. That safety argument assumed the text on this
  channel is the human's; this restores that assumption.