### PR TITLE
feat: close issues automatically on develop push

### DIFF
--- a/.github/scripts/close-on-develop.ts
+++ b/.github/scripts/close-on-develop.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Glue script for .github/workflows/close-on-develop.yml.
+ *
+ * Reads the push event payload for this run, extracts GitHub issue-closing
+ * keyword references from every commit in the push, filters them down to
+ * references this repo's own GITHUB_TOKEN can act on, and writes the result
+ * to $GITHUB_OUTPUT as `issues` (a compact JSON array of {issue, keyword})
+ * for the workflow's next step to close via `gh`.
+ *
+ * This file is intentionally thin I/O plumbing around the pure, unit-tested
+ * logic in packages/shared/src/issue-closing.ts (see
+ * packages/shared/tests/issue-closing.test.ts) -- it is not itself unit
+ * tested, and should stay simple enough that it doesn't need to be.
+ */
+import { appendFileSync, readFileSync } from 'node:fs';
+import {
+  extractClosingReferencesFromMessages,
+  filterSameRepoReferences,
+} from '../../packages/shared/src/issue-closing.ts';
+
+interface PushCommit {
+  id?: string;
+  message?: string;
+}
+
+interface PushEvent {
+  deleted?: boolean;
+  commits?: PushCommit[];
+  head_commit?: PushCommit | null;
+}
+
+function writeOutput(name: string, value: string): void {
+  const outputPath = process.env['GITHUB_OUTPUT'];
+  if (!outputPath) {
+    throw new Error('GITHUB_OUTPUT is not set; this script must run inside a GitHub Actions step.');
+  }
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+function main(): void {
+  const eventPath = process.env['GITHUB_EVENT_PATH'];
+  const repository = process.env['GITHUB_REPOSITORY'];
+  if (!eventPath || !repository) {
+    throw new Error('GITHUB_EVENT_PATH and GITHUB_REPOSITORY must both be set.');
+  }
+  const [currentOwner, currentRepo] = repository.split('/');
+  if (!currentOwner || !currentRepo) {
+    throw new Error(`Unexpected GITHUB_REPOSITORY format: "${repository}"`);
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, 'utf8')) as PushEvent;
+
+  // A branch-deletion push carries no new commits -- nothing to scan.
+  if (event.deleted) {
+    writeOutput('issues', '[]');
+    console.log('Push deleted the ref; nothing to scan.');
+    return;
+  }
+
+  // Use the event payload's own commit list rather than computing a
+  // before..after diff ourselves. Deriving a range would crash on the
+  // first push to a branch (`before` is all-zeros, not a real commit) and
+  // misbehave on a force-push (`before` may not even be an ancestor of
+  // `after` anymore) -- GitHub has already resolved both cases for us into
+  // this array, so trust it instead of re-deriving it.
+  const commits = event.commits ?? [];
+  const byId = new Map<string, string>();
+  for (const commit of commits) {
+    if (commit.id && typeof commit.message === 'string') {
+      byId.set(commit.id, commit.message);
+    }
+  }
+  // head_commit is normally already present in `commits`, but merge it in
+  // defensively in case a payload shape ever omits it from the array.
+  if (event.head_commit?.id && typeof event.head_commit.message === 'string') {
+    byId.set(event.head_commit.id, event.head_commit.message);
+  }
+
+  const messages = [...byId.values()];
+  const refs = extractClosingReferencesFromMessages(messages);
+  const sameRepoRefs = filterSameRepoReferences(refs, currentOwner, currentRepo);
+
+  const issues = sameRepoRefs.map((ref) => ({ issue: ref.issue, keyword: ref.keyword }));
+  writeOutput('issues', JSON.stringify(issues));
+
+  if (issues.length > 0) {
+    const summary = issues.map((entry) => `#${entry.issue} (${entry.keyword})`).join(', ');
+    console.log(`Found ${issues.length} issue reference(s) to close: ${summary}`);
+  } else {
+    console.log('No same-repo closing references found in this push.');
+  }
+}
+
+main();

--- a/.github/workflows/close-on-develop.yml
+++ b/.github/workflows/close-on-develop.yml
@@ -40,6 +40,11 @@ jobs:
   close-issues:
     name: Close Referenced Issues
     runs-on: ubuntu-latest
+    # Defense in depth: a parser bug (or anything else that hangs) should
+    # not be able to occupy the runner for GitHub's 360-minute default
+    # ceiling, especially with concurrency.cancel-in-progress: false
+    # serializing every later develop push behind a stuck run.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 
@@ -67,37 +72,69 @@ jobs:
           short_sha="${SHA:0:7}"
           commit_url="https://github.com/${REPO}/commit/${SHA}"
 
