### PR TITLE
feat: carry a reason on auto-approve denials (#976)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Changed
+- **An auto-approve deny now tells Claude why** (#976). The hook response
+  carried a bare `{behavior:"deny"}`, so Claude learned only that it was
+  refused — leaving it to guess or give up. `PermissionDecision` gains the
+  `{behavior:'deny', message?, interrupt?}` variant the official hooks reference
+  defines, where `message` is *"For `deny` only: tells Claude why the permission
+  was denied"* — model-directed, not terminal UI. With `interrupt` unset the turn
+  continues, so the reason is actionable.
+
+  The message offers two exits, deliberately in this order: use a different
+  approach, or ask the user to authorize explicitly. Leading with "ask the user"
+  would push Claude to interrupt even when a safe equivalent existed. The second
+  exit also closes the #976 loop — the user's answer arrives via
+  `UserPromptSubmit` as genuine EXPLICIT authorization from a channel text cannot
+  forge, which is the only route above `implicit` under the ADR 0015 amendment.
+
+  Deliberately NOT claimed anywhere: that Claude will then ask. The docs
+  guarantee only that it is not stopped and has been told why; what it does next
+  is its own choice, and that is an expectation to verify by observation rather
+  than a contract. The bare `'deny'` string stays valid and equivalent to
+  omitting the message, so no existing caller changes.
+
 ### Fixed
 - **Machine-generated text no longer reaches the auto-approve authority channel**
   (#982). `UserPromptSubmit` is authority's PRIMARY source, and `authority.ts`'s

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -93,6 +93,7 @@ import { log, logError } from '../cli/logger.ts';
 import type { PermissionDecision, PermissionRequestHookInput } from '../hooks/index.ts';
 import { type DeliveryOutcome, isDelivered } from '../notifications/notification-dispatcher.ts';
 import type { SessionRegistry } from '../session/index.ts';
+import { buildDenyMessage } from './deny-floor.ts';
 import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
 import type { AutoApproveResult } from './types.ts';
 
@@ -1432,7 +1433,10 @@ export class AutoApproveGate {
     }
     if (result.decision === 'deny') {
       this.markHandled(isSubagent);
-      return 'deny';
+      // #976: carry the reason to Claude instead of a bare refusal, so it can
+      // route around or ask the user rather than guess. `interrupt` is left
+      // unset (false) so the turn continues and it can act on the message.
+      return { behavior: 'deny', message: buildDenyMessage(result.reasoning) };
     }
     if (result.decision === 'pick') {
       // Multi-choice pick (#399): the response can't express it, so render the
@@ -1490,7 +1494,9 @@ export class AutoApproveGate {
       if (second.decision === 'deny') {
         log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) denied`);
         this.markHandled(isSubagent);
-        return 'deny';
+        // #976: same reasoned deny as the primary path above, carrying the
+        // SECOND opinion's reasoning since that is the verdict being applied.
+        return { behavior: 'deny', message: buildDenyMessage(second.reasoning) };
       }
       if (second.decision === 'cancelled') {
         // Claude already advanced (cancelStale fired during the slower second

--- a/packages/daemon/src/auto-approve/deny-floor.ts
+++ b/packages/daemon/src/auto-approve/deny-floor.ts
@@ -126,3 +126,44 @@ export function enforceDenyFloor(
   }
   return { decision: 'escalate', overridden: true };
 }
+
+/**
+ * Cap on the reason text echoed to Claude. The model's own `reasoning` can run
+ * long, and this rides in a hook response Claude Code parses on the blocking
+ * path — bounded beats verbose.
+ */
+const DENY_MESSAGE_REASON_MAX = 300;
+
+/**
+ * Build the `message` for a deny that Claude will actually read (#976).
+ *
+ * A bare `'deny'` tells Claude only that it was refused, so its options are to
+ * guess or to give up. The official hooks reference defines
+ * `decision.message` as "For `deny` only: tells Claude why the permission was
+ * denied" — model-directed — and leaves the turn running unless `interrupt` is
+ * set, so a reason is actionable.
+ *
+ * Two exits are offered deliberately, in this order:
+ *
+ *   1. a different approach — often there is a safer equivalent, and taking it
+ *      costs the user nothing;
+ *   2. asking the user to authorize explicitly.
+ *
+ * A message that said only "ask the user" would push Claude to interrupt even
+ * when a safe alternative existed. The second exit also closes the #976 loop:
+ * the user's answer arrives via `UserPromptSubmit` as genuine EXPLICIT
+ * authorization from a channel text cannot forge, which is the only way to get
+ * above `implicit` under the ADR 0015 amendment.
+ *
+ * Deliberately does NOT claim Claude will ask. The docs guarantee only that it
+ * is not stopped and has been told why; what it does next is its own choice.
+ */
+export function buildDenyMessage(reasoning?: string): string {
+  const trimmed = (reasoning ?? '').trim();
+  const reason =
+    trimmed.length > DENY_MESSAGE_REASON_MAX
+      ? `${trimmed.slice(0, DENY_MESSAGE_REASON_MAX)}…`
+      : trimmed;
+  const why = reason ? ` Reason: ${reason}` : '';
+  return `Remi's auto-approve did not have authorization to approve this operation.${why} Either use a different approach that does not require it, or ask the user to authorize this explicitly before retrying.`;
+}

--- a/packages/daemon/src/hooks/hook-server.ts
+++ b/packages/daemon/src/hooks/hook-server.ts
@@ -103,7 +103,33 @@ export type PermissionDecision =
   | 'allow'
   | 'deny'
   | 'passthrough'
-  | { readonly behavior: 'allow'; readonly updatedPermissions: readonly unknown[] };
+  | { readonly behavior: 'allow'; readonly updatedPermissions: readonly unknown[] }
+  /**
+   * A deny that tells Claude WHY (#976). Per the official hooks reference's
+   * PermissionRequest decision-control table:
+   *
+   *   `message`   — "For `deny` only: tells Claude why the permission was denied"
+   *   `interrupt` — "For `deny` only: if `true`, stops Claude"
+   *
+   * So `message` is MODEL-directed, not terminal-UI-directed (PreToolUse's
+   * `permissionDecisionReason` is the field that splits those two audiences;
+   * this event has no user-facing variant at all). With `interrupt` absent or
+   * false the turn continues, so Claude has seen the reason and can act on it —
+   * route around with a safer command, or ask the user directly.
+   *
+   * That last step is the documented LIMIT worth respecting: the docs guarantee
+   * Claude is not stopped and has been told why. They do NOT say it will then
+   * ask the user. Treat "Claude asks" as an expectation to verify by
+   * observation, never as a contract.
+   *
+   * The bare `'deny'` string above stays valid and equivalent to omitting the
+   * message — every existing caller keeps working unchanged.
+   */
+  | {
+      readonly behavior: 'deny';
+      readonly message?: string;
+      readonly interrupt?: boolean;
+    };
 
 export type PermissionResolver = (input: PermissionRequestHookInput) => Promise<PermissionDecision>;
 

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -196,7 +196,8 @@ describe('AutoApproveGate', () => {
 
   test('deny returns "deny" with NO inject (main context) (#496)', async () => {
     const d = await gateWith(evaluator(deny)).resolvePermission(pr());
-    expect(d).toBe('deny');
+    // #976: a deny now carries its reason to Claude instead of a bare refusal.
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
     expect(submits).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });
@@ -408,7 +409,8 @@ describe('AutoApproveGate', () => {
 
   test('escalate_model second opinion denies -> "deny" (no escalation) (#522)', async () => {
     const d = await gateWithSecondOpinion(deny).resolvePermission(pr());
-    expect(d).toBe('deny');
+    // #976: a deny now carries its reason to Claude instead of a bare refusal.
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
     expect(escalations).toHaveLength(0);
     expect(submits).toHaveLength(0);
   });
@@ -696,7 +698,10 @@ describe('AutoApproveGate lifecycle callbacks (#513)', () => {
   });
 
   test('deny fires start then handled', async () => {
-    expect(await gate(evaluator(deny)).resolvePermission(pr())).toBe('deny');
+    expect(await gate(evaluator(deny)).resolvePermission(pr())).toEqual({
+      behavior: 'deny',
+      message: expect.stringContaining('ask the user'),
+    });
     expect(events).toEqual(['start', 'handled']);
   });
 
@@ -1023,7 +1028,8 @@ describe('AutoApproveGate hold + resolve (#573 Parts A/C)', () => {
   test('#625 deny pushes NOTHING (no phantom)', async () => {
     const gate = holdGate(evaluator(deny));
     const d = await gate.resolvePermission(pr());
-    expect(d).toBe('deny');
+    // #976: a deny now carries its reason to Claude instead of a bare refusal.
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
     expect(heldPushes).toHaveLength(0);
     expect(escalations).toHaveLength(0);
   });

--- a/packages/daemon/tests/auto-approve/deny-floor.test.ts
+++ b/packages/daemon/tests/auto-approve/deny-floor.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { enforceDenyFloor, matchesCatastrophicPattern } from '../../src/auto-approve/deny-floor.ts';
+import {
+  buildDenyMessage,
+  enforceDenyFloor,
+  matchesCatastrophicPattern,
+} from '../../src/auto-approve/deny-floor.ts';
 
 const bash = (command: string) => ({ command });
 
@@ -116,5 +120,39 @@ describe('matchesCatastrophicPattern — still reachable from its new home', () 
     // The exact discrimination the whole guard rests on: this is destructive
     // but NOT catastrophic, so it must escalate rather than deny.
     expect(matchesCatastrophicPattern('Bash', bash('rm -rf dist'))).toBeNull();
+  });
+});
+
+describe('buildDenyMessage (#976)', () => {
+  test('offers TWO exits, in order: another approach, then ask the user', () => {
+    const m = buildDenyMessage('rm -rf / matched the deny floor');
+    // Order matters. A message that led with "ask the user" would push Claude to
+    // interrupt even when a safe equivalent existed.
+    const alt = m.indexOf('different approach');
+    const ask = m.indexOf('ask the user');
+    expect(alt).toBeGreaterThan(-1);
+    expect(ask).toBeGreaterThan(-1);
+    expect(alt).toBeLessThan(ask);
+  });
+
+  test('carries the reason so the denial is actionable rather than a bare refusal', () => {
+    expect(buildDenyMessage('matched DENY FLOOR pattern "sudo rm"')).toContain(
+      'matched DENY FLOOR pattern "sudo rm"',
+    );
+  });
+
+  test('omits the reason clause entirely when there is no reasoning', () => {
+    for (const empty of [undefined, '', '   ']) {
+      const m = buildDenyMessage(empty);
+      expect(m).not.toContain('Reason:');
+      // Still tells Claude what to do — the exits are the load-bearing half.
+      expect(m).toContain('ask the user');
+    }
+  });
+
+  test('bounds a long reason: this rides a blocking-path hook response', () => {
+    const m = buildDenyMessage('x'.repeat(5000));
+    expect(m.length).toBeLessThan(700);
+    expect(m).toContain('…');
   });
 });

--- a/packages/daemon/tests/hooks/hook-server.test.ts
+++ b/packages/daemon/tests/hooks/hook-server.test.ts
@@ -582,6 +582,42 @@ describe('HookServer', () => {
       });
     });
 
+    it('#976: serializes a reasoned deny as decision.{behavior,message} on the wire', async () => {
+      // The exact envelope the official hooks reference defines for
+      // PermissionRequest: `message` lives INSIDE `decision`, alongside
+      // `behavior` — not as a top-level `reason`, and not as PreToolUse's
+      // `permissionDecisionReason` (a different event's field).
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => ({
+        behavior: 'deny' as const,
+        message: 'no authorization; ask the user',
+      }));
+      server.start();
+      const res = await postPermission(port);
+      expect(await res.json()).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'PermissionRequest',
+          decision: { behavior: 'deny', message: 'no authorization; ask the user' },
+        },
+      });
+    });
+
+    it('#976: a reasoned deny omits `interrupt` unless asked, so the turn continues', async () => {
+      // `interrupt: true` STOPS Claude. Leaving it unset is what lets Claude act
+      // on the message (route around, or ask the user). An accidental `true`
+      // here would silently kill the turn instead.
+      server = new HookServer({ port });
+      server.setPermissionResolver(async () => ({
+        behavior: 'deny' as const,
+        message: 'why',
+      }));
+      server.start();
+      const body = (await (await postPermission(port)).json()) as {
+        hookSpecificOutput: { decision: Record<string, unknown> };
+      };
+      expect('interrupt' in body.hookSpecificOutput.decision).toBe(false);
+    });
+
     it('returns the object decision verbatim, echoing updatedPermissions (#718)', async () => {
       const updatedPermissions = [
         {


### PR DESCRIPTION
Part of #976. First shipping piece of the authorization work, and useful on its
own today.

## What was wrong

The hook response carried a bare `{behavior:"deny"}`. Claude learned only that
it was refused, never why — so its options were to guess at an alternative or
give up. Every auto-approve denial looked identical to it.

## What changed

`PermissionDecision` gains the variant the official hooks reference defines for
PermissionRequest:

```ts
| { readonly behavior: 'deny'; readonly message?: string; readonly interrupt?: boolean }
```

From the reference's decision-control table, verbatim:

> `message` — For `"deny"` only: tells Claude why the permission was denied
> `interrupt` — For `"deny"` only: if `true`, stops Claude

So `message` is **model-directed**, not terminal UI — PreToolUse's
`permissionDecisionReason` is the field that splits those audiences; this event
has no user-facing variant at all. With `interrupt` unset the turn continues, so
the reason is actionable rather than a postscript.

Both gate deny sites (primary verdict and second-opinion) now build a message
from the verdict's own reasoning.

**The serializer needed no change** — `permissionDecisionResponse` already passes
an object decision through verbatim into `hookSpecificOutput.decision`. Only the
type was too narrow, which is why this was never possible before.

## The message design

> Remi's auto-approve did not have authorization to approve this operation.
> Reason: <the verdict's reasoning>. Either use a different approach that does
> not require it, or ask the user to authorize this explicitly before retrying.

Two exits, and the ORDER is load-bearing: a message leading with "ask the user"
pushes Claude to interrupt even when a safe equivalent exists. Asserted by test,
not just intended.

The second exit is what closes the #976 loop: the user's answer arrives via
`UserPromptSubmit` as genuine EXPLICIT authorization from a channel text cannot
forge — the only route above `implicit` under the ADR 0015 amendment.

## The limit, stated so nobody builds past it

The docs guarantee Claude is not stopped and has been told why. They do **not**
say it will then ask the user. That is an expectation to verify by observation,
never a contract, and nothing here or in the code comments claims otherwise.

## Testing

- Full suite: **4561 pass, 0 fail**.
- Wire-shape tests in `hook-server.test.ts`: the exact
  `hookSpecificOutput.decision.{behavior,message}` envelope (nested inside
  `decision`, NOT a top-level `reason`, NOT `permissionDecisionReason`), plus one
  asserting `interrupt` is omitted unless asked — an accidental `true` there
  would silently kill the turn.
- `buildDenyMessage` tests: two exits present and correctly ORDERED, reason
  carried through, reason clause omitted entirely when there is no reasoning, and
  a long reason bounded (this rides a blocking-path response).
- Four existing gate assertions updated from `toBe('deny')` to the reasoned
  shape — they caught the change, which is them doing their job.

## Note on a flaky failure seen mid-run

One full-suite run showed `live-sessions-watcher.test.ts > watcher re-arms after
a transient error` failing at exactly 5000.55ms. Zero overlap with this diff;
6/6 pass in isolation across three consecutive runs; full re-run 4561/0. Third
instance of the same shape in this repo (with `shell-path` and `session-events`)
— all timeouts at bun's default 5000ms in tests waiting on real I/O under
full-suite contention.