### PR TITLE
fix: never type an answer into a session with no prompt on screen

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -1266,6 +1266,32 @@ export class QuestionPresenceTracker {
   }
 
   /**
+   * True when the PTY parser's most recent observation is a prompt that has
+   * not been cleared since — "is SOMETHING on screen right now", regardless of
+   * who owns it (#1002).
+   *
+   * Weaker than `isPromptVisibleOnPTY`, and deliberately so. That flag means
+   * "THIS tracker pushed a card off a PTY render", which is true for the
+   * hookless, orphan and parked-render paths and FALSE for the most common
+   * case of all: a gate-owned hook card whose native prompt renders is routed
+   * to `onOrphanPTYPrompt`, recognised as an echo of something already pushed,
+   * and suppressed without ever setting the flag. Verified by probing this
+   * class directly rather than by reading it — `recordPendingHook` followed by
+   * `onOrphanPTYPrompt` leaves `isPromptVisibleOnPTY()` false while a real
+   * prompt is genuinely on screen.
+   *
+   * `observedPTYQuestionId` has no such gap: `onOrphanPTYPrompt` records it
+   * before any branch decides to push, buffer, suppress or arbitrate, and both
+   * `onStatusChange` (away from `waiting`) and `clearPending` null it. So it
+   * answers "is a prompt on screen" for every cohort, which is exactly what a
+   * caller about to type a digit into the PTY needs to know, and all it needs
+   * to know.
+   */
+  isPromptObservedOnPTY(): boolean {
+    return this.observedPTYQuestionId !== null;
+  }
+
+  /**
    * True when `questionId` is BOTH on screen and still the LATEST prompt this
    * tracker observed (#814). The identity half is what `isPromptVisibleOnPTY`
    * cannot express, and it is load-bearing for any ASYNC verdict:

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1944,6 +1944,11 @@ const inputHandlers: InputHandlers = createInputHandlers({
   // current" — fail toward refusing the injection.
   isPromptCurrent: (sessionId, questionId, ptyText) =>
     sessionTrackers.get(sessionId)?.isPromptCurrent(questionId, ptyText) ?? false,
+  // #1002: the weaker "is ANY prompt on screen" backstop, for the hook-paired
+  // cards `isPromptCurrent` structurally cannot serve. Same map, same
+  // no-tracker-means-refuse default.
+  isPromptObservedOnPTY: (sessionId) =>
+    sessionTrackers.get(sessionId)?.isPromptObservedOnPTY() ?? false,
   // #976 prerequisite: route a classified answer to the RIGHT session's
   // precedent store (populated per session in createNewSession, same
   // map-per-sessionId shape as sessionGateHandles/sessionTrackers above). No

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -87,6 +87,42 @@ export interface InputHandlerDeps {
    */
   isPromptCurrent?: (sessionId: UUID, questionId: UUID, ptyText: string) => boolean;
   /**
+   * Weaker companion to `isPromptCurrent`: "is this session rendering ANY
+   * interactive prompt right now?", backed by
+   * `QuestionPresenceTracker.isPromptObservedOnPTY` (#1002).
+   *
+   * NOT backed by that class's `isPromptVisibleOnPTY`, despite the closer
+   * name. That flag means "this tracker pushed a card off a PTY render", which
+   * is false for the most common cohort of all: a gate-owned hook card whose
+   * native prompt renders is recognised as an echo and suppressed without ever
+   * setting it. Probing the real tracker showed `recordPendingHook` +
+   * `onOrphanPTYPrompt` leaving it false while a prompt is genuinely on
+   * screen, so a guard built on it would have refused legitimate answers —
+   * trading a stray-injection bug for a cannot-answer-at-all bug.
+   *
+   * Exists because `isPromptCurrent` cannot serve hook-paired cards at all. A
+   * hook-paired question's `id`/`text` are the HOOK's (tool + command text),
+   * never the raw PTY parse, so its id/text match would fail for that whole
+   * cohort — which is why the #920 guard is scoped to `source === 'pty'` and
+   * why widening it on id/text would refuse legitimate answers rather than fix
+   * anything.
+   *
+   * But the scoping left a real hole: a hook-sourced card whose hold is ALREADY
+   * gone still reached `pty.submitInput` with nothing checked, and typed its
+   * option digit into whatever Claude was doing. Observed live — a bare `1`
+   * landed in an unrelated session as a chat message, recorded in the
+   * transcript as a user entry (#1002).
+   *
+   * Two different questions were being conflated: "is THIS prompt on screen?"
+   * (needs id/text, genuinely impossible for hook-paired cards) and "is ANY
+   * prompt on screen?" (all that is needed before typing a digit, and
+   * perfectly answerable for them). This dep answers the second.
+   *
+   * Absent => treated as NOT visible, the same fail-toward-refusing default
+   * `isPromptCurrent` documents.
+   */
+  isPromptObservedOnPTY?: (sessionId: UUID) => boolean;
+  /**
    * Record a human-classified permission answer into this session's
    * precedent store (#976 prerequisite, `auto-approve/precedent.ts`). Called
    * ONLY for answers `handleAnswer` can classify with confidence as an
@@ -261,6 +297,7 @@ export function createInputHandlers(deps: InputHandlerDeps) {
     cancelAutoApproveForQuestion,
     onQuestionResolved,
     isPromptCurrent,
+    isPromptObservedOnPTY,
     recordPrecedent,
   } = deps;
 
@@ -650,12 +687,27 @@ export function createInputHandlers(deps: InputHandlerDeps) {
         // one injects into a live session with nothing to undo it. Those
         // costs are not symmetric, so ambiguity resolves toward not
         // injecting.
-        if (
-          active.source === 'pty' &&
-          !(isPromptCurrent?.(session.sessionId, questionId, active.text) ?? false)
-        ) {
+        //
+        // #1002 extends the same principle to the cohort the `source: 'pty'`
+        // scoping left uncovered. A hook-sourced card only reaches this line
+        // when NO hold was resolved and NONE was released just now, i.e. this
+        // answer will cause nothing to render — so if no prompt is on screen
+        // already, the digit lands in whatever Claude is doing. That is not
+        // hypothetical: it was observed typing a bare `1` into an unrelated
+        // session, recorded in the transcript as a user message.
+        //
+        // The `!released` condition is what keeps this from refusing the
+        // legitimate case: when the answer itself pops a held hook to
+        // passthrough, Claude is deliberately about to render its native
+        // prompt and the submit is intended, so presence cannot be required
+        // yet.
+        const promptGone =
+          active.source === 'pty'
+            ? !(isPromptCurrent?.(session.sessionId, questionId, active.text) ?? false)
+            : !released && !(isPromptObservedOnPTY?.(session.sessionId) ?? false);
+        if (promptGone) {
           log(
-            `[Answer] refusing PTY submit for ${questionId.slice(0, 8)}: prompt no longer on screen (source=pty)`,
+            `[Answer] refusing PTY submit for ${questionId.slice(0, 8)}: no prompt on screen (source=${active.source})`,
           );
           traceQuestionEvent({
             action: 'stale_answer',
@@ -664,7 +716,10 @@ export function createInputHandlers(deps: InputHandlerDeps) {
             promptId: active.promptId,
             signal: 'STALE_ANSWER',
             callSite: 'input-events.handleAnswer:promptCurrencyGuard',
-            detail: { reason: 'prompt-not-current', source: active.source },
+            detail: {
+              reason: active.source === 'pty' ? 'prompt-not-current' : 'no-prompt-on-screen',
+              source: active.source,
+            },
           });
           removalReason = 'user_answer:stale_prompt';
           if (!viaRelay) {

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -364,3 +364,58 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
   });
 });
+
+/**
+ * #1002. `handleAnswer` needs to know "is a prompt on screen?" before typing a
+ * digit into the PTY. The obvious candidate, `isPromptVisibleOnPTY`, cannot
+ * answer that: it means "this tracker PUSHED a card off a PTY render", which is
+ * false for the most common cohort of all — a gate-owned hook card whose native
+ * prompt renders is recognised as an echo and suppressed without setting it.
+ *
+ * These tests exist because the first attempt at #1002 used that flag and would
+ * have refused every legitimate hook-sourced answer. They pin the distinction so
+ * the two are not "simplified" back together.
+ */
+describe('#1002 prompt-on-screen signals are not interchangeable', () => {
+  test('a gate-owned hook render: visible=false, observed=true', () => {
+    const { tracker } = buildTracker();
+    const hook = makeHookRecord('Allow Bash: ls -la');
+    tracker.recordPendingHook(hook);
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Allow Bash: ls -la'));
+
+    // Suppressed as a gate-owned echo, so it never pushed a card off the render.
+    expect(tracker.isPromptVisibleOnPTY()).toBe(false);
+    // But a prompt IS genuinely on screen, and this reports it.
+    expect(tracker.isPromptObservedOnPTY()).toBe(true);
+  });
+
+  test('observed starts false, before anything has rendered', () => {
+    const { tracker } = buildTracker();
+    expect(tracker.isPromptObservedOnPTY()).toBe(false);
+  });
+
+  test('a status transition off waiting clears observed (the stale-card case)', () => {
+    const { tracker } = buildTracker();
+    tracker.recordPendingHook(makeHookRecord('Allow Bash: ls -la'));
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Allow Bash: ls -la'));
+    expect(tracker.isPromptObservedOnPTY()).toBe(true);
+
+    tracker.onStatusChange('thinking');
+    expect(tracker.isPromptObservedOnPTY()).toBe(false);
+  });
+
+  test('clearPending clears observed', () => {
+    const { tracker } = buildTracker();
+    tracker.recordPendingHook(makeHookRecord('Allow Bash: ls -la'));
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Allow Bash: ls -la'));
+    tracker.clearPending();
+    expect(tracker.isPromptObservedOnPTY()).toBe(false);
+  });
+
+  test('a hookless render sets both signals', () => {
+    const { tracker } = buildTracker();
+    tracker.onPTYPromptVisible(makeHooklessPTYQuestion());
+    expect(tracker.isPromptVisibleOnPTY()).toBe(true);
+    expect(tracker.isPromptObservedOnPTY()).toBe(true);
+  });
+});

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -51,6 +51,16 @@ function fakeMessageAPI(bulletMap: Map<number, string | null>): MessageAPI {
 
 const CID = 'conn0000-0000-0000-0000-000000000000' as UUID;
 const QID = 'ques0000-0000-0000-0000-000000000000' as UUID;
+
+/**
+ * The #1002 guard refuses a PTY submit when no prompt is on screen, and
+ * treats an unwired dep as "no prompt" (fail toward not injecting). Every
+ * test below that exercises the PTY-submit path is describing the ordinary
+ * case where Claude IS showing its prompt, so they say so explicitly rather
+ * than inheriting the refusing default. The refusal itself is covered by its
+ * own tests in the `#1002` block.
+ */
+const PROMPT_ON_SCREEN = { isPromptObservedOnPTY: () => true };
 const REQ = 'req00000-0000-0000-0000-000000000000' as UUID;
 
 describe('createInputHandlers', () => {
@@ -92,7 +102,12 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(CID, sessionId, '\x1b[A', true);
 
       expect(ptyCapture.writes).toEqual(['\x1b[A']);
@@ -110,7 +125,12 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(CID, sessionId, 'hello world', false);
 
       expect(ptyCapture.submits).toEqual(['hello world']);
@@ -120,7 +140,12 @@ describe('createInputHandlers', () => {
     test('logs and returns when no session is attached to the connection', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await handlers.onUserInput(
         CID,
@@ -133,7 +158,12 @@ describe('createInputHandlers', () => {
     });
 
     test('sends SESSION_NOT_FOUND when the session does not exist at all (#662)', async () => {
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const missingSessionId = 'nosn0000-0000-0000-0000-000000000000' as UUID;
 
       await handlers.onUserInput(CID, missingSessionId, 'ignored', false);
@@ -162,7 +192,12 @@ describe('createInputHandlers', () => {
       // not queued behind the first.
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(firstConn, sessionId, 'from first', false);
       await handlers.onUserInput(CID, sessionId, 'from second', false);
 
@@ -187,7 +222,12 @@ describe('createInputHandlers', () => {
       // The first connection detaches (e.g. it closed its tab).
       sessionRegistry.detachConnection(firstConn);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(CID, sessionId, 'still typing', false);
 
       // CID's submit still lands -- it was never affected by the other
@@ -214,7 +254,12 @@ describe('createInputHandlers', () => {
       );
       // CID never attaches (as a query-mode connection would not).
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(CID, sessionId, 'ignored', false);
 
       expect(sendCalls).toHaveLength(1);
@@ -242,7 +287,12 @@ describe('createInputHandlers', () => {
       );
       // CID never attaches.
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const droppedMessageId = generateId();
       await handlers.onUserInput(CID, sessionId, 'ignored', false, undefined, droppedMessageId);
 
@@ -277,7 +327,12 @@ describe('createInputHandlers', () => {
       );
       sessionRegistry.attachConnection(sessionId, CID);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // Should not throw
       await handlers.onUserInput(CID, sessionId, 'x', true);
 
@@ -308,7 +363,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, 'yes');
 
       expect(ptyCapture.submits).toEqual(['yes']);
@@ -347,6 +407,7 @@ describe('createInputHandlers', () => {
 
         const resolvedCalls: Array<{ sessionId: UUID; questionId: UUID }> = [];
         const handlers = createInputHandlers({
+          ...PROMPT_ON_SCREEN,
           sessionRegistry,
           bindingStore,
           send,
@@ -380,6 +441,7 @@ describe('createInputHandlers', () => {
 
         const checked: Array<{ sessionId: UUID; questionId: UUID; ptyText: string }> = [];
         const handlers = createInputHandlers({
+          ...PROMPT_ON_SCREEN,
           sessionRegistry,
           bindingStore,
           send,
@@ -399,9 +461,15 @@ describe('createInputHandlers', () => {
 
       // A hook-paired question's merged id/text are the HOOK's, never the raw
       // PTY parse (question-presence-tracker.ts consumeAndMerge), so a blanket
-      // currency check would misfire on this cohort. The guard is scoped to
-      // `source === 'pty'` ONLY; proven with a spy that throws if consulted.
-      test('a non-pty-sourced card is never checked', async () => {
+      // currency check would misfire on this cohort. The ID/TEXT guard is
+      // scoped to `source === 'pty'` ONLY; proven with a spy that throws if
+      // consulted.
+      //
+      // Renamed for #1002: this cohort IS checked now, just not by this dep —
+      // `isPromptObservedOnPTY` asks the weaker "is anything on screen?", which
+      // hook-paired cards CAN answer. The old name claimed the cohort was
+      // unguarded, which was true and was the bug.
+      test('a non-pty-sourced card is not checked by the id/text guard', async () => {
         const ptyCapture = { writes: [] as string[], submits: [] as string[] };
         const sessionId = sessionRegistry.createSessionId();
         sessionRegistry.registerSession(
@@ -423,6 +491,7 @@ describe('createInputHandlers', () => {
         });
 
         const handlers = createInputHandlers({
+          ...PROMPT_ON_SCREEN,
           sessionRegistry,
           bindingStore,
           send,
@@ -435,6 +504,127 @@ describe('createInputHandlers', () => {
 
         expect(ptyCapture.submits).toEqual(['1']);
         expect(sessionRegistry.getSession(sessionId)?.currentQuestions.size).toBe(0);
+      });
+
+      /**
+       * #1002. Observed live: a bare `1` arrived in an unrelated session as a
+       * chat message. The card was hook-sourced, its hold was already gone, so
+       * `hadHold` was false and nothing released — and because the id/text
+       * guard above is scoped to `source === 'pty'`, the digit went to the PTY
+       * with nothing checked at all.
+       */
+      describe('#1002 no-prompt-on-screen guard for hook-sourced cards', () => {
+        function addHookSourcedQuestion(sessionId: UUID): void {
+          sessionRegistry.addQuestion(sessionId, {
+            id: QID,
+            text: 'Allow Bash: ls -la',
+            options: [
+              { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
+              { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
+            ],
+            allowsFreeText: false,
+            isAnswered: false,
+            source: 'permission_request',
+          });
+        }
+
+        test('no prompt on screen and no hold: refuses to submit, reports STALE_ANSWER', async () => {
+          const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+          const sessionId = sessionRegistry.createSessionId();
+          sessionRegistry.registerSession(
+            sessionId,
+            '/test/dir',
+            fakePTY(ptyCapture),
+            fakeMessageAPI(new Map()),
+          );
+          addHookSourcedQuestion(sessionId);
+
+          const handlers = createInputHandlers({
+            sessionRegistry,
+            bindingStore,
+            send,
+            isPromptObservedOnPTY: () => false, // nothing on screen
+          });
+
+          await handlers.onAnswer(CID, sessionId, QID, '1');
+
+          expect(ptyCapture.submits).toEqual([]); // the whole point: no stray digit
+          expect(
+            sendCalls.filter(
+              (c) => c.message.type === 'error' && c.message.code === 'STALE_ANSWER',
+            ),
+          ).toHaveLength(1);
+        });
+
+        test('an unwired dep is treated as no prompt (fails toward not injecting)', async () => {
+          const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+          const sessionId = sessionRegistry.createSessionId();
+          sessionRegistry.registerSession(
+            sessionId,
+            '/test/dir',
+            fakePTY(ptyCapture),
+            fakeMessageAPI(new Map()),
+          );
+          addHookSourcedQuestion(sessionId);
+
+          const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+
+          await handlers.onAnswer(CID, sessionId, QID, '1');
+          expect(ptyCapture.submits).toEqual([]);
+        });
+
+        test('a prompt IS on screen: submits normally', async () => {
+          const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+          const sessionId = sessionRegistry.createSessionId();
+          sessionRegistry.registerSession(
+            sessionId,
+            '/test/dir',
+            fakePTY(ptyCapture),
+            fakeMessageAPI(new Map()),
+          );
+          addHookSourcedQuestion(sessionId);
+
+          const handlers = createInputHandlers({
+            sessionRegistry,
+            bindingStore,
+            send,
+            isPromptObservedOnPTY: () => true,
+          });
+
+          await handlers.onAnswer(CID, sessionId, QID, '1');
+          expect(ptyCapture.submits).toEqual(['1']);
+          expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+        });
+
+        /**
+         * The condition that keeps this guard from breaking the legitimate
+         * case. When the answer ITSELF pops a held hook to passthrough, Claude
+         * is deliberately about to render its native prompt — so nothing is on
+         * screen YET, and requiring presence here would refuse a good answer.
+         */
+        test('releasing a hold in this same call submits even with nothing on screen', async () => {
+          const ptyCapture = { writes: [] as string[], submits: [] as string[] };
+          const sessionId = sessionRegistry.createSessionId();
+          sessionRegistry.registerSession(
+            sessionId,
+            '/test/dir',
+            fakePTY(ptyCapture),
+            fakeMessageAPI(new Map()),
+          );
+          addHookSourcedQuestion(sessionId);
+
+          const handlers = createInputHandlers({
+            sessionRegistry,
+            bindingStore,
+            send,
+            releaseHeldAsPassthrough: () => true, // a hold existed, popped now
+            isPromptObservedOnPTY: () => false, // prompt has not rendered yet
+          });
+
+          await handlers.onAnswer(CID, sessionId, QID, '1');
+          expect(ptyCapture.submits).toEqual(['1']);
+          expect(sendCalls.filter((c) => c.message.type === 'error')).toHaveLength(0);
+        });
       });
 
       // Held-hook answers resolve via the hook response and never PTY-submit
@@ -453,6 +643,7 @@ describe('createInputHandlers', () => {
         addPtySourcedQuestion(sessionId);
 
         const handlers = createInputHandlers({
+          ...PROMPT_ON_SCREEN,
           sessionRegistry,
           bindingStore,
           send,
@@ -486,6 +677,7 @@ describe('createInputHandlers', () => {
         sessionRegistry.attachConnection(sessionId, CID);
 
         const handlers = createInputHandlers({
+          ...PROMPT_ON_SCREEN,
           sessionRegistry,
           bindingStore,
           send,
@@ -521,7 +713,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, '', undefined, { cancel: true });
 
       expect(ptyCapture.writes).toEqual([AUQ_KEYS.ESC]);
@@ -547,7 +744,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, '', undefined, {
         selections: [{ questionIndex: 0, optionIndices: [0] }],
       });
@@ -600,7 +802,12 @@ describe('createInputHandlers', () => {
         ],
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // Pick Green (index 1): expect DOWN then ENTER, then closure -> question gone.
       await handlers.onAnswer(CID, sessionId, QID, '', undefined, {
         selections: [{ questionIndex: 0, optionIndices: [1] }],
@@ -664,7 +871,12 @@ describe('createInputHandlers', () => {
         ],
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // Q1 -> Green (index 1); Q2 -> Apple + Cherry (indices 0, 2).
       await handlers.onAnswer(CID, sessionId, QID, '', undefined, {
         selections: [
@@ -730,6 +942,7 @@ describe('createInputHandlers', () => {
       });
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -775,7 +988,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await expect(handlers.onAnswer(CID, sessionId, QID, 'y')).rejects.toThrow('pty closed');
 
       // No zombie question left behind for a retry to double-submit.
@@ -805,7 +1023,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // Pass a bogus sessionId, handler should still find the session via connection
       await handlers.onAnswer(CID, 'bogus000-0000-0000-0000-000000000000' as UUID, QID, 'hello');
 
@@ -830,7 +1053,12 @@ describe('createInputHandlers', () => {
       // must signal the drop back to the iOS client so the user is not left
       // wondering whether their tap landed.
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, 'hi');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -861,7 +1089,12 @@ describe('createInputHandlers', () => {
       });
 
       const stale = 'stal0000-0000-0000-0000-000000000000' as UUID;
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, stale, 'yes');
 
       expect(ptyCapture.submits).toEqual([]);
@@ -903,7 +1136,12 @@ describe('createInputHandlers', () => {
         agentId: 'sub-7',
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // Answer the first; it should inject and be removed, the second stays.
       await handlers.onAnswer(CID, sessionId, QID, 'one');
       expect(ptyCapture.submits).toEqual(['one']);
@@ -922,7 +1160,12 @@ describe('createInputHandlers', () => {
     test('logs when neither sessionId nor connectionId maps to a session', async () => {
       const logs: string[] = [];
       configureLogger({ writeLog: (msg) => logs.push(msg) });
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await handlers.onAnswer(CID, 'miss0000-0000-0000-0000-000000000000' as UUID, QID, 'y');
 
@@ -959,6 +1202,7 @@ describe('createInputHandlers', () => {
       const held: Array<{ sessionId: UUID; questionId: UUID; decision: 'allow' | 'deny' }> = [];
       const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -992,6 +1236,7 @@ describe('createInputHandlers', () => {
 
       const held: Array<'allow' | 'deny'> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1025,6 +1270,7 @@ describe('createInputHandlers', () => {
       const released: UUID[] = [];
       const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1086,6 +1332,7 @@ describe('createInputHandlers', () => {
 
       const held: Array<{ decision: 'allow' | 'deny'; suggestionIndex: number | undefined }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1114,6 +1361,7 @@ describe('createInputHandlers', () => {
 
       const cancels: Array<{ sessionId: UUID; questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1153,6 +1401,7 @@ describe('createInputHandlers', () => {
 
       let resolveHeldCalled = false;
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1181,7 +1430,12 @@ describe('createInputHandlers', () => {
       );
       addYesNoQuestion(sessionId);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, '1');
 
       expect(ptyCapture.submits).toEqual(['1']); // PTY path, no held resolution
@@ -1222,6 +1476,7 @@ describe('createInputHandlers', () => {
 
       const held: Array<'allow' | 'deny'> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1251,6 +1506,7 @@ describe('createInputHandlers', () => {
 
       const held: Array<'allow' | 'deny'> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1282,6 +1538,7 @@ describe('createInputHandlers', () => {
 
       const released: UUID[] = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1312,6 +1569,7 @@ describe('createInputHandlers', () => {
       addYesNoAlwaysQuestion(sessionId);
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1339,6 +1597,7 @@ describe('createInputHandlers', () => {
       addYesNoAlwaysQuestion(sessionId);
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1376,6 +1635,7 @@ describe('createInputHandlers', () => {
       });
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1406,6 +1666,7 @@ describe('createInputHandlers', () => {
       });
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1432,6 +1693,7 @@ describe('createInputHandlers', () => {
       addYesNoAlwaysQuestion(sessionId);
 
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1454,7 +1716,12 @@ describe('createInputHandlers', () => {
 
   describe('onBulletExpandRequest', () => {
     test('sends NOT_FOUND when session is missing', () => {
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       handlers.onBulletExpandRequest(CID, 'noses000-0000-0000-0000-000000000000' as UUID, 1, REQ);
 
@@ -1473,7 +1740,12 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       handlers.onBulletExpandRequest(CID, sessionId, 99, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -1491,7 +1763,12 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map([[7, 'full expanded content']])),
       );
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       handlers.onBulletExpandRequest(CID, sessionId, 7, REQ);
 
       expect(sendCalls).toHaveLength(1);
@@ -1537,7 +1814,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, 'y', bound);
 
       expect(capture.submits).toEqual(['y']);
@@ -1556,7 +1838,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, 'y', stale);
 
       expect(capture.submits).toEqual([]);
@@ -1579,7 +1866,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onAnswer(CID, sessionId, QID, 'y');
 
       expect(capture.submits).toEqual(['y']);
@@ -1591,7 +1883,12 @@ describe('createInputHandlers', () => {
       const stale = '99999999-aaaa-bbbb-cccc-dddddddddddd' as UUID;
       const { sessionId, capture } = registerSessionWithBinding(bound);
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       await handlers.onUserInput(CID, sessionId, 'ls', false, stale);
 
       expect(capture.submits).toEqual([]);
@@ -1620,7 +1917,12 @@ describe('createInputHandlers', () => {
         allowsFreeText: false,
         isAnswered: false,
       });
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       const claudeId = '11111111-2222-3333-4444-555555555555' as UUID;
       await handlers.onAnswer(CID, sessionId, QID, 'y', claudeId);
@@ -1654,7 +1956,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
 
       expect(outcome).toBe('delivered');
@@ -1689,6 +1996,7 @@ describe('createInputHandlers', () => {
       const held: Array<{ decision: 'allow' | 'deny' }> = [];
       const cancels: Array<{ questionId: UUID; reason: string }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1730,7 +2038,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       // The relay surfaces the throw (the HTTP route turns it into a 500).
       await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
       // Question consumed exactly once despite the throw.
@@ -1738,7 +2051,12 @@ describe('createInputHandlers', () => {
     });
 
     test('returns session-not-found for an unknown session (no error frame)', async () => {
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const outcome = await handlers.relayAnswer(
         'unknown0-0000-0000-0000-000000000000' as UUID,
         QID,
@@ -1758,7 +2076,12 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
       // No question added: the relay must report stale rather than submitting.
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const outcome = await handlers.relayAnswer(sessionId, QID, 'Yes');
 
       expect(outcome).toBe('stale');
@@ -1793,7 +2116,12 @@ describe('createInputHandlers', () => {
         isAnswered: false,
       });
 
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const outcome = await handlers.relayAnswer(
         sessionId,
         QID,
@@ -1835,7 +2163,12 @@ describe('createInputHandlers', () => {
 
     test('a same-value relay duplicate after a relay success reports delivered, no re-submit', async () => {
       const { sessionId, ptyCapture } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
       expect(ptyCapture.submits).toEqual(['1']);
@@ -1847,7 +2180,12 @@ describe('createInputHandlers', () => {
 
     test('cross-channel: a WS answer then its relay duplicate reports delivered', async () => {
       const { sessionId, ptyCapture } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // in-app WS copy wins
       expect(ptyCapture.submits).toEqual(['1']);
@@ -1858,7 +2196,12 @@ describe('createInputHandlers', () => {
 
     test('a WS duplicate sends NO STALE_ANSWER error frame', async () => {
       const { sessionId } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await handlers.onAnswer(CID, sessionId, QID, 'Yes');
       await handlers.onAnswer(CID, sessionId, QID, 'Yes'); // duplicate
@@ -1868,7 +2211,12 @@ describe('createInputHandlers', () => {
 
     test('a CONFLICTING late answer (different value) still reports stale', async () => {
       const { sessionId, ptyCapture } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       expect(await handlers.relayAnswer(sessionId, QID, 'Yes')).toBe('delivered');
       // A second device answered "No" after "Yes" already won: must fail loudly.
@@ -1896,7 +2244,12 @@ describe('createInputHandlers', () => {
         allowsFreeText: false,
         isAnswered: false,
       });
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await expect(handlers.relayAnswer(sessionId, QID, 'Yes')).rejects.toThrow('pty closed');
       // The answer was never applied, so its duplicate is NOT a success echo.
@@ -1905,7 +2258,12 @@ describe('createInputHandlers', () => {
 
     test('an unknown question with no recorded answer still reports stale', async () => {
       const { sessionId } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const other = 'cccccccc-0000-0000-0000-000000000000' as UUID;
       expect(await handlers.relayAnswer(sessionId, other, 'Yes')).toBe('stale');
     });
@@ -1915,7 +2273,12 @@ describe('createInputHandlers', () => {
       // the label ("Yes"). Same tap, different spelling — the cache records
       // both at application time (#759 review finding 1).
       const { sessionId, ptyCapture } = registerYesNo();
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await handlers.onAnswer(CID, sessionId, QID, '1'); // in-app value
       expect(ptyCapture.submits).toEqual(['1']);
@@ -1928,6 +2291,7 @@ describe('createInputHandlers', () => {
       const { sessionId, ptyCapture } = registerYesNo();
       const held: Array<'allow' | 'deny'> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -1978,7 +2342,12 @@ describe('createInputHandlers', () => {
           },
         ],
       });
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
       const selections = [{ questionIndex: 0, optionIndices: [0] }];
 
       await handlers.onAnswer(CID, sessionId, QID, '', undefined, { selections });
@@ -2019,6 +2388,7 @@ describe('createInputHandlers', () => {
       const sessionId = registerWithQuestion(QID);
       const resolved: Array<{ sessionId: UUID; questionId: UUID }> = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -2042,6 +2412,7 @@ describe('createInputHandlers', () => {
       // No question registered -> the answer is stale.
       const resolved: UUID[] = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -2056,6 +2427,7 @@ describe('createInputHandlers', () => {
     test('a throwing onQuestionResolved never breaks answer handling', async () => {
       const sessionId = registerWithQuestion(QID);
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -2112,6 +2484,7 @@ describe('createInputHandlers', () => {
       );
       const calls: RecordCall[] = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -2185,6 +2558,7 @@ describe('createInputHandlers', () => {
       registerPermissionQuestion(sessionId, { source: 'pty' });
       const calls: RecordCall[] = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,
@@ -2342,7 +2716,12 @@ describe('createInputHandlers', () => {
         fakeMessageAPI(new Map()),
       );
       registerPermissionQuestion(sessionId);
-      const handlers = createInputHandlers({ sessionRegistry, bindingStore, send });
+      const handlers = createInputHandlers({
+        sessionRegistry,
+        bindingStore,
+        send,
+        ...PROMPT_ON_SCREEN,
+      });
 
       await expect(handlers.onAnswer(CID, sessionId, QID, 'Yes')).resolves.toBe(undefined);
       expect(ptyCapture.submits).toEqual(['1']);
@@ -2353,6 +2732,7 @@ describe('createInputHandlers', () => {
       registerPermissionQuestion(sessionId);
       const recorded: RecordCall[] = [];
       const handlers = createInputHandlers({
+        ...PROMPT_ON_SCREEN,
         sessionRegistry,
         bindingStore,
         send,


### PR DESCRIPTION
Fixes #1002.

A bare `1` arrived in a live, unrelated session as a chat message. It was an
answer tapped on a phone for a different session's card.

```
Answer from d9b3f39d-... for session 1919f245-...: 1
Push dismissal sent for question 9fc9e52f-...
Status: thinking
[Transcript] User entry: 1f03ff52          <- the digit, as a USER MESSAGE
```

No `Resolved held permission` line, so it took the PTY-submit branch. No
`refusing PTY submit` line, so the #920 guard never ran.

## Root cause

#920's guard is scoped to `source === 'pty'`. Its reasoning is correct as far as
it goes: a hook-paired card's `id`/`text` are the HOOK's (tool + command), never
the raw PTY parse, so an "is THIS prompt current" match could never succeed for
that cohort, and widening it on id/text would refuse legitimate answers.

But the scoping conflated two different questions:

| question | needs | answerable for hook-paired cards? |
|---|---|---|
| is THIS prompt on screen? | id/text match | no, structurally |
| is ANY prompt on screen? | presence only | **yes** |

Only the first was ever asked. A hook-sourced card reaches `submitInput` only
when no hold was resolved AND none was released, i.e. this answer causes nothing
to render — so if nothing is on screen already, the digit lands in whatever
Claude is doing.

## The two things this turns on

Both were settled by probing the real `QuestionPresenceTracker`, not by reading it.

**1. Not `isPromptVisibleOnPTY`, despite the name.** That flag means "this
tracker pushed a card off a PTY render". It is FALSE for the commonest case of
all: a gate-owned hook card whose native prompt renders is routed to
`onOrphanPTYPrompt`, recognised as an echo, and suppressed without ever setting
it. My first attempt used it; the probe showed `recordPendingHook` +
`onOrphanPTYPrompt` leaving it false with a prompt genuinely on screen. Shipping
that would have traded a stray-digit bug for a cannot-answer-at-all bug.

New `isPromptObservedOnPTY` reads `observedPTYQuestionId`, which
`onOrphanPTYPrompt` sets *before* any branch decides to push/suppress/arbitrate,
and which `onStatusChange` (off `waiting`) and `clearPending` null. It has no
such gap. Five tests pin the distinction so the two are not "simplified" back
together.

**2. The `!released` condition.** When the answer itself pops a held hook to
passthrough, Claude is deliberately about to render its native prompt — nothing
is on screen YET, and requiring presence there would refuse a good answer. This
is what keeps the guard from breaking the legitimate path.

Absent dep is treated as "no prompt", matching `isPromptCurrent`'s documented
default and for its stated reason: a refused legitimate answer costs a re-answer
with the card still visible; an accepted stale one injects text into a live
session with nothing to undo it.

## Test changes worth reviewing carefully

- **43 existing tests** that exercise the PTY-submit path now state explicitly
  that a prompt is on screen (`PROMPT_ON_SCREEN`) instead of inheriting the
  refusing default. They predate the dep; their intent is unchanged.
- **One test was renamed.** `a non-pty-sourced card is never checked` asserted
  exactly the hole: that cohort was unguarded. It is now `...is not checked by
  the id/text guard`, which is what it actually pins.

## Verification

- Mutation: guard removed -> **2 RED**; `!released` dropped -> **1 RED**. Each
  new test fails for its own reason.
- 1598 pass across `cli/` + `api/` + `hooks/` (develop on the same combo: 1589;
  +9 new). One `HookServer` failure seen once was a port-contention flake —
  three consecutive clean runs after, and it passes standalone on both branches.

## Not fixed here

The other half of #1002: the card is never removed from the pending set, so it
is re-sent on every reconnect (**576** `Re-sent N pending question(s)` in the
same log; session `1919f245` answered `1` six times from six connections). That
is what supplies the repeated answers in the first place. This PR stops the
damage; the re-send loop needs its own change.
