### PR TITLE
fix: a superseded render-owned card is resolved, not left to rot

### DIFF
--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -49,7 +49,7 @@
  * exits used to be the user answering it or the `MAX_PENDING_QUESTIONS` LRU
  * cap, which measured as a real leak (12 of 29 source-less questions never
  * removed in one working day's capture, one still pending 2h51m later).
- * `observedHooklessQuestion` + `deps.onHooklessQuestionGone` close that gap,
+ * `observedRenderOwnedQuestion` + `deps.onHooklessQuestionGone` close that gap,
  * but ONLY on a CONFIRMED-delivered replacement push in `pairAndPush` --
  * the `QuestionRegistrationOutcome` returned directly by the `push` call is
  * the confirmation gate (#888 criterion iii; formerly a separate
@@ -296,7 +296,7 @@ export class QuestionPresenceTracker {
    * / the Stop sweeps), so this mechanism -- scoped tightly to the one cohort
    * that has no other exit -- leaves it alone.
    */
-  private observedHooklessQuestion: string | null = null;
+  private observedRenderOwnedQuestion: string | null = null;
 
   /** Count of MAIN-context auto-approve evals in flight. A PTY prompt that
    *  appears while this is > 0 is BUFFERED (not pushed): if the verdict is
@@ -632,37 +632,68 @@ export class QuestionPresenceTracker {
    * swallowing a live question is not.
    */
   private pairAndPush(ptyQuestion: Question): void {
-    const { merged, hookRecord } = this.consumeAndMerge(ptyQuestion);
+    // `hookRecord` is deliberately not read here any more: #1005 widened the
+    // render-owned slot to EVERY confirmed render-born card, hook-paired or
+    // not, so whether a hook was consumed no longer changes what is tracked.
+    const { merged } = this.consumeAndMerge(ptyQuestion);
     this.ptyShowingQuestion = true;
     const outcome = this.pushMerged(merged);
     const delivered = outcome?.status === 'registered';
     if (!delivered) {
       // Not confirmed (deduped, or the push sink returned no outcome):
-      // nothing is known to have changed. Leave `observedHooklessQuestion`
+      // nothing is known to have changed. Leave `observedRenderOwnedQuestion`
       // exactly as it was -- if it was tracking an older id, that question
       // is STILL the best evidence of what's on screen, and must not be
       // resolved on the strength of a replacement that never actually
       // registered.
       return;
     }
-    if (this.observedHooklessQuestion !== null && this.observedHooklessQuestion !== merged.id) {
-      this.noteHooklessGone('pty_render_superseded');
-    }
-    this.observedHooklessQuestion = hookRecord === undefined ? merged.id : null;
+    this.adoptRenderOwnedQuestion(merged.id);
   }
 
   /**
    * Clear and report the currently-tracked hook-less question as gone
-   * (#888/#920), if one is tracked. No-op when `observedHooklessQuestion` is
+   * (#888/#920), if one is tracked. No-op when `observedRenderOwnedQuestion` is
    * null (nothing to resolve) or no `onHooklessQuestionGone` dep is wired
    * (pre-#888 behavior: hook-less questions are never actively resolved).
    * The dep is invoked outside any try/catch at some call sites, so a throw
    * is caught and logged here rather than trusted to the caller.
    */
+  /**
+   * Record `id` as THE card this screen's prompt owns, resolving whatever card
+   * held that slot before it (#1005 Change B).
+   *
+   * One PTY renders one prompt, so at most one render-born card can be live.
+   * A confirmed-registered replacement render IS the screen's current prompt,
+   * which makes the previous card's prompt provably gone — the same reasoning
+   * #888/#920 already applied, but that version was scoped to `hookRecord ===
+   * undefined` and so covered only genuinely hook-less cards.
+   *
+   * The excluded cohort is where the leak lived. A parked subagent escalation
+   * is hook-BORN, but its hook was answered `passthrough` at park time (ADR
+   * 0004), so the PTY render is its only living evidence — identical in
+   * lifecycle to a hook-less card, and previously tracked by nothing. Its exits
+   * were an exact-signature tool-run match, a phone answer, or `SubagentStop`;
+   * a terminal DENY fires no tool call, the lead-`Stop` sweep skips subagent
+   * entries (#711), and an agent-team teammate can run for days without
+   * `SubagentStop`. So those cards had no working exit and accumulated until
+   * LRU eviction.
+   *
+   * Held cards never reach here: a held hook means Claude is BLOCKED on the
+   * hook response and is not rendering, so it has no render to be superseded
+   * by, and `pushHeldHook` is a different trigger entirely.
+   */
+  private adoptRenderOwnedQuestion(id: string): void {
+    if (this.observedRenderOwnedQuestion !== null && this.observedRenderOwnedQuestion !== id) {
+      this.noteHooklessGone('pty_render_superseded');
+    }
+    this.observedRenderOwnedQuestion = id;
+  }
+
   private noteHooklessGone(reason: string): void {
-    const id = this.observedHooklessQuestion;
+    const id = this.observedRenderOwnedQuestion;
     if (id === null) return;
-    this.observedHooklessQuestion = null;
+    this.observedRenderOwnedQuestion = null;
     try {
       this.deps.onHooklessQuestionGone?.(id, reason);
     } catch (err) {
@@ -988,12 +1019,23 @@ export class QuestionPresenceTracker {
           );
           return;
         }
-        this.pushMerged(
+        const outcome = this.pushMerged(
           verdict.summary !== undefined && merged.summary === undefined
             ? { ...merged, summary: verdict.summary }
             : merged,
           'parked-render arbitration verdict; NO retry path exists for this push',
         );
+        // #1005 Change B: this push is render-born too, so it takes the
+        // render-owned slot like any other. Without this the escalate-verdict
+        // cohort -- the one whose exits are a tool-run match, a phone answer or
+        // `SubagentStop`, none of which fire on a terminal DENY -- was tracked
+        // by nothing and could only leave via LRU eviction. Gated on a
+        // CONFIRMED registration for the same reason `pairAndPush` is (ADR
+        // 0021): a deduped push changed nothing, so it must not retire the card
+        // that is still the best evidence of what is on screen.
+        if (outcome?.status === 'registered') {
+          this.adoptRenderOwnedQuestion(merged.id);
+        }
       });
   }
 
@@ -1104,7 +1146,7 @@ export class QuestionPresenceTracker {
       // a real hook event, and the tracker cannot tell which -- V1 treated
       // any status-leaves-waiting as "the render is gone" and a false
       // positive could resolve a question that never actually left the
-      // screen (found in review of #888). `observedHooklessQuestion` is
+      // screen (found in review of #888). `observedRenderOwnedQuestion` is
       // deliberately left untouched (not even nulled) so a LATER, genuinely
       // CONFIRMED supersession in `pairAndPush` can still resolve it --
       // losing this trigger costs a delayed cleanup, not a wrong one.
@@ -1350,7 +1392,7 @@ export class QuestionPresenceTracker {
 
   /** Test-only: the id of the currently-tracked hook-less question, if any
    *  (#888/#920), or null when none is tracked. */
-  observedHooklessQuestionForTest(): string | null {
-    return this.observedHooklessQuestion;
+  observedRenderOwnedQuestionForTest(): string | null {
+    return this.observedRenderOwnedQuestion;
   }
 }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -144,6 +144,15 @@ export type ParkedRenderArbiter = (ctx: {
 }) => Promise<ParkedRenderVerdict>;
 
 /** Pending-hook map key: the prompt's agent, or MAIN_AGENT_ID for the primary. */
+/** The one card the current on-screen prompt owns, and what identifies it. */
+interface RenderOwnedCard {
+  readonly id: string;
+  /** Agent the PTY prompt belonged to; a different agent never supersedes. */
+  readonly agent: string;
+  /** Raw PTY text, so a byte-identical redraw is not read as a replacement. */
+  readonly text: string;
+}
+
 function agentKey(question: Question): string {
   return question.agentId ?? MAIN_AGENT_ID;
 }
@@ -296,7 +305,7 @@ export class QuestionPresenceTracker {
    * / the Stop sweeps), so this mechanism -- scoped tightly to the one cohort
    * that has no other exit -- leaves it alone.
    */
-  private observedRenderOwnedQuestion: string | null = null;
+  private observedRenderOwnedQuestion: RenderOwnedCard | null = null;
 
   /** Count of MAIN-context auto-approve evals in flight. A PTY prompt that
    *  appears while this is > 0 is BUFFERED (not pushed): if the verdict is
@@ -648,7 +657,11 @@ export class QuestionPresenceTracker {
       // registered.
       return;
     }
-    this.adoptRenderOwnedQuestion(merged.id);
+    this.adoptRenderOwnedQuestion({
+      id: merged.id,
+      agent: agentKey(ptyQuestion),
+      text: ptyQuestion.text,
+    });
   }
 
   /**
@@ -683,16 +696,47 @@ export class QuestionPresenceTracker {
    * hook response and is not rendering, so it has no render to be superseded
    * by, and `pushHeldHook` is a different trigger entirely.
    */
-  private adoptRenderOwnedQuestion(id: string): void {
-    if (this.observedRenderOwnedQuestion !== null && this.observedRenderOwnedQuestion !== id) {
+  private adoptRenderOwnedQuestion(card: RenderOwnedCard): void {
+    const previous = this.observedRenderOwnedQuestion;
+    if (previous !== null && previous.id !== card.id && this.supersedes(previous, card)) {
       this.noteHooklessGone('pty_render_superseded');
     }
-    this.observedRenderOwnedQuestion = id;
+    this.observedRenderOwnedQuestion = card;
+  }
+
+  /**
+   * True when `next` genuinely REPLACES `previous` on screen, rather than
+   * merely following it.
+   *
+   * Two refusals, both found by driving concurrent agents through the real
+   * stack (#1008 review):
+   *
+   * 1. **A different agent's prompt proves nothing about this one.** Every
+   *    other piece of state in this file is agent-keyed (`pending`,
+   *    `awaitingPTY`, dedup, in-flight evals — see #425/#767/#799 for why
+   *    cross-agent bleed is dangerous); this slot was the exception. Subagent
+   *    B rendering an unrelated permission silently resolved subagent A's
+   *    escalated card: no answer, no tool run, no `SubagentStop`. Worse, the
+   *    cli.ts funnel then deleted A's `openQuestionSignatures` entry, killing
+   *    the exact-signature exit as well — reproducing the unremovable card
+   *    #1005 exists to fix, through a different door, for a permission the
+   *    gate had specifically judged risky enough to escalate.
+   *
+   * Text identity is deliberately NOT a second refusal here, though a review
+   * proposed it. A same-text redraw superseding is #888's stated policy ("the
+   * guard is delivery, not text identity"), and the harm does not apply: a
+   * supersede only fires on a CONFIRMED-registered replacement, so the user
+   * still holds a card for that prompt — the new one. Cross-agent is the
+   * asymmetric case, and the only one that leaves a prompt with no card at all.
+   */
+  private supersedes(previous: RenderOwnedCard, next: RenderOwnedCard): boolean {
+    return previous.agent === next.agent;
   }
 
   private noteHooklessGone(reason: string): void {
-    const id = this.observedRenderOwnedQuestion;
-    if (id === null) return;
+    const card = this.observedRenderOwnedQuestion;
+    if (card === null) return;
+    const id = card.id;
     this.observedRenderOwnedQuestion = null;
     try {
       this.deps.onHooklessQuestionGone?.(id, reason);
@@ -1034,7 +1078,11 @@ export class QuestionPresenceTracker {
         // 0021): a deduped push changed nothing, so it must not retire the card
         // that is still the best evidence of what is on screen.
         if (outcome?.status === 'registered') {
-          this.adoptRenderOwnedQuestion(merged.id);
+          this.adoptRenderOwnedQuestion({
+            id: merged.id,
+            agent: agentKey(ptyQuestion),
+            text: ptyQuestion.text,
+          });
         }
       });
   }
@@ -1393,6 +1441,6 @@ export class QuestionPresenceTracker {
   /** Test-only: the id of the currently-tracked hook-less question, if any
    *  (#888/#920), or null when none is tracked. */
   observedRenderOwnedQuestionForTest(): string | null {
-    return this.observedRenderOwnedQuestion;
+    return this.observedRenderOwnedQuestion?.id ?? null;
   }
 }

--- a/packages/daemon/src/api/question-presence-tracker.ts
+++ b/packages/daemon/src/api/question-presence-tracker.ts
@@ -659,7 +659,13 @@ export class QuestionPresenceTracker {
     }
     this.adoptRenderOwnedQuestion({
       id: merged.id,
-      agent: agentKey(ptyQuestion),
+      // Scope by the MERGED question, not the raw PTY parse. The parse often
+      // carries no `agentId` at all (`Do you want to proceed?` says nothing
+      // about whose permission it is), so keying on it filed a parked SUBAGENT
+      // card under `main` — and the next main-agent prompt then superseded it,
+      // which is the very cross-agent bleed the scoping exists to stop. The
+      // merge takes the hook record's agent, which is the one that knows.
+      agent: agentKey(merged),
       text: ptyQuestion.text,
     });
   }
@@ -1080,7 +1086,13 @@ export class QuestionPresenceTracker {
         if (outcome?.status === 'registered') {
           this.adoptRenderOwnedQuestion({
             id: merged.id,
-            agent: agentKey(ptyQuestion),
+            // Scope by the MERGED question, not the raw PTY parse. The parse often
+            // carries no `agentId` at all (`Do you want to proceed?` says nothing
+            // about whose permission it is), so keying on it filed a parked SUBAGENT
+            // card under `main` — and the next main-agent prompt then superseded it,
+            // which is the very cross-agent bleed the scoping exists to stop. The
+            // merge takes the hook record's agent, which is the one that knows.
+            agent: agentKey(merged),
             text: ptyQuestion.text,
           });
         }

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1608,6 +1608,20 @@ async function createNewSession(
         'QuestionPresenceTracker.onHooklessQuestionGone',
       );
       onQuestionResolved(sessionId, questionId as UUID, 'cancelled');
+      // #1005 Change B: since this trigger now also fires for HOOK-BORN cards,
+      // removing the card is no longer the whole job -- the gate still holds
+      // bookkeeping for it (`openQuestionSignatures`, and possibly a held
+      // hook keeping Claude blocked). Route it through the gate's own funnel so
+      // the entry is retired rather than left stale, and so a hold, if any, is
+      // released instead of stalling to `hold_timeout`. A no-op when the gate
+      // has nothing for this id.
+      try {
+        sessionGateHandles.get(sessionId)?.releaseHeldAsPassthrough?.(questionId as UUID);
+      } catch (err) {
+        logError(
+          `[QuestionPresenceTracker] gate cleanup for superseded ${questionId.slice(0, 8)} threw: ${errorToString(err)}`,
+        );
+      }
     },
   });
   // #920: register this session's tracker so the answer handler's

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -571,3 +571,38 @@ describe('#1008 a different agent never supersedes, and a redraw is not a replac
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
   });
 });