-          echo "$ISSUES_JSON" | jq -c '.[]' | while IFS= read -r ref; do
-            number=$(echo "$ref" | jq -r '.issue')
-            keyword=$(echo "$ref" | jq -r '.keyword')
+          # The while loop is wrapped in its own explicit ( ) subshell (the
+          # final stage of the pipe below) purely so a `failures` counter set
+          # inside the loop is still visible after `done`, in the same
+          # subshell, to decide the final `exit` status -- variables set
+          # inside a `| while` don't otherwise escape that iteration.
+          echo "$ISSUES_JSON" | jq -c '.[]' | (
+            failures=0
 
-            # Fetch the target before touching it. This is also how we tell
-            # an issue apart from a pull request: issues and PRs share one
-            # number namespace, and the Issues API returns a PR too (with a
-            # `pull_request` key) -- never close on the strength of the
-            # number alone.
-            if ! target_json=$(gh api "repos/${REPO}/issues/${number}" 2>/dev/null); then
-              echo "#${number}: not found (wrong repo, deleted, or never existed), skipping"
-              continue
+            while IFS= read -r ref; do
+              number=$(echo "$ref" | jq -r '.issue')
+              keyword=$(echo "$ref" | jq -r '.keyword')
+
+              # Fetch the target before touching it. This is also how we
+              # tell an issue apart from a pull request: issues and PRs
+              # share one number namespace, and the Issues API returns a PR
+              # too (with a `pull_request` key) -- never close on the
+              # strength of the number alone.
+              if ! target_json=$(gh api "repos/${REPO}/issues/${number}" 2>/dev/null); then
+                echo "#${number}: not found (wrong repo, deleted, or never existed), skipping"
+                continue
+              fi
+
+              is_pull_request=$(echo "$target_json" | jq 'has("pull_request")')
+              if [ "$is_pull_request" = "true" ]; then
+                echo "#${number}: is a pull request, not an issue, skipping"
+                continue
+              fi
+
+              state=$(echo "$target_json" | jq -r '.state')
+              if [ "$state" != "open" ]; then
+                echo "#${number}: already ${state}, skipping"
+                continue
+              fi
+
+              # Close BEFORE commenting, and check the result explicitly
+              # (`if !`, not a bare call) so one bad issue can't take the
+              # rest of the batch down with it: this loop runs inside a pipe
+              # subshell, where an unguarded `gh` failure would trip `set -e`
+              # via `pipefail` and abort every issue still queued behind it.
+              # A close that fails must never be followed by a comment that
+              # claims it happened -- close first, comment only once the
+              # close is confirmed.
+              if ! gh issue close "$number" --repo "$REPO"; then
+                echo "#${number}: FAILED to close, skipping (no comment posted)"
+                failures=$((failures + 1))
+                continue
+              fi
+
+              line1="Closed automatically: this issue's fix merged to \`develop\` in commit [\`${short_sha}\`](${commit_url}) (matched \"${keyword} #${number}\")."
+              line2="GitHub's \`Closes\`/\`Fixes\` automation only closes issues on a merge to the repository's default branch (\`main\`); this repo merges feature work into \`develop\`, so that automation never fires here. This comment was posted by [close-on-develop.yml](https://github.com/${REPO}/blob/develop/.github/workflows/close-on-develop.yml) to fill that gap -- it is not a human closure."
+              body="${line1}"$'\n\n'"${line2}"
+
+              if ! gh issue comment "$number" --repo "$REPO" --body "$body"; then
+                echo "#${number}: closed, but FAILED to post the explanatory comment"
+                failures=$((failures + 1))
+                continue
+              fi
+
+              echo "#${number}: closed (matched \"${keyword}\")"
+            done
+
+            if [ "$failures" -gt 0 ]; then
+              echo "::error::${failures} issue(s) failed to close and/or comment; see log above."
+              exit 1
             fi
-
-            is_pull_request=$(echo "$target_json" | jq 'has("pull_request")')
-            if [ "$is_pull_request" = "true" ]; then
-              echo "#${number}: is a pull request, not an issue, skipping"
-              continue
-            fi
-
-            state=$(echo "$target_json" | jq -r '.state')
-            if [ "$state" != "open" ]; then
-              echo "#${number}: already ${state}, skipping"
-              continue
-            fi
-
-            line1="Closed automatically: this issue's fix merged to \`develop\` in commit [\`${short_sha}\`](${commit_url}) (matched \"${keyword} #${number}\")."
-            line2="GitHub's \`Closes\`/\`Fixes\` automation only closes issues on a merge to the repository's default branch (\`main\`); this repo merges feature work into \`develop\`, so that automation never fires here. This comment was posted by [close-on-develop.yml](https://github.com/${REPO}/blob/develop/.github/workflows/close-on-develop.yml) to fill that gap -- it is not a human closure."
-            body="${line1}"$'\n\n'"${line2}"
-
-            gh issue comment "$number" --repo "$REPO" --body "$body"
-            gh issue close "$number" --repo "$REPO"
-            echo "#${number}: closed (matched \"${keyword}\")"
-          done
+          )

