### PR TITLE
fix: a retired escalation never pushes a card

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -104,6 +104,12 @@ import type { AutoApproveResult } from './types.ts';
  *  is the right eviction. */
 const MAX_PARKED_INPUTS = 64;
 
+/** Hard cap on `retiredEscalations` (#1005). Only needs to outlive the gap
+ *  between a retirement and the PTY render it must suppress, which is a
+ *  render cycle; sized generously above `MAX_PARKED_INPUTS` because forgetting
+ *  early fails toward an extra card, not toward silence. */
+const MAX_RETIRED_ESCALATIONS = 256;
+
 /** The (tool_name, tool_input) signature of an OPEN escalation (#673),
  *  tracked so an external-resolution signal can find and cancel it. */
 interface ToolSignature {
@@ -593,6 +599,39 @@ export class AutoApproveGate {
   private readonly openQuestionSignatures = new Map<UUID, ToolSignature>();
 
   /**
+   * Ids of escalations this gate has RETIRED — resolved, released, or answered
+   * on the user's behalf (#1005).
+   *
+   * Exists so `arbitrateParkedRender` can tell "this permission is already
+   * settled" from "I have never heard of this id". Those look identical in
+   * `openQuestionSignatures` (absent either way) and need opposite handling:
+   * settled must not push a card, unknown MUST still push, because an id the
+   * gate has no record of is one it has no evidence about and the standing
+   * rule is that ambiguity resolves toward showing the user.
+   *
+   * A card pushed for a retired escalation is unremovable by design: retirement
+   * already deleted the signature entry, and every sweep this gate has iterates
+   * that map. So the cost of getting this wrong is not a redundant prompt, it
+   * is a permanent one.
+   *
+   * Bounded like `parkedInputs`: insertion-ordered, oldest evicted past the
+   * cap. Forgetting an old retirement fails toward pushing (a redundant card
+   * the user can dismiss), never toward silence.
+   */
+  private readonly retiredEscalations = new Set<UUID>();
+
+  /** Record a retirement, bounded like `parkedInputs` (oldest evicted). */
+  private markRetired(questionId: UUID): void {
+    this.retiredEscalations.delete(questionId);
+    this.retiredEscalations.add(questionId);
+    while (this.retiredEscalations.size > MAX_RETIRED_ESCALATIONS) {
+      const oldest = this.retiredEscalations.values().next().value;
+      if (oldest === undefined) break;
+      this.retiredEscalations.delete(oldest);
+    }
+  }
+
+  /**
    * The original hook input of every PARKED subagent permission (#814), keyed
    * by the parked `Question.id`. The hook itself was answered 'passthrough'
    * immediately (#807), so this is the only surviving record of what the
@@ -885,6 +924,9 @@ export class AutoApproveGate {
     // escalation this question tracked is resolved now regardless of which
     // branch below runs -- clear it unconditionally, not just on the hit path.
     this.openQuestionSignatures.delete(questionId);
+    // #1005: pair every signature retirement with a positive record of it,
+    // so a later parked render can tell "settled" from "never seen".
+    this.markRetired(questionId);
     this.parkedInputs.delete(questionId); // #814, see releaseHeld
     this.confirmedDeliveries.delete(questionId); // #733: same unconditional cleanup
     const hold = this.pendingHolds.get(questionId);
@@ -1683,6 +1725,9 @@ export class AutoApproveGate {
     toolName?: string,
   ): boolean {
     this.openQuestionSignatures.delete(questionId);
+    // #1005: pair every signature retirement with a positive record of it,
+    // so a later parked render can tell "settled" from "never seen".
+    this.markRetired(questionId);
     // #814: a parked permission resolved through any of these paths can never
     // be arbitrated on render any more; retire its remembered hook input with
     // the signature it belongs to.
@@ -1841,6 +1886,28 @@ export class AutoApproveGate {
   ): Promise<ParkedRenderVerdict> {
     const input = this.parkedInputs.get(parkedQuestionId);
     const service = this.deps.service;
+    // #1005: this escalation was RETIRED (resolved / released / answered).
+    // Pushing here mints a card for a permission that is already settled, and
+    // -- because retirement deleted its `openQuestionSignatures` entry on the
+    // way out -- that card lands OUTSIDE every removal path this gate has: the
+    // signature sweeps and `cancelStaleForAgent` both iterate that map. Only
+    // LRU eviction or a user answer could ever remove it, which is how 7 of the
+    // 8 cards found stuck in a live pending set were born (2.5-12.5h lifetimes,
+    // `lru_eviction` their only removal).
+    //
+    // Keyed on POSITIVE evidence of retirement, never on the absence of a
+    // signature entry. Absence cannot tell "was retired" from "was never
+    // parked", and those need opposite handling: an id this gate knows nothing
+    // about is one it has no evidence about, so it must still fail open to the
+    // user. (An existing test, "an unknown parked id pushes without
+    // evaluating", pins exactly that and caught this when the check was written
+    // the absent-entry way.)
+    if (this.retiredEscalations.has(parkedQuestionId)) {
+      log(
+        `[AutoApprove ${this.sessionTag}] Parked render for ${parkedQuestionId.slice(0, 8)} already retired; not pushing`,
+      );
+      return { outcome: 'answered' };
+    }
     if (input === undefined || service === null) {
       // No auto-approve, or the park was already consumed/retired (an external
       // resolution, a session teardown, a duplicate render, a MAX_PARKED_INPUTS
@@ -1895,10 +1962,27 @@ export class AutoApproveGate {
     }
 
     if (result.decision === 'cancelled') {
-      // The eval was aborted because something proved the prompt moot (the
-      // agent advanced, the user answered in the terminal). Report push: the
-      // tracker drops it when the prompt is already off screen, and if it is
-      // somehow still up, the user is the right fallback.
+      // #1005: distinguish WHOSE resolution cancelled this eval. If this
+      // question's own bookkeeping is gone, the cancel was ITS resolution --
+      // the permission is settled and a card would be a zombie born outside
+      // every removal path (see the retired-park check at the top).
+      //
+      // The tracker cannot be relied on to drop it instead: `isPromptCurrent`'s
+      // text fallback matches "Do you want to proceed?", which is what EVERY
+      // Claude Code permission prompt renders, so with agent-team traffic
+      // something text-identical is almost always on screen. That check is
+      // structurally blind here.
+      if (this.retiredEscalations.has(parkedQuestionId)) {
+        log(
+          `[AutoApprove ${this.sessionTag}] Parked-render eval cancelled by its own resolution: ${result.reasoning}`,
+        );
+        this.markHandled(true);
+        return { outcome: 'answered' };
+      }
+      // The entry survives, so the cancel was collateral -- a SIBLING's
+      // PostToolUse aborted this eval. The prompt may well still be live, so
+      // keep failing open to the user. Mapping `cancelled` to `answered`
+      // unconditionally would swallow it.
       log(`[AutoApprove ${this.sessionTag}] Parked-render eval cancelled: ${result.reasoning}`);
       return this.escalateRenderedParked();
     }
@@ -1911,6 +1995,9 @@ export class AutoApproveGate {
         // to retire, which a deny in particular would otherwise leak until
         // SubagentStop (a denial fires no tool call to match against).
         this.openQuestionSignatures.delete(parkedQuestionId);
+        // #1005: pair every signature retirement with a positive record of it,
+        // so a later parked render can tell "settled" from "never seen".
+        this.markRetired(parkedQuestionId);
         this.markHandled(true);
         return { outcome: 'answered' };
       }
@@ -1945,6 +2032,9 @@ export class AutoApproveGate {
         (await this.answerRenderedParked(input, second, rendered, ptyPrompt))
       ) {
         this.openQuestionSignatures.delete(parkedQuestionId);
+        // #1005: pair every signature retirement with a positive record of it,
+        // so a later parked render can tell "settled" from "never seen".
+        this.markRetired(parkedQuestionId);
         this.markHandled(true);
         log(
           `[AutoApprove ${this.sessionTag}] escalate_model (${this.deps.escalateModel}) ${second.decision === 'deny' ? 'denied' : 'approved'} a parked render (${input.tool_name})`,

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -3634,6 +3634,65 @@ describe('AutoApproveGate parked-render arbitration (#814)', () => {
     expect(evalCalls).toHaveLength(0);
   });
 
+  /**
+   * #1005. A parked render whose escalation was ALREADY retired must not push:
+   * retirement deleted its `openQuestionSignatures` entry, and every sweep this
+   * gate has iterates that map, so the resulting card is unremovable by anything
+   * except LRU eviction or a user answer. That is how 7 of the 8 cards found
+   * stuck in a live pending set were born.
+   *
+   * Keyed on a positive record of retirement, NOT on the signature entry being
+   * absent -- absent cannot tell "settled" from "never parked", and the test
+   * immediately below pins that the latter must still push.
+   */
+  describe('#1005 a retired escalation does not push a card', () => {
+    test('externally resolved before its render: answered, no push', async () => {
+      const g = gate(escalate);
+      await g.resolvePermission(pr('git push'));
+      const r = rendered(parkedIds[0] as UUID);
+      promptOnScreen(r);
+
+      // The tool actually ran -- PostToolUse retires the escalation.
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-1' },
+        'PostToolUse-subagent',
+      );
+
+      expect(await g.arbitrateParkedRender(parkedIds[0] as UUID, r, screen(r))).toEqual({
+        outcome: 'answered',
+      });
+    });
+
+    test('a cancelled eval for a retired question is answered, not pushed', async () => {
+      const g = gate(cancelled);
+      await g.resolvePermission(pr('git push'));
+      const r = rendered(parkedIds[0] as UUID);
+      promptOnScreen(r);
+      g.cancelExternallyResolved(
+        { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-1' },
+        'PostToolUse-subagent',
+      );
+
+      expect(await g.arbitrateParkedRender(parkedIds[0] as UUID, r, screen(r))).toEqual({
+        outcome: 'answered',
+      });
+    });
+
+    test('a cancelled eval whose OWN escalation is still open still pushes', async () => {
+      // The cancel was collateral -- a sibling agent's PostToolUse aborted this
+      // eval. The prompt may well be live, so mapping `cancelled` to `answered`
+      // unconditionally would swallow it.
+      const g = gate(cancelled);
+      await g.resolvePermission(pr('git push'));
+      const r = rendered(parkedIds[0] as UUID);
+      promptOnScreen(r);
+
+      expect(await g.arbitrateParkedRender(parkedIds[0] as UUID, r, screen(r))).toEqual({
+        outcome: 'push',
+      });
+    });
+  });
+
   test('an unknown parked id pushes without evaluating', async () => {
     const g = gate(approve);
     const unknown = rendered(generateId() as UUID);

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -3984,19 +3984,14 @@ describe('#1005 end-to-end: a retired escalation registers no card via the real 
   function wire(pushes: Question[]) {
     const sid = registry.createSessionId();
     const submits: string[] = [];
-    registry.registerSession(
-      sid,
-      '/d',
-      fakePTY({ writes: [], submits }) as unknown as PTYSession,
-      {
-        handleMessage: () => {},
-        handleQuestion: (q: Question) => {
-          pushes.push(q);
-          registry.addQuestion(sid, q as never);
-        },
-        handleStatusChange: () => {},
-      } as never,
-    );
+    registry.registerSession(sid, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: (q: Question) => {
+        pushes.push(q);
+        registry.addQuestion(sid, q as never);
+      },
+      handleStatusChange: () => {},
+    } as never);
     const tracker = new QuestionPresenceTracker((q) => {
       pushes.push(q);
       registry.addQuestion(sid, q as never);

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -3956,3 +3956,154 @@ describe('autoAnswerValue (#814)', () => {
     expect(autoAnswerValue(deny, [], [])).toBeUndefined();
   });
 });
+
+/**
+ * #1005, end to end through the REAL tracker pairing path.
+ *
+ * The parked-render tests above call `gate.arbitrateParkedRender` directly,
+ * which is the right unit for the verdict logic but skips how the arbiter is
+ * actually reached in production: the tracker pairs a PTY render against its
+ * `awaitingPTY` map (`matchAwaitingPTYKey`) and invokes the arbiter itself.
+ * A fix verified only at the unit level could pass while the wiring that feeds
+ * it changed underneath — noted in review of this PR, and closed here rather
+ * than left as a manual check somebody ran once.
+ */
+describe('#1005 end-to-end: a retired escalation registers no card via the real pairing path', () => {
+  let registry: SessionRegistry;
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    configureLogger({ writeLog: () => {} });
+  });
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  /** Real tracker + real gate, wired the way cli.ts wires them. */
+  function wire(pushes: Question[]) {
+    const sid = registry.createSessionId();
+    const submits: string[] = [];
+    registry.registerSession(
+      sid,
+      '/d',
+      fakePTY({ writes: [], submits }) as unknown as PTYSession,
+      {
+        handleMessage: () => {},
+        handleQuestion: (q: Question) => {
+          pushes.push(q);
+          registry.addQuestion(sid, q as never);
+        },
+        handleStatusChange: () => {},
+      } as never,
+    );
+    const tracker = new QuestionPresenceTracker((q) => {
+      pushes.push(q);
+      registry.addQuestion(sid, q as never);
+      return { status: 'registered' as const };
+    });
+    const gate = new AutoApproveGate(
+      {
+        service: { evaluate: async () => escalate, cancel: () => true },
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => true,
+        escalate: () => undefined,
+        // Wired exactly as cli.ts does: the gate hands the rich question to the
+        // tracker, which is what makes the PTY render pair with it later. The
+        // unit tests above stub this out and call the arbiter directly; that is
+        // precisely the wiring this end-to-end pair exists to cover.
+        parkForPTY: (input) => {
+          const q = {
+            id: generateId(),
+            text: `reviewer · Bash: ${String((input.tool_input as { command?: string }).command)}`,
+            options: [
+              { value: '1', label: '1', isRecommended: false, isYes: false, isNo: false },
+              { value: '2', label: '2', isRecommended: false, isYes: false, isNo: false },
+            ],
+            allowsFreeText: false,
+            isAnswered: false,
+            source: 'permission_request',
+            agentId: input.agent_id,
+          } as unknown as Question;
+          tracker.recordPendingHook(q);
+          tracker.parkAwaitingPTY(q);
+          return q.id as UUID;
+        },
+      },
+      sid,
+    );
+    tracker.setParkedRenderArbiter((ctx) =>
+      gate.arbitrateParkedRender(ctx.parkedQuestionId, ctx.rendered, ctx.ptyPrompt),
+    );
+    return { sid, tracker, gate };
+  }
+
+  test('baseline: a parked render with no retirement DOES push (harness is not vacuous)', async () => {
+    const pushes: Question[] = [];
+    const { sid, tracker, gate } = wire(pushes);
+    await gate.resolvePermission({
+      session_id: 'c',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      agent_id: 'agent-1',
+      agent_type: 'general-purpose',
+    } as PermissionRequestHookInput);
+    tracker.onOrphanPTYPrompt({
+      id: generateId(),
+      text: 'Do you want to proceed?',
+      options: [
+        { value: '1', label: '1', isRecommended: false, isYes: false, isNo: false },
+        { value: '2', label: '2', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    } as Question);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(pushes.length).toBeGreaterThan(0);
+    expect(registry.getSession(sid)?.currentQuestions.size).toBeGreaterThan(0);
+  });
+
+  test('retired before its render: no card, and the pending set stays empty', async () => {
+    const pushes: Question[] = [];
+    const { sid, tracker, gate } = wire(pushes);
+    await gate.resolvePermission({
+      session_id: 'c',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'git push' },
+      agent_id: 'agent-1',
+      agent_type: 'general-purpose',
+    } as PermissionRequestHookInput);
+
+    // The tool actually ran: PostToolUse retires the escalation before any
+    // prompt reaches the screen.
+    gate.cancelExternallyResolved(
+      { toolName: 'Bash', toolInput: { command: 'git push' }, agentId: 'agent-1' },
+      'PostToolUse-subagent',
+    );
+
+    tracker.onOrphanPTYPrompt({
+      id: generateId(),
+      text: 'Do you want to proceed?',
+      options: [
+        { value: '1', label: '1', isRecommended: false, isYes: false, isNo: false },
+        { value: '2', label: '2', isRecommended: false, isYes: false, isNo: false },
+      ],
+      allowsFreeText: false,
+      isAnswered: false,
+    } as Question);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(pushes).toHaveLength(0);
+    // The whole point: nothing accumulates in the store that no sweep can clear.
+    expect(registry.getSession(sid)?.currentQuestions.size).toBe(0);
+  });
+});

--- a/packages/daemon/tests/session/question-containers-classification.test.ts
+++ b/packages/daemon/tests/session/question-containers-classification.test.ts
@@ -188,6 +188,12 @@ const REGISTRY: readonly Entry[] = [
   },
   {
     file: 'auto-approve/auto-approve-gate.ts',
+    field: 'retiredEscalations',
+    cls: 'mixed',
+    note: "NEW (#1005). Ids of escalations this gate RETIRED -- resolved, released, or answered on the user's behalf -- so a later parked render can tell 'already settled' from 'never seen' and refuse to push a card no sweep could ever remove. Mixed for the same reason openQuestionSignatures is: retiring a HELD escalation is post-card metadata (its card was registered), retiring a PARKED one (#814) is pre-card (parkAwaitingPTY, no card ever existed). Never a pendingness opinion -- consulted only to SUPPRESS creating a card, never to claim one is live, and forgetting an entry past the cap fails toward pushing.",
+  },
+  {
+    file: 'auto-approve/auto-approve-gate.ts',
     field: 'parkedInputs',
     cls: 'pre-card',
     note: 'Original hook input of every PARKED subagent permission (#814) -- the sole surviving record of what a parked permission asked, before any card exists.',


### PR DESCRIPTION
Part of #1005 — Change A of two. Change B is not in this PR.

A parked subagent render whose escalation was ALREADY retired pushed a card
anyway. Retirement had deleted its `openQuestionSignatures` entry on the way
out, and every sweep this gate has (`cancelStaleForAgent`, the signature
sweeps) iterates that map — so the resulting card was unremovable by anything
except LRU eviction or a user answer.

## That is how the stuck cards were born

Tracing the 8 ids listed in a live `STALE_ANSWER` pending set:

```
7 of 8 subagent-tagged
every one removed ONLY by lru_eviction
lifetimes 2.5 - 12.5 hours
```

`MAX_PENDING_QUESTIONS = 8` is why every reconnect re-sent exactly 8, and why
the re-send counts in the log climb and pin there (`196x "Re-sent 1"` …
`59x "Re-sent 8"`).

## The design decision worth reviewing

The check is keyed on a **positive record of retirement**, not on the signature
entry being absent.

Absence cannot distinguish two cases that need opposite handling:

| state | meaning | correct action |
|---|---|---|
| retired | resolved / released / answered | do NOT push — the card would be unremovable |
| never parked | the gate has no record at all | **still push** — no evidence, so fail toward showing |

Both look identical in `openQuestionSignatures`. The first implementation used
the absent-entry check and the pre-existing test **"an unknown parked id pushes
without evaluating"** caught it — mutating back to that check is precisely what
turns that test red today.

So this adds `retiredEscalations`, written at all four sites that delete a
signature entry (`resolveHeld`, `releaseHeld`, and the two answered branches).
Bounded like `parkedInputs`; forgetting an old retirement fails toward pushing a
redundant card the user can dismiss, never toward silence.

## `cancelled` now asks WHOSE resolution cancelled the eval

- entry retired => this question's own resolution => settled, `answered`
- entry alive => collateral, a sibling agent's `PostToolUse` aborted the eval =>
  the prompt may well be live => keep failing open and push

Mapping `cancelled` to `answered` unconditionally would swallow a live prompt.
The third new test pins that difference.

The tracker cannot be relied on to drop these instead: `isPromptCurrent`'s text
fallback matches "Do you want to proceed?", which is what EVERY Claude Code
permission prompt renders, so with agent-team traffic something text-identical
is almost always on screen. That check is structurally blind here.

## Verification

- Mutation: ledger never records -> **2 RED**; `cancelled` always answered ->
  **4 RED**; absent-entry instead of ledger -> **1 RED** (the pre-existing
  unknown-id test).
- 482 pass across `auto-approve-gate` + `hold-hook` +
  `held-escalation-roundtrip` + `api/` + `cli/handlers/`.

## Measurement caveat, for anyone re-deriving these numbers

`~/.remi/question-trace.jsonl` is written by the TEST SUITE as well as the live
daemon — the module header documents this and `provenance` exists (#934) so
readers can filter. Unfiltered, "never removed" reads 2,424; 1,586 of those are
test records. Filter `provenance != "test"` before quoting any aggregate. The
8-card diagnosis above predates the test pollution and was verified id by id.

## Not in this PR

**Change B**: generalize the tracker's #888/#920 confirmed-supersede resolution
from "hookless" to "render-owned, non-held", so the second cohort — genuine
escalations that lose their exit when a terminal deny fires no tool call and a
teammate never emits `SubagentStop` — also gets bounded. Tracked in #1005.