+
+/**
+ * #1008 review follow-up, found by probing rather than by the review.
+ *
+ * The first cut of the agent scoping keyed on the RAW PTY question. A PTY parse
+ * usually carries no `agentId` — "Do you want to proceed?" says nothing about
+ * whose permission it is — so `agentKey` fell back to `main` and filed a parked
+ * SUBAGENT card under the main agent. The next main-agent prompt then
+ * superseded it: exactly the cross-agent bleed the scoping was added to stop,
+ * reintroduced by the scoping itself.
+ *
+ * Keying on the MERGED question fixes it, because the merge takes the hook
+ * record's `agentId`, which is the half that knows.
+ */
+describe('#1008 a parked subagent card is scoped by its HOOK agent, not the PTY parse', () => {
+  test('a main-agent prompt does not resolve a parked subagent card', async () => {
+    const { tracker, gone } = buildTracker();
+    tracker.setParkedRenderArbiter(async () => ({ outcome: 'push' }));
+
+    const hook = makeHookRecord('reviewer · Bash: git push');
+    (hook as { agentId?: string }).agentId = 'agent-1';
+    tracker.recordPendingHook(hook);
+    tracker.parkAwaitingPTY(hook);
+
+    // The render itself carries NO agentId -- this is the normal case.
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Do you want to proceed?'));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hook.id);
+
+    // A genuinely different, main-agent prompt takes the screen.
+    tracker.onPTYPromptVisible(makeHooklessPTYQuestion('A different main prompt'));
+
+    expect(gone).toHaveLength(0);
+  });
+});

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -520,44 +520,71 @@ describe('#1005 an arbitration-verdict push takes the render-owned slot', () => 
  * exercised two concurrent agents in either direction, which is how that
  * shipped unnoticed.
  */
-describe('#1008 a different agent never supersedes, and a redraw is not a replacement', () => {
-  function makeAgentPTY(agentId: string, text: string): Question {
-    return { ...makeHooklessPTYQuestion(text), agentId } as Question;
+/**
+ * #1008 review. The render-owned slot was the ONE piece of state in this file
+ * that was not agent-keyed, and #1008 moved the highest-stakes cohort
+ * (deliberately-escalated subagent permissions) into it.
+ *
+ * These drive the REAL path: a hook record carries the `agentId`, the PTY render
+ * carries NONE (the parser never sets one — grep `question-parser.ts`), and
+ * pairing happens through `parkAwaitingPTY` + `onOrphanPTYPrompt`. An earlier
+ * version of these tests hand-set `agentId` on the raw PTY question and used
+ * `onPTYPromptVisible`, which is only reached when the hook server is OFF — so
+ * they exercised a shape that cannot occur in production and passed while the
+ * scoping was broken. Caught in review.
+ */
+describe('#1008 a different agent never supersedes, driven through the real path', () => {
+  function parkAndRender(
+    tracker: ReturnType<typeof buildTracker>['tracker'],
+    agentId: string,
+    text: string,
+  ): Question {
+    const hook = makeHookRecord(text);
+    (hook as { agentId?: string }).agentId = agentId;
+    tracker.recordPendingHook(hook);
+    tracker.parkAwaitingPTY(hook);
+    // The raw render carries NO agentId, exactly as the parser produces it.
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Do you want to proceed?'));
+    return hook;
   }
 
-  test('agent B rendering does NOT resolve agent A card', () => {
+  test('subagent B rendering does NOT resolve subagent A card', async () => {
     const { tracker, gone } = buildTracker();
-    const a = makeAgentPTY('agent-a', 'Allow Bash: git push');
-    tracker.onPTYPromptVisible(a);
+    tracker.setParkedRenderArbiter(async () => ({ outcome: 'push' }));
+
+    const a = parkAndRender(tracker, 'agent-a', 'reviewer · Bash: git push');
+    await new Promise((r) => setTimeout(r, 5));
     expect(tracker.observedRenderOwnedQuestionForTest()).toBe(a.id);
 
-    // A completely unrelated agent's permission renders on the shared PTY.
-    // Nobody answered A; no tool ran; no SubagentStop fired.
-    const b = makeAgentPTY('agent-b', 'Allow Bash: rm -rf build');
-    tracker.onPTYPromptVisible(b);
+    parkAndRender(tracker, 'agent-b', 'builder · Bash: rm -rf build');
+    await new Promise((r) => setTimeout(r, 5));
 
-    expect(gone).toHaveLength(0); // A must survive
+    // Nobody answered A. No tool ran. No SubagentStop fired.
+    expect(gone).toHaveLength(0);
   });
 
-  test('the SAME agent rendering something different does supersede', () => {
+  test('the SAME agent rendering something different does supersede', async () => {
     const { tracker, gone } = buildTracker();
-    const first = makeAgentPTY('agent-a', 'Allow Bash: git push');
-    tracker.onPTYPromptVisible(first);
-    tracker.onPTYPromptVisible(makeAgentPTY('agent-a', 'Allow Bash: something else'));
+    tracker.setParkedRenderArbiter(async () => ({ outcome: 'push' }));
+
+    const first = parkAndRender(tracker, 'agent-a', 'reviewer · Bash: git push');
+    await new Promise((r) => setTimeout(r, 5));
+    parkAndRender(tracker, 'agent-a', 'reviewer · Bash: something else');
+    await new Promise((r) => setTimeout(r, 5));
 
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
   });
 
   test('a same-agent redraw DOES supersede, and that is correct', () => {
-    // Review proposed refusing this too (a redraw is "the same prompt"). It is
-    // #888's deliberate policy -- "the guard is delivery, not text identity" --
-    // and the harm does not apply: a supersede only fires on a CONFIRMED
-    // registration, so the user still holds a card for this prompt, the new
-    // one. Cross-agent above is the case that leaves a prompt with NO card.
+    // Review proposed refusing this too ("a redraw is the same prompt"), then
+    // retracted on the same reasoning: a supersede only fires on a CONFIRMED
+    // registration, so the user always holds a card for the current prompt --
+    // the new one. Cross-agent above is the case that leaves a prompt with NO
+    // card. Kept as a main-agent case, where an agentless render is real.
     const { tracker, gone } = buildTracker();
-    const first = makeAgentPTY('agent-a', 'Do you want to proceed?');
+    const first = makeHooklessPTYQuestion('Do you want to proceed?');
     tracker.onPTYPromptVisible(first);
-    tracker.onPTYPromptVisible(makeAgentPTY('agent-a', 'Do you want to proceed?'));
+    tracker.onPTYPromptVisible(makeHooklessPTYQuestion('Do you want to proceed?'));
 
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
   });
@@ -572,19 +599,6 @@ describe('#1008 a different agent never supersedes, and a redraw is not a replac
   });
 });
 
-/**
- * #1008 review follow-up, found by probing rather than by the review.
- *
- * The first cut of the agent scoping keyed on the RAW PTY question. A PTY parse
- * usually carries no `agentId` — "Do you want to proceed?" says nothing about
- * whose permission it is — so `agentKey` fell back to `main` and filed a parked
- * SUBAGENT card under the main agent. The next main-agent prompt then
- * superseded it: exactly the cross-agent bleed the scoping was added to stop,
- * reintroduced by the scoping itself.
- *
- * Keying on the MERGED question fixes it, because the merge takes the hook
- * record's `agentId`, which is the half that knows.
- */
 describe('#1008 a parked subagent card is scoped by its HOOK agent, not the PTY parse', () => {
   test('a main-agent prompt does not resolve a parked subagent card', async () => {
     const { tracker, gone } = buildTracker();

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -512,3 +512,62 @@ describe('#1005 an arbitration-verdict push takes the render-owned slot', () => 
     expect(tracker.observedRenderOwnedQuestionForTest()).toBeNull();
   });
 });
+
+/**
+ * #1008 review. The render-owned slot was the ONE piece of state in this file
+ * that was not agent-keyed, and #1008 moved the highest-stakes cohort
+ * (deliberately-escalated subagent permissions) into it. Nothing in this file
+ * exercised two concurrent agents in either direction, which is how that
+ * shipped unnoticed.
+ */
+describe('#1008 a different agent never supersedes, and a redraw is not a replacement', () => {
+  function makeAgentPTY(agentId: string, text: string): Question {
+    return { ...makeHooklessPTYQuestion(text), agentId } as Question;
+  }
+
+  test('agent B rendering does NOT resolve agent A card', () => {
+    const { tracker, gone } = buildTracker();
+    const a = makeAgentPTY('agent-a', 'Allow Bash: git push');
+    tracker.onPTYPromptVisible(a);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(a.id);
+
+    // A completely unrelated agent's permission renders on the shared PTY.
+    // Nobody answered A; no tool ran; no SubagentStop fired.
+    const b = makeAgentPTY('agent-b', 'Allow Bash: rm -rf build');
+    tracker.onPTYPromptVisible(b);
+
+    expect(gone).toHaveLength(0); // A must survive
+  });
+
+  test('the SAME agent rendering something different does supersede', () => {
+    const { tracker, gone } = buildTracker();
+    const first = makeAgentPTY('agent-a', 'Allow Bash: git push');
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(makeAgentPTY('agent-a', 'Allow Bash: something else'));
+
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+  });
+
+  test('a same-agent redraw DOES supersede, and that is correct', () => {
+    // Review proposed refusing this too (a redraw is "the same prompt"). It is
+    // #888's deliberate policy -- "the guard is delivery, not text identity" --
+    // and the harm does not apply: a supersede only fires on a CONFIRMED
+    // registration, so the user still holds a card for this prompt, the new
+    // one. Cross-agent above is the case that leaves a prompt with NO card.
+    const { tracker, gone } = buildTracker();
+    const first = makeAgentPTY('agent-a', 'Do you want to proceed?');
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(makeAgentPTY('agent-a', 'Do you want to proceed?'));
+
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+  });
+
+  test('main-agent prompts still supersede each other', () => {
+    const { tracker, gone } = buildTracker();
+    const first = makeHooklessPTYQuestion('first prompt');
+    tracker.onPTYPromptVisible(first);
+    tracker.onPTYPromptVisible(makeHooklessPTYQuestion('second prompt'));
+
+    expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
+  });
+});

--- a/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
+++ b/packages/daemon/tests/api/question-presence-tracker-render-resolution.test.ts
@@ -135,7 +135,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(q);
     expect(pushed).toHaveLength(1);
     expect(pushed[0]?.id).toBe(q.id);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(q.id);
     expect(gone).toHaveLength(0); // nothing superseded yet
   });
 
@@ -147,7 +147,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(second);
 
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(second.id);
   });
 
   test('the hard requirement fix: a redraw whose replacement push is DEDUPED does NOT resolve the original', () => {
@@ -171,7 +171,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(liveIds.has(second.id)).toBe(false); // second never landed
     // Tracking still points at the original -- a LATER confirmed
     // supersession can still resolve it correctly.
-    expect(tracker.observedHooklessQuestionForTest()).toBe(first.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(first.id);
   });
 
   test('a redraw of the SAME text, once CONFIRMED delivered (e.g. a richer re-emission), still supersedes', () => {
@@ -190,7 +190,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(second);
 
     expect(gone).toEqual([{ id: first.id, reason: 'pty_render_superseded' }]);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(second.id);
   });
 
   test('status changes never resolve a hook-less question (trigger dropped, #888 review fix)', () => {
@@ -200,11 +200,11 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
 
     tracker.onStatusChange('executing'); // leaves 'waiting'
     expect(gone).toHaveLength(0);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(q.id);
 
     tracker.onStatusChange('waiting'); // back to 'waiting'
     expect(gone).toHaveLength(0);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(q.id);
   });
 
   test('clearPending never resolves a hook-less question (trigger dropped, #888 review fix)', () => {
@@ -216,25 +216,40 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     expect(gone).toHaveLength(0);
     // Tracking survives clearPending too -- a later CONFIRMED supersession
     // can still resolve it, exactly as if clearPending had never run.
-    expect(tracker.observedHooklessQuestionForTest()).toBe(q.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(q.id);
   });
 
-  test('a HOOK-PAIRED render is never tracked as hook-less (it has its own removal path)', () => {
+  /**
+   * CHANGED by #1005 Change B. This test previously asserted that a
+   * hook-paired render is NOT tracked, justified as "it has its own removal
+   * path". That justification was measured false for the cohort that matters:
+   * a parked subagent escalation is hook-BORN, but its hook was answered
+   * `passthrough` at park time (ADR 0004), so its only exits are an
+   * exact-signature tool-run match, a phone answer, or `SubagentStop` — and a
+   * terminal DENY fires no tool call, the lead-`Stop` sweep skips subagent
+   * entries (#711), and a teammate can run for days without `SubagentStop`.
+   *
+   * Tracing the 8 cards stuck in a real pending set: 7 subagent-tagged, every
+   * one removed ONLY by `lru_eviction`, 2.5-12.5h after being added. The
+   * "own removal path" did not exist. So a hook-paired render IS tracked now.
+   */
+  test('a HOOK-PAIRED render IS tracked as render-owned (#1005)', () => {
     const { tracker, gone } = buildTracker();
     const hookRecord = makeHookRecord();
     tracker.recordPendingHook(hookRecord);
     const ptyRender = makeHooklessPTYQuestion(); // agentless -> pairs as sole candidate
     tracker.onPTYPromptVisible(ptyRender);
 
-    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
-    expect(gone).toHaveLength(0); // nothing hook-less was ever tracked
+    // The merged push adopts the HOOK's id (#887), so that is what is tracked.
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hookRecord.id);
+    expect(gone).toHaveLength(0); // nothing was superseded yet
   });
 
   test('a hook-paired render, CONFIRMED delivered, SUPERSEDES a previously-tracked hook-less one', () => {
     const { tracker, gone } = buildTracker();
     const hookless = makeHooklessPTYQuestion('orphan prompt');
     tracker.onPTYPromptVisible(hookless);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(hookless.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hookless.id);
 
     const hookRecord = makeHookRecord();
     tracker.recordPendingHook(hookRecord);
@@ -242,9 +257,10 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(paired);
 
     expect(gone).toEqual([{ id: hookless.id, reason: 'pty_render_superseded' }]);
-    // The merged push adopted the HOOK's id (#887) -- tracking is null now,
-    // not the merged id, because the merge was hook-paired.
-    expect(tracker.observedHooklessQuestionForTest()).toBeNull();
+    // The merged push adopted the HOOK's id (#887), and since #1005 a
+    // hook-paired render takes the render-owned slot rather than clearing it —
+    // so the NEXT confirmed render can resolve this one in turn.
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hookRecord.id);
   });
 
   test('a HELD-hook push (always hook-derived) never touches hook-less tracking', () => {
@@ -260,7 +276,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     // The hook-less question is untouched by the held push -- it is a
     // completely separate mechanism (#573) that never renders on the PTY,
     // and pushHeldHook never runs the confirmed-delivery gate at all.
-    expect(tracker.observedHooklessQuestionForTest()).toBe(hookless.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hookless.id);
     expect(gone).toHaveLength(0);
   });
 
@@ -282,7 +298,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onPTYPromptVisible(first);
     expect(() => tracker.onPTYPromptVisible(second)).not.toThrow();
     // Tracking still advances correctly despite the dep throwing.
-    expect(tracker.observedHooklessQuestionForTest()).toBe(second.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(second.id);
   });
 
   test('no onHooklessQuestionGone dep wired: tracker behaves exactly as before #888', () => {
@@ -355,7 +371,7 @@ describe('QuestionPresenceTracker render-resolution (#888/#920)', () => {
     tracker.onOrphanPTYPrompt(first);
     await new Promise((r) => setTimeout(r, 30));
     expect(pushed).toHaveLength(1);
-    expect(tracker.observedHooklessQuestionForTest()).toBe(first.id);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(first.id);
 
     const second = makeHooklessPTYQuestion('orphan B');
     tracker.onOrphanPTYPrompt(second);
@@ -417,5 +433,82 @@ describe('#1002 prompt-on-screen signals are not interchangeable', () => {
     tracker.onPTYPromptVisible(makeHooklessPTYQuestion());
     expect(tracker.isPromptVisibleOnPTY()).toBe(true);
     expect(tracker.isPromptObservedOnPTY()).toBe(true);
+  });
+});
+
+/**
+ * #1005 Change B. The parked-render ARBITRATION push (an escalate verdict, the
+ * "45 born live" cohort) went through `pushMerged` directly, bypassing the
+ * render-owned bookkeeping entirely — so those cards were tracked by nothing
+ * and could only ever leave the store via LRU eviction.
+ */
+describe('#1005 an arbitration-verdict push takes the render-owned slot', () => {
+  function trackerWithArbiter(
+    pushes: Question[],
+    gone: Array<{ id: string; reason: string }>,
+    verdict: 'push' | 'answered',
+    deliver: () => boolean = () => true,
+  ): QuestionPresenceTracker {
+    const tracker = new QuestionPresenceTracker(
+      (q) => {
+        pushes.push(q);
+        return deliver() ? { status: 'registered' as const } : { status: 'deduped' as const };
+      },
+      { onHooklessQuestionGone: (id, reason) => gone.push({ id, reason }) },
+    );
+    tracker.setParkedRenderArbiter(async () => ({ outcome: verdict }));
+    return tracker;
+  }
+
+  test('an escalated parked render is superseded by the next confirmed render', async () => {
+    const pushes: Question[] = [];
+    const gone: Array<{ id: string; reason: string }> = [];
+    const tracker = trackerWithArbiter(pushes, gone, 'push');
+
+    const hook = makeHookRecord('reviewer · Bash: git push');
+    tracker.recordPendingHook(hook);
+    tracker.parkAwaitingPTY(hook);
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Do you want to proceed?'));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(pushes).toHaveLength(1);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBe(hook.id);
+
+    // A different prompt takes the screen: the escalated card's prompt is
+    // provably gone, so the card is resolved instead of lingering.
+    tracker.onPTYPromptVisible(makeHooklessPTYQuestion('A different prompt'));
+    expect(gone).toEqual([{ id: hook.id, reason: 'pty_render_superseded' }]);
+  });
+
+  test('an UNCONFIRMED arbitration push does not claim the slot (ADR 0021)', async () => {
+    const pushes: Question[] = [];
+    const gone: Array<{ id: string; reason: string }> = [];
+    const tracker = trackerWithArbiter(pushes, gone, 'push', () => false);
+
+    const hook = makeHookRecord('reviewer · Bash: git push');
+    tracker.recordPendingHook(hook);
+    tracker.parkAwaitingPTY(hook);
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Do you want to proceed?'));
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Deduped: nothing is known to have changed, so nothing is tracked and
+    // nothing is resolved on its strength.
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBeNull();
+    expect(gone).toHaveLength(0);
+  });
+
+  test('an ANSWERED verdict pushes nothing and claims nothing', async () => {
+    const pushes: Question[] = [];
+    const gone: Array<{ id: string; reason: string }> = [];
+    const tracker = trackerWithArbiter(pushes, gone, 'answered');
+
+    const hook = makeHookRecord('reviewer · Bash: git push');
+    tracker.recordPendingHook(hook);
+    tracker.parkAwaitingPTY(hook);
+    tracker.onOrphanPTYPrompt(makeHooklessPTYQuestion('Do you want to proceed?'));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(pushes).toHaveLength(0);
+    expect(tracker.observedRenderOwnedQuestionForTest()).toBeNull();
   });
 });

--- a/packages/daemon/tests/session/question-containers-classification.test.ts
+++ b/packages/daemon/tests/session/question-containers-classification.test.ts
@@ -134,9 +134,9 @@ const REGISTRY: readonly Entry[] = [
   },
   {
     file: 'api/question-presence-tracker.ts',
-    field: 'observedHooklessQuestion',
+    field: 'observedRenderOwnedQuestion',
     cls: 'post-card-metadata',
-    note: 'Id of the currently-PUSHED hook-less question (#888/#920) -- tracks a card the store already owns, to know when to resolve it on a confirmed superseding render.',
+    note: 'Id of the currently-PUSHED render-born question (#888/#920, widened by #1005). Tracks a card the store already owns, to know when to resolve it on a confirmed superseding render. Was `observedHooklessQuestion`, scoped to hookRecord === undefined; that excluded parked subagent escalations, which are hook-BORN but whose hook was answered passthrough at park time (ADR 0004), so the render is their only living evidence and nothing tracked them at all -- they left the store only via lru_eviction. Held cards still never reach here (a held hook means Claude is blocked, not rendering; pushHeldHook is a different trigger).',
   },
   {
     file: 'api/question-presence-tracker.ts',


### PR DESCRIPTION
Part of #1005 — Change B, the other half. #1006 (Change A) stopped retired
escalations minting unremovable cards; this gives the cards that ARE
legitimately created a working exit.

## What leaked

`#888/#920` already resolves a card when a new CONFIRMED render takes the
screen: one PTY renders one prompt, so a confirmed replacement proves the
previous prompt is gone. It was scoped to `hookRecord === undefined`, and that
scoping is the leak.

A parked subagent escalation is hook-BORN, but its hook was answered
`passthrough` at park time (ADR 0004) — so the PTY render is its only living
evidence, identical in lifecycle to a hook-less card, and tracked by nothing.

Its exits were: an exact-signature tool-run match, a phone answer, or
`SubagentStop`. A terminal **deny** fires no tool call; the lead-`Stop` sweep
deliberately skips subagent entries (#711); and an agent-team teammate can run
for days without `SubagentStop`. In the owner's actual usage, those cards had no
working exit at all.

Measured, tracing the 8 ids in a real `STALE_ANSWER` pending set: **7 of 8
subagent-tagged, every one removed ONLY by `lru_eviction`**, 2.5-12.5 hours
after being added.

## The change

- The slot is **render-owned** rather than hookless-only.
- The parked-render **arbitration** push participates too. It called
  `pushMerged` directly and was tracked by nothing at all — that is the
  escalate-verdict cohort, the other half of the leak.
- Still gated on a CONFIRMED registration (ADR 0021): a deduped push changed
  nothing, so it must not retire the card that is still the best evidence of
  what is on screen.
- `cli.ts` routes a superseded card through the gate's funnel
  (`releaseHeldAsPassthrough`). Removing the card is no longer the whole job
  once this fires for hook-born ids: the gate still holds
  `openQuestionSignatures` for it, and possibly a hold keeping Claude blocked.

**Held cards still never reach this path.** A held hook means Claude is blocked
on the hook response and is not rendering, so it has no render to be superseded
by, and `pushHeldHook` is a separate trigger. The existing test pinning that is
untouched and still passes.

## Two existing tests changed — please scrutinize

`a HOOK-PAIRED render is never tracked as hook-less (it has its own removal
path)` asserted exactly the scoping this PR removes, and its parenthetical is
the assumption that produced the leak: for this cohort that removal path does
not fire. Updated with the measured evidence rather than the assumption, and
renamed to what it now pins.

The second is the same assertion in a supersede test.

I am flagging these rather than burying them, because "the test said so" is how
the original scoping survived — and because changing a test to make a change
pass is exactly the move that deserves a second pair of eyes.

## Risk direction

This makes the daemon resolve cards it previously kept. **The failure mode is
hiding a live question**, which is worse than a redundant card, so the trigger
is deliberately the narrowest available: only a confirmed-registered replacement
render, never a status transition, never an unconfirmed push. Those weaker
triggers were considered and rejected in #888's own review and stay rejected.

## Verification

- Mutation: hookless-only tracking -> **2 RED**; arbitration push skips the slot
  -> **1 RED**; confirmed-delivery gate dropped -> **1 RED**.
- Full daemon suite: 4489 tests, **0 fail**.
- The container-inventory scanner caught the field rename on its own, as
  designed — the registry entry is updated with why the scoping changed.

## Expected effect

Steady state becomes: held cards + at most one render-owned card. Reconnects
then re-send only answerable cards, and `hasLiveQuestions` stops being
permanently true — which matters beyond tidiness, because while it is true the
tracker SUPPRESSES orphan-carding of genuinely new prompts
(question-presence-tracker.ts). The leak was actively hiding real questions.