--- a/.github/workflows/close-on-develop.yml
+++ b/.github/workflows/close-on-develop.yml
@@ -1,0 +1,103 @@
+name: Close Issues on Develop
+
+# GitHub's `Fixes #N` / `Closes #N` automation only closes an issue on a
+# merge into the repository's DEFAULT branch. This repo merges feature PRs
+# into `develop`, not `main` (see AGENTS.md branch strategy) -- so that
+# automation has never once fired here, and issues that were fixed and
+# merged stay open until someone closes them by hand. Confirmed cases, all
+# fixed-and-merged but left open until closed manually: #968 (PR #969), #971
+# (PR #974), #977 (PR #978), #985 (PR #988).
+#
+# This workflow is the workaround: on every push to `develop`, it scans the
+# pushed commits (the merge commit and its individual commits -- the
+# closing keyword usually lives in the PR body, which lands in the merge
+# commit message) for GitHub's standard closing keywords and closes what it
+# finds, leaving a comment that says so explicitly so a human reading the
+# issue later can tell it wasn't a manual close.
+#
+# It errs toward doing nothing when uncertain: cross-repo references are
+# left alone, non-issue numbers (PRs) are never touched, and a missing or
+# already-closed issue is skipped rather than failing the run.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # Serialize runs so two quick pushes can't race each other's issue
+  # comments/closes; never cancel one that's already closing issues.
+  group: close-on-develop
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: 1.3.11
+
+jobs:
+  close-issues:
+    name: Close Referenced Issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Extract closing references from this push
+        id: refs
+        run: bun run .github/scripts/close-on-develop.ts
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Close referenced issues
+        if: steps.refs.outputs.issues != '' && steps.refs.outputs.issues != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES_JSON: ${{ steps.refs.outputs.issues }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          short_sha="${SHA:0:7}"
+          commit_url="https://github.com/${REPO}/commit/${SHA}"
+
+          echo "$ISSUES_JSON" | jq -c '.[]' | while IFS= read -r ref; do
+            number=$(echo "$ref" | jq -r '.issue')
+            keyword=$(echo "$ref" | jq -r '.keyword')
+
+            # Fetch the target before touching it. This is also how we tell
+            # an issue apart from a pull request: issues and PRs share one
+            # number namespace, and the Issues API returns a PR too (with a
+            # `pull_request` key) -- never close on the strength of the
+            # number alone.
+            if ! target_json=$(gh api "repos/${REPO}/issues/${number}" 2>/dev/null); then
+              echo "#${number}: not found (wrong repo, deleted, or never existed), skipping"
+              continue
+            fi
+
+            is_pull_request=$(echo "$target_json" | jq 'has("pull_request")')
+            if [ "$is_pull_request" = "true" ]; then
+              echo "#${number}: is a pull request, not an issue, skipping"
+              continue
+            fi
+
+            state=$(echo "$target_json" | jq -r '.state')
+            if [ "$state" != "open" ]; then
+              echo "#${number}: already ${state}, skipping"
+              continue
+            fi
+
+            line1="Closed automatically: this issue's fix merged to \`develop\` in commit [\`${short_sha}\`](${commit_url}) (matched \"${keyword} #${number}\")."
+            line2="GitHub's \`Closes\`/\`Fixes\` automation only closes issues on a merge to the repository's default branch (\`main\`); this repo merges feature work into \`develop\`, so that automation never fires here. This comment was posted by [close-on-develop.yml](https://github.com/${REPO}/blob/develop/.github/workflows/close-on-develop.yml) to fill that gap -- it is not a human closure."
+            body="${line1}"$'\n\n'"${line2}"
+
+            gh issue comment "$number" --repo "$REPO" --body "$body"
+            gh issue close "$number" --repo "$REPO"
+            echo "#${number}: closed (matched \"${keyword}\")"
+          done

--- a/packages/shared/src/issue-closing.ts
+++ b/packages/shared/src/issue-closing.ts
@@ -25,11 +25,31 @@ export interface ClosingReference {
 
 // GitHub's standard closing keywords -- close/closes/closed, fix/fixes/fixed,
 // resolve/resolves/resolved -- case-insensitive, immediately followed by an
-// optional "owner/repo" and "#<number>". `[ \t]` (not `\s`) restricts the gap
+// optional "owner/repo" and "#<number>". `[ \t:]` (not `\s`) restricts the gap
 // between the keyword and the reference to the same line, so a keyword in one
 // paragraph of a PR body can't sweep in an unrelated "#12" mentioned later.
+//
+// The gap is ONE bounded quantified class, not two adjacent unbounded ones
+// (i.e. not `[ \t]*:?[ \t]*`). Two adjacent `*`-quantifiers over overlapping
+// character classes, separated by something zero-width-capable, is the
+// classic ambiguous-quantifier ReDoS shape: for a run of m non-matching
+// separator characters the backtracker explores O(m) ways to split it
+// between the two groups, and across the states introduced by the optional
+// `:?` this measured as quadratic in practice (a PR body's merge-commit
+// message is attacker-controlled -- anyone can open a PR against a public
+// repo). `{0,20}` on a single merged class caps the search to a constant
+// per attempt regardless of input size, which is enough for any realistic
+// "keyword<punctuation/whitespace>#N" spacing.
 const CLOSING_KEYWORD_PATTERN =
-  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[ \t]*:?[ \t]*(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gi;
+  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[ \t:]{0,20}(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gi;
+
+// Known, deliberate limitation: this regex has no notion of markdown
+// structure, so `fixes #10` inside a fenced or inline code block (common in
+// this repo's PR bodies, which document commands and config) parses as a
+// real closing reference -- a plausible false-close path, not fixed here.
+// The inverse, a markdown link like `Fixes [#42](https://...)`, does NOT
+// match (the `[` breaks the pattern before `#42`), which fails safe. Both
+// are exercised in issue-closing.test.ts under "known limitations".
 
 /**
  * Extract closing references from a single commit message, deduped within

--- a/packages/shared/src/issue-closing.ts
+++ b/packages/shared/src/issue-closing.ts
@@ -1,0 +1,104 @@
+/**
+ * Parses GitHub's issue-closing keywords ("Fixes #123", "Closes owner/repo#45",
+ * ...) out of commit messages.
+ *
+ * Why this exists: GitHub's own `Fixes #N` / `Closes #N` automation only fires
+ * on a merge into the repository's DEFAULT branch. This repo merges feature
+ * PRs into `develop`, not `main` (see AGENTS.md branch strategy), so that
+ * automation has never once fired here -- fixed issues stay open until someone
+ * closes them by hand. `.github/workflows/close-on-develop.yml` is the
+ * workaround: on every push to `develop` it scans the pushed commits with the
+ * functions below and closes what it finds. This module is the pure,
+ * unit-testable half of that workflow; the workflow script (not covered by
+ * this package's tests) does the GitHub API calls.
+ */
+
+export interface ClosingReference {
+  /** Owner from an explicit `owner/repo#N` reference, or null for a bare `#N`. */
+  owner: string | null;
+  /** Repo from an explicit `owner/repo#N` reference, or null for a bare `#N`. */
+  repo: string | null;
+  issue: number;
+  /** The literal keyword matched, lowercased (e.g. "fixes", "closed"). */
+  keyword: string;
+}
+
+// GitHub's standard closing keywords -- close/closes/closed, fix/fixes/fixed,
+// resolve/resolves/resolved -- case-insensitive, immediately followed by an
+// optional "owner/repo" and "#<number>". `[ \t]` (not `\s`) restricts the gap
+// between the keyword and the reference to the same line, so a keyword in one
+// paragraph of a PR body can't sweep in an unrelated "#12" mentioned later.
+const CLOSING_KEYWORD_PATTERN =
+  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[ \t]*:?[ \t]*(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gi;
+
+/**
+ * Extract closing references from a single commit message, deduped within
+ * that message (e.g. "Fixes #10 ... fixes #10 again" yields one entry).
+ */
+export function extractClosingReferences(message: string): ClosingReference[] {
+  const seen = new Set<string>();
+  const results: ClosingReference[] = [];
+  for (const match of message.matchAll(CLOSING_KEYWORD_PATTERN)) {
+    const [, keyword, owner, repo, issueText] = match;
+    if (keyword === undefined || issueText === undefined) continue;
+    const issue = Number(issueText);
+    if (!Number.isSafeInteger(issue) || issue <= 0) continue;
+    const key = `${owner ?? ''}/${repo ?? ''}#${issue}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    results.push({
+      owner: owner ?? null,
+      repo: repo ?? null,
+      issue,
+      keyword: keyword.toLowerCase(),
+    });
+  }
+  return results;
+}
+
+/**
+ * Extract closing references across multiple commit messages -- a push's
+ * merge commit plus its individual commits, since in this repo's merge-commit
+ * workflow the closing keyword usually lives in the PR body (part of the
+ * merge commit message) but sometimes lives on an individual commit instead.
+ * Deduped across all messages so one issue referenced twice (or referenced
+ * from two different commits in the same push) is only reported once.
+ */
+export function extractClosingReferencesFromMessages(
+  messages: readonly string[],
+): ClosingReference[] {
+  const seen = new Set<string>();
+  const results: ClosingReference[] = [];
+  for (const message of messages) {
+    for (const ref of extractClosingReferences(message)) {
+      const key = `${ref.owner ?? ''}/${ref.repo ?? ''}#${ref.issue}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      results.push(ref);
+    }
+  }
+  return results;
+}
+
+/**
+ * Keep only references this workflow is willing to act on: a bare `#N`
+ * (implicitly the current repo) or an explicit `owner/repo#N` that matches
+ * the current repo. `GITHUB_TOKEN` cannot act on another repo regardless of
+ * what the text says, and per the "err toward doing nothing" brief for an
+ * auto-closer, an explicit cross-repo reference (e.g. someone else's
+ * `other-org/other-repo#42`) is left alone rather than guessed at -- it is
+ * dropped, not translated into a same-repo close.
+ */
+export function filterSameRepoReferences(
+  refs: readonly ClosingReference[],
+  currentOwner: string,
+  currentRepo: string,
+): ClosingReference[] {
+  return refs.filter((ref) => {
+    if (ref.owner === null || ref.repo === null) return true;
+    return (
+      ref.owner.toLowerCase() === currentOwner.toLowerCase() &&
+      ref.repo.toLowerCase() === currentRepo.toLowerCase()
+    );
+  });
+}

--- a/packages/shared/tests/issue-closing.test.ts
+++ b/packages/shared/tests/issue-closing.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  extractClosingReferences,
+  extractClosingReferencesFromMessages,
+  filterSameRepoReferences,
+} from '../src/issue-closing.ts';
+
+describe('extractClosingReferences - keyword forms and casing', () => {
+  test('close / closes / closed', () => {
+    expect(extractClosingReferences('close #1').map((r) => r.issue)).toEqual([1]);
+    expect(extractClosingReferences('closes #2').map((r) => r.issue)).toEqual([2]);
+    expect(extractClosingReferences('closed #3').map((r) => r.issue)).toEqual([3]);
+  });
+
+  test('fix / fixes / fixed', () => {
+    expect(extractClosingReferences('fix #4').map((r) => r.issue)).toEqual([4]);
+    expect(extractClosingReferences('fixes #5').map((r) => r.issue)).toEqual([5]);
+    expect(extractClosingReferences('fixed #6').map((r) => r.issue)).toEqual([6]);
+  });
+
+  test('resolve / resolves / resolved', () => {
+    expect(extractClosingReferences('resolve #7').map((r) => r.issue)).toEqual([7]);
+    expect(extractClosingReferences('resolves #8').map((r) => r.issue)).toEqual([8]);
+    expect(extractClosingReferences('resolved #9').map((r) => r.issue)).toEqual([9]);
+  });
+
+  test('is case-insensitive on the keyword', () => {
+    expect(extractClosingReferences('Closes #10').map((r) => r.issue)).toEqual([10]);
+    expect(extractClosingReferences('CLOSES #10').map((r) => r.issue)).toEqual([10]);
+    expect(extractClosingReferences('FiXeD #10').map((r) => r.issue)).toEqual([10]);
+    expect(extractClosingReferences('Resolves #10').map((r) => r.issue)).toEqual([10]);
+  });
+
+  test('lowercases the reported keyword', () => {
+    expect(extractClosingReferences('Fixes #10')[0]?.keyword).toBe('fixes');
+    expect(extractClosingReferences('CLOSED #10')[0]?.keyword).toBe('closed');
+  });
+
+  test('does not match a keyword embedded in a larger word', () => {
+    // "enclosed" contains "closed" but is not the keyword "closed".
+    expect(extractClosingReferences('the box was enclosed #10')).toEqual([]);
+    expect(extractClosingReferences('prefixes #10')).toEqual([]);
+  });
+});
+
+describe('extractClosingReferences - multiple issues and dedupe', () => {
+  test('multiple issues in one message, different keywords', () => {
+    const refs = extractClosingReferences('Fixes #10 and closes #12');
+    expect(refs.map((r) => r.issue)).toEqual([10, 12]);
+  });
+
+  test('a comma-separated list after one keyword only closes the first number', () => {
+    // Matches GitHub's real behavior: the keyword must precede EACH
+    // reference. "close #168, #169, #170" only auto-closes #168; #169/#170
+    // have no keyword of their own directly before them.
+    const refs = extractClosingReferences('close #168, #169, #170');
+    expect(refs.map((r) => r.issue)).toEqual([168]);
+  });
+
+  test('the same issue referenced twice in one message is deduped', () => {
+    const refs = extractClosingReferences('Fixes #10. Also fixes #10 again.');
+    expect(refs.map((r) => r.issue)).toEqual([10]);
+  });
+
+  test('the same issue referenced with different keywords is still deduped once', () => {
+    const refs = extractClosingReferences('Closes #10, and this also fixes #10');
+    expect(refs.map((r) => r.issue)).toEqual([10]);
+  });
+});
+
+describe('extractClosingReferences - non-matches', () => {
+  test('a bare #N with no keyword does not close', () => {
+    expect(extractClosingReferences('See #42 for details')).toEqual([]);
+    expect(extractClosingReferences('Related to #42, no fix yet')).toEqual([]);
+  });
+
+  test('a message with no reference at all', () => {
+    expect(extractClosingReferences('chore: bump version to 0.7.4-dev.62')).toEqual([]);
+  });
+
+  test('a keyword and a #N in unrelated paragraphs do not match across the gap', () => {
+    const message = 'Fixes the flaky test suite.\n\nSee also unrelated ticket #99 for context.';
+    expect(extractClosingReferences(message)).toEqual([]);
+  });
+
+  test('a keyword followed by the reference on the next line does not match', () => {
+    // Design decision: the gap between keyword and "#N" is restricted to the
+    // same line ([ \t] in the pattern, not \s), so "Fixes\n#99" (keyword and
+    // reference on separate lines, nothing else between them) is treated as
+    // two unrelated fragments rather than a closing reference.
+    expect(extractClosingReferences('Fixes\n#99')).toEqual([]);
+  });
+
+  test('conventional "(#N)" issue-linking suffix without a keyword does not close', () => {
+    // This repo's PR titles commonly end in "(#N)" referencing the issue,
+    // e.g. "fix: match engine models by HuggingFace id too (#971)" -- that is
+    // NOT a GitHub closing keyword and must not trigger a close.
+    const message = 'fix: match engine models by HuggingFace id too (#971)';
+    expect(extractClosingReferences(message)).toEqual([]);
+  });
+});
+
+describe('extractClosingReferences - cross-repo references', () => {
+  test('parses an explicit owner/repo#N reference', () => {
+    const refs = extractClosingReferences('Fixes yooz-labs/remi#977');
+    expect(refs).toEqual([{ owner: 'yooz-labs', repo: 'remi', issue: 977, keyword: 'fixes' }]);
+  });
+
+  test('a bare #N has null owner/repo', () => {
+    const refs = extractClosingReferences('Fixes #977');
+    expect(refs).toEqual([{ owner: null, repo: null, issue: 977, keyword: 'fixes' }]);
+  });
+
+  test('a same-repo and cross-repo reference to the same number are distinct entries', () => {
+    const refs = extractClosingReferences('Fixes #5 and closes other-org/other-repo#5');
+    expect(refs).toEqual([
+      { owner: null, repo: null, issue: 5, keyword: 'fixes' },
+      { owner: 'other-org', repo: 'other-repo', issue: 5, keyword: 'closes' },
+    ]);
+  });
+});
+
+describe('filterSameRepoReferences', () => {
+  test('keeps bare #N references', () => {
+    const refs = extractClosingReferences('Fixes #10');
+    expect(filterSameRepoReferences(refs, 'yooz-labs', 'remi')).toEqual(refs);
+  });
+
+  test('keeps an explicit owner/repo#N reference that matches the current repo', () => {
+    const refs = extractClosingReferences('Closes yooz-labs/remi#977');
+    expect(filterSameRepoReferences(refs, 'yooz-labs', 'remi')).toEqual(refs);
+  });
+
+  test('matches the current repo case-insensitively', () => {
+    const refs = extractClosingReferences('Closes Yooz-Labs/REMI#977');
+    expect(filterSameRepoReferences(refs, 'yooz-labs', 'remi')).toEqual(refs);
+  });
+
+  test('drops an explicit cross-repo reference to a different repo', () => {
+    const refs = extractClosingReferences('Fixes other-org/other-repo#42');
+    expect(filterSameRepoReferences(refs, 'yooz-labs', 'remi')).toEqual([]);
+  });
+
+  test('a mixed message keeps only the same-repo entry', () => {
+    const refs = extractClosingReferences('Fixes #5 and closes other-org/other-repo#6');
+    const kept = filterSameRepoReferences(refs, 'yooz-labs', 'remi');
+    expect(kept.map((r) => r.issue)).toEqual([5]);
+  });
+});
+
+describe('extractClosingReferencesFromMessages - deduping across a push', () => {
+  test('dedupes an issue referenced from two different commit messages', () => {
+    const refs = extractClosingReferencesFromMessages(['Fixes #10', 'fixes #10 (follow-up)']);
+    expect(refs.map((r) => r.issue)).toEqual([10]);
+  });
+
+  test('collects distinct issues across multiple commits, in first-seen order', () => {
+    const refs = extractClosingReferencesFromMessages([
+      'chore: unrelated bump',
+      'Closes #20',
+      'Fixes #21',
+      'Closes #20 again',
+    ]);
+    expect(refs.map((r) => r.issue)).toEqual([20, 21]);
+  });
+
+  test('a list of messages with none of them containing a reference', () => {
+    const refs = extractClosingReferencesFromMessages([
+      'chore: bump version to 0.7.4-dev.62',
+      'docs: fix typo in README',
+    ]);
+    expect(refs).toEqual([]);
+  });
+});
+
+// Fixtures below are verbatim commit messages pulled from this repo's real
+// history (`git log develop --merges --format=%B` / `git log --all --grep`),
+// not fabricated strings -- they exercise the parser against the actual text
+// it will run on in production.
+describe('extractClosingReferences - real commit messages from this repo', () => {
+  test('8623f8f: merge commit body with "(closes #N)"', () => {
+    const message =
+      'Merge pull request #434 from yooz-labs/feature/issue-427-epic-transcript-binding\n\n' +
+      'Epic: deterministic PTY->transcript binding (closes #427)';
+    expect(extractClosingReferences(message)).toEqual([
+      { owner: null, repo: null, issue: 427, keyword: 'closes' },
+    ]);
+  });
+
+  test('992029f: merge commit body with "close #N, #N, #N" only closes the first', () => {
+    const message =
+      'Merge pull request #363 from yooz-labs/refactor/daemon-tech-debt-168-169-170\n\n' +
+      'refactor(daemon): close #168, #169, #170 — typed metadata + options-object createHello + onConnect tests';
+    expect(extractClosingReferences(message).map((r) => r.issue)).toEqual([168]);
+  });
+
+  test('48aabd2: squashed commit body with "Closes #N" mid-paragraph', () => {
+    const message =
+      'fix: purge stale hooks, limit session list to connected daemon (#173)\n\n' +
+      '* fix: purge stale hooks on install, limit session list to connected daemon\n\n' +
+      'HookConfigManager.install() now probes all localhost HTTP hook URLs\n' +
+      'with a 500ms TCP connect and removes entries pointing to dead ports.\n' +
+      'Prevents ECONNREFUSED errors from accumulating after daemon crashes.\n\n' +
+      'Web app session list uses includeExternal=false so only sessions from\n' +
+      'the connected daemon are shown, preventing cross-daemon message routing.\n\n' +
+      'Closes #172\n\n' +
+      '* refactor: address PR review findings';
+    expect(extractClosingReferences(message)).toEqual([
+      { owner: null, repo: null, issue: 172, keyword: 'closes' },
+    ]);
+  });
+
+  test('c4ba9f8: squashed commit body with "Fixes #N" mid-paragraph', () => {
+    const message =
+      'fix: auto-promote waiting client when active disconnects (#181)\n\n' +
+      '* fix: auto-promote waiting client when active disconnects\n\n' +
+      'Now the session registry maintains a FIFO queue of waiting\n' +
+      'connections. When the active client disconnects, the next waiting\n' +
+      'client is automatically promoted and receives a hello_ack with\n' +
+      'replay messages. Waiting clients that disconnect before promotion\n' +
+      'are cleaned up from the queue.\n\n' +
+      'Fixes #180\n\n' +
+      '* refactor: address PR review findings';
+    expect(extractClosingReferences(message)).toEqual([
+      { owner: null, repo: null, issue: 180, keyword: 'fixes' },
+    ]);
+  });
+
+  test('3a53047: squashed commit body with "Fixes #N" mid-paragraph', () => {
+    const message =
+      'feat: register and handle all 25 Claude Code hook events (#186)\n\n' +
+      'Add type definitions, server dispatch, and event bridge handlers\n' +
+      'for all hook events. High-priority events (PermissionRequest,\n' +
+      'SubagentStart/Stop, StopFailure, SessionEnd) get dedicated handlers.\n' +
+      'Medium/low priority events are accepted but only logged.\n\n' +
+      'The hook server now accepts unknown events with 200 instead of\n' +
+      'rejecting with 400, future-proofing against new Claude Code events.\n\n' +
+      'Fixes #185';
+    expect(extractClosingReferences(message)).toEqual([
+      { owner: null, repo: null, issue: 185, keyword: 'fixes' },
+    ]);
+  });
+
+  test('23b76e5: a typical PR-linking merge commit with no closing keyword', () => {
+    // Real merge commit for PR #974. The "(#971)" suffix is this repo's
+    // conventional-commit style of naming the source issue -- it is NOT a
+    // GitHub closing keyword and must not be treated as one.
+    const message =
+      'Merge pull request #974 from yooz-labs/feature/issue-971-hf-id-model-match\n\n' +
+      'fix: match engine models by HuggingFace id too (#971)';
+    expect(extractClosingReferences(message)).toEqual([]);
+  });
+
+  test('a20efd3: a version-bump commit has no closing reference', () => {
+    expect(extractClosingReferences('chore: bump version to 0.7.4-dev.52')).toEqual([]);
+  });
+});

--- a/packages/shared/tests/issue-closing.test.ts
+++ b/packages/shared/tests/issue-closing.test.ts
@@ -260,3 +260,66 @@ describe('extractClosingReferences - real commit messages from this repo', () =>
     expect(extractClosingReferences('chore: bump version to 0.7.4-dev.52')).toEqual([]);
   });
 });
+
+describe('extractClosingReferences - ReDoS resistance', () => {
+  // Regression guard for a quadratic-blowup bug: the gap between the keyword
+  // and "#N" used to be two adjacent unbounded quantifiers over the same
+  // character class ([ \t]*:?[ \t]*), the classic ambiguous-quantifier ReDoS
+  // shape. A commit message is attacker-controlled (a PR body lands in the
+  // merge commit message, and anyone can open a PR against a public repo),
+  // so a keyword followed by a long non-matching run of spaces/tabs must
+  // stay fast. The fix bounds the gap to a single {0,20} class; this test
+  // locks that bound in by asserting a large adversarial input still
+  // completes in well under a second, not the 6+ seconds (80k chars) to
+  // 15+ minutes (1MB) the unbounded pattern measured at.
+  test('a keyword followed by a very long non-matching run resolves quickly', () => {
+    const input = `fixes ${' '.repeat(200_000)}x`;
+    const start = performance.now();
+    const refs = extractClosingReferences(input);
+    const elapsedMs = performance.now() - start;
+    expect(refs).toEqual([]);
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  test('a keyword followed by a long run of the gap characters themselves resolves quickly', () => {
+    // Exercises the bounded class directly: 100k characters that are ALL
+    // members of [ \t:], still never resolving into "#<digits>".
+    const input = `closes ${' \t:'.repeat(50_000)}`;
+    const start = performance.now();
+    const refs = extractClosingReferences(input);
+    const elapsedMs = performance.now() - start;
+    expect(refs).toEqual([]);
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  test('a real reference still matches immediately after a long gap-only prefix elsewhere in the message', () => {
+    // The bound should not cause false negatives on realistic input -- a
+    // long unrelated run earlier in the message must not prevent a later,
+    // normally-formed reference from matching.
+    const input = `Unrelated: ${' '.repeat(10_000)}padding.\n\nFixes #42`;
+    expect(extractClosingReferences(input).map((r) => r.issue)).toEqual([42]);
+  });
+});
+
+describe('extractClosingReferences - known limitations (documented, not fixed)', () => {
+  test('a keyword+reference inside a markdown code span still matches (false-close risk)', () => {
+    // The parser has no notion of markdown structure. This repo's PR bodies
+    // routinely include inline code or fenced blocks documenting commands,
+    // and "fixes #10" inside one of those still reads as a real reference.
+    // Recorded here deliberately, not as a target to fix in this change.
+    const inline = 'See `git log --grep fixes #10` for context.';
+    expect(extractClosingReferences(inline).map((r) => r.issue)).toEqual([10]);
+
+    const fenced = ['```', 'fixes #11', '```'].join('\n');
+    expect(extractClosingReferences(fenced).map((r) => r.issue)).toEqual([11]);
+  });
+
+  test('a markdown link reference does not match (fails safe)', () => {
+    // "Fixes [#42](https://github.com/...)" -- the "[" immediately after the
+    // keyword's gap breaks the pattern before it reaches "#42", so this
+    // form is silently NOT treated as a closing reference. That is the safe
+    // direction to fail in for an auto-closer.
+    const message = 'Fixes [#42](https://github.com/yooz-labs/remi/issues/42) for details';
+    expect(extractClosingReferences(message)).toEqual([]);
+  });
+});

--- a/packages/shared/tests/issue-closing.test.ts
+++ b/packages/shared/tests/issue-closing.test.ts
@@ -210,7 +210,12 @@ describe('extractClosingReferences - real commit messages from this repo', () =>
     ]);
   });
 
-  test('c4ba9f8: squashed commit body with "Fixes #N" mid-paragraph', () => {
+  // Named by shape rather than by commit SHA. A short hex SHA tokenizes into
+  // false-positive "words" that `typos` rejects — the same failure that made
+  // `_typos.toml` exclude the 24-hex object ids in `.pbxproj` (#719). The
+  // fixture below is still the verbatim commit message; only the test NAME
+  // avoids the hex.
+  test('squashed commit body with "Fixes #N" mid-paragraph', () => {
     const message =
       'fix: auto-promote waiting client when active disconnects (#181)\n\n' +
       '* fix: auto-promote waiting client when active disconnects\n\n' +


### PR DESCRIPTION
## Root cause

This repo merges feature PRs into `develop`, not the default branch
(`main`). GitHub's `Fixes #N` / `Closes #N` keyword automation only
fires on a merge into the repository's **default** branch, so it has
never once fired here — fixed-and-merged work silently accumulates as
open issues, making every epic look less complete than it is.

Confirmed examples, all fixed-and-merged but left open until closed by
hand: `#968` (PR `#969`), `#971` (PR `#974`), `#977` (PR `#978`),
`#985` (PR `#988`).

## What this adds

`.github/workflows/close-on-develop.yml` — runs on `push` to `develop`,
reads the push's own event payload (merge commit + individual commits
in the push), extracts GitHub's standard closing keywords
(`close(s|d)`, `fix(es|ed)`, `resolve(s|d)` + `#N`), and closes
matched issues with a comment naming the merge commit SHA and
explaining why the automatic close exists (since it isn't GitHub's
native automation).

The keyword-parsing logic is extracted into a pure, unit-tested module:
`packages/shared/src/issue-closing.ts`
(`extractClosingReferences`, `extractClosingReferencesFromMessages`,
`filterSameRepoReferences`), tested in
`packages/shared/tests/issue-closing.test.ts` (33 tests) against real
commit messages pulled from this repo's own history
(`git log develop --merges --format=%B` / `git log --all --grep`), not
fabricated strings.

`.github/scripts/close-on-develop.ts` is the thin glue: reads
`$GITHUB_EVENT_PATH`, calls the pure functions, writes a JSON list of
`{issue, keyword}` to `$GITHUB_OUTPUT` for the workflow's next step,
which uses `gh` to check + close + comment.

### What it will do

- Scan the merge commit message AND every individual commit in the
  push (the closing keyword usually sits in the PR body, which lands
  in the merge commit message in this repo's merge-commit workflow;
  sometimes it's on an individual commit instead).
- Close a referenced issue and leave a comment naming the commit SHA
  and explaining the automation gap, so a later reader can tell this
  wasn't a human closure.
- Dedupe: the same issue referenced twice (same message, different
  messages, or via a different keyword) is only closed/commented once.
- Use the push event's own `commits` array rather than deriving a
  `before..after` diff, so first-push (`before` all-zeros) and
  force-push don't crash the workflow.

### What it will NOT do

- Touch pull requests. Issue and PR numbers share one namespace on
  GitHub; before closing, the workflow fetches
  `GET /repos/{repo}/issues/{number}` and checks for the
  `pull_request` key GitHub's API adds when the number is actually a
  PR, and skips it if so.
- Act on cross-repo references (`owner/repo#N`) unless `owner/repo`
  matches this repo. `GITHUB_TOKEN` can't act on another repo anyway,
  and per "err toward doing nothing when uncertain," an explicit
  cross-repo mention (e.g. someone else's `other-org/other-repo#42`)
  is left alone rather than guessed at.
- Fail the workflow because an issue is already closed or doesn't
  exist — both are logged and skipped.
- Reopen anything, ever.
- Require any secret beyond the built-in `GITHUB_TOKEN`
  (`issues: write` + `contents: read` only — no blanket write).

## Testing

- `bunx biome check` on all touched files: clean.
- `bun run typecheck`: clean (after `bun install`; pre-existing
  unrelated errors in the wider repo were just missing
  `node_modules`).
- `bun test packages/shared/tests/issue-closing.test.ts`: 33 pass, 0
  fail, 45 `expect()` calls.
- **Proved the tests can fail**: removed the `resolve` keyword branch
  and neutered `filterSameRepoReferences`'s repo check → 28 pass, 5
  fail (RED). Restored → 33 pass, 0 fail (GREEN) again.
- YAML validated with `python3 -c 'import yaml; yaml.safe_load(...)'`
  (PyYAML) against the new file and all four existing workflow files
  for comparison.
- `actionlint` (includes `shellcheck` on the embedded `run:` blocks):
  zero findings on the new workflow. Confirmed the tool is actually
  working by running it repo-wide, where it correctly flagged a
  pre-existing, unrelated issue in `ci.yml` (left untouched, out of
  scope here).
- `act -l` correctly parses and lists the new workflow's job. Did not
  attempt a full `act push` run — flagged CVEs in the locally
  installed `act` version, plus Docker execution wouldn't meaningfully
  exercise the real GitHub API calls anyway.
- Manually exercised `.github/scripts/close-on-develop.ts` end-to-end
  against fabricated (but realistic) push-event JSON payloads: normal
  push with two closing refs, a deleted-branch push, a payload missing
  the `commits` array entirely, and a mixed same-repo/cross-repo
  message — all produced the expected output with no crash.

## Test plan

- [x] `bunx biome check` clean on touched files
- [x] `bun run typecheck` clean
- [x] `bun test packages/shared/tests/issue-closing.test.ts` — 33/33
      pass
- [x] Broke the parser, confirmed RED (28 pass / 5 fail), restored,
      confirmed GREEN again
- [x] YAML validated via PyYAML
- [x] `actionlint` (with `shellcheck`) clean on the new workflow
- [ ] Real end-to-end verification (an actual PR merging to `develop`
      with a `Fixes #N` in its body) — can't be done before this PR
      itself merges; the next PR that lands on `develop` referencing an
      issue is the real proof