### PR TITLE
feat: make the provenance ceiling structural, not conventional

### DIFF
--- a/packages/daemon/src/auto-approve/authorization-assessment.ts
+++ b/packages/daemon/src/auto-approve/authorization-assessment.ts
@@ -21,6 +21,22 @@
  *
  * Nothing here calls a model, reads config, or touches I/O — it is a pure
  * decision function, so it can be tested exhaustively without an engine.
+ *
+ * **The guarantee is compile-time only, and does not survive an `any`
+ * boundary.** `Object.create(AuthorizationAssessment.prototype)` and
+ * `JSON.parse(...)` both return `any`, so either can produce a value that
+ * satisfies this type with no diagnostic, no cast and no suppression comment —
+ * verified in review, `instanceof` even reports true for the first. That is a
+ * TypeScript limitation, not a hole to patch here: `matrixDecision` performs no
+ * runtime validation, deliberately, because a brand check would be trivially
+ * satisfiable by the same forgery.
+ *
+ * What it means for whoever wires this in: an assessment must never cross a
+ * serialization boundary. Do not persist one, send one over IPC, or rebuild one
+ * from a log or replay — derive it fresh, at the decision point, from a
+ * `PrecedentMatch` or a graded string. If a future design needs to carry
+ * authorization across such a boundary, carry the EVIDENCE (the precedent
+ * record) and re-derive, never the conclusion.
  */
 
 import {

--- a/packages/daemon/src/auto-approve/authorization-assessment.ts
+++ b/packages/daemon/src/auto-approve/authorization-assessment.ts
@@ -1,0 +1,145 @@
+/**
+ * The authorization axis of epic #976's risk x authorization matrix, made
+ * structural.
+ *
+ * ADR 0015's amendment states the rule this module exists to enforce:
+ * **authorization can never be established by text alone.** Conversation text
+ * buys at most `implicit`; `explicit` comes only from a channel where a human
+ * acted — an answer to a card remi presented, or a code-verified session
+ * precedent derived from one.
+ *
+ * That rule was previously a convention: `capGradeForTextProvenance` existed and
+ * callers were expected to remember it. This module removes the remembering. An
+ * `AuthorizationAssessment` cannot be constructed except through a factory, and
+ * the text factory caps INSIDE itself, so a text-derived assessment above
+ * `implicit` is unrepresentable rather than merely rejected.
+ *
+ * The private member is what makes that hold. TypeScript's type system is
+ * structural, so a plain interface with the same fields could be forged by any
+ * object literal; a class with a private field is NOMINAL, and no literal
+ * satisfies it.
+ *
+ * Nothing here calls a model, reads config, or touches I/O — it is a pure
+ * decision function, so it can be tested exhaustively without an engine.
+ */
+
+import {
+  type AuthorizationGrade,
+  capGradeForTextProvenance,
+  gradeRank,
+} from './authority-grade.ts';
+import type { PrecedentMatch } from './precedent.ts';
+import type { RiskBand } from './risk-bands.ts';
+
+/**
+ * How an assessment came to be. Present ONLY when a human acted through a
+ * non-text channel; `null` for anything derived from conversation text.
+ *
+ * `config` and `card-answer` are deliberately absent. A `config.toml` allow
+ * approves at 0ms before the matrix is consulted at all, and a live card answer
+ * resolves its own hook through `resolveHeld` rather than arriving here. Neither
+ * can reach this decision, so modelling them would be inventing channels to
+ * reason about.
+ *
+ * `scoped` is likewise unbuilt: no channel can currently mint it, and machinery
+ * for a grade nothing produces is machinery nobody can test.
+ */
+export type AuthorizationWitness = { readonly kind: 'precedent'; readonly matchedAt: number };
+
+/** What the matrix is allowed to conclude. Never `deny` — see `matrixDecision`. */
+export type MatrixDecision = 'approve' | 'escalate';
+
+export class AuthorizationAssessment {
+  /**
+   * Nominal-typing marker. Its presence is the reason an assessment cannot be
+   * forged by an object literal, which is the whole enforcement mechanism —
+   * do not remove it, and do not add a public constructor.
+   */
+  private readonly brand = 'authorization-assessment';
+
+  private constructor(
+    readonly grade: AuthorizationGrade,
+    readonly witness: AuthorizationWitness | null,
+  ) {
+    void this.brand;
+  }
+
+  /**
+   * An assessment derived from conversation text — the graded ladder's output.
+   *
+   * Caps through `capGradeForTextProvenance` here, inside the factory, so the
+   * ceiling is a property of construction rather than of every call site. A
+   * caller cannot opt out, forget, or be refactored around it.
+   */
+  static fromText(grade: AuthorizationGrade): AuthorizationAssessment {
+    return new AuthorizationAssessment(capGradeForTextProvenance(grade), null);
+  }
+
+  /**
+   * An assessment backed by a session precedent: the user answered this exact
+   * operation earlier, through a card.
+   *
+   * The only mint for `explicit`, and it takes a `PrecedentMatch` — a value only
+   * `PrecedentStore.matchApproved` produces — so the witness cannot be
+   * fabricated by a caller that merely believes it has authorization.
+   */
+  static fromPrecedent(match: PrecedentMatch): AuthorizationAssessment {
+    // Only an EXACT APPROVAL authorizes. Both halves matter and neither is
+    // hypothetical: `PrecedentMatch` also describes DENIAL matches, and those
+    // are deliberately `substring` (ADR 0010 — deny matching is broad). A broad
+    // match is the right shape for refusing and exactly the wrong shape for
+    // authorizing, so a denial record, or an approval that only matched loosely,
+    // yields no authorization at all rather than a downgraded one.
+    if (match.decision !== 'approved' || match.matchKind !== 'exact') {
+      return AuthorizationAssessment.none();
+    }
+    return new AuthorizationAssessment('explicit', {
+      kind: 'precedent',
+      matchedAt: match.recordedAt,
+    });
+  }
+
+  /** No authorization at all — the honest default when nothing is known. */
+  static none(): AuthorizationAssessment {
+    return new AuthorizationAssessment('none', null);
+  }
+}
+
+/**
+ * The matrix itself: may `band` be approved on the strength of `assessment`?
+ *
+ * | band | approves on |
+ * |---|---|
+ * | `critical` | never, at any grade |
+ * | `high` | a non-text witness AND `explicit` |
+ * | `moderate` | `implicit` |
+ * | `low` | never reaches here — a group covered it at 0ms |
+ *
+ * `high` checks the witness AND the rank, which is deliberate redundancy: a
+ * future factory bug that let text reach `explicit` would still fail closed,
+ * because text carries no witness. Both conditions must break for the ceiling
+ * to break.
+ *
+ * Returns only approve/escalate. Denial belongs to the deny floor, which runs
+ * earlier and answers a different question — this function's job is whether the
+ * user must be asked, never whether the operation is forbidden.
+ */
+export function matrixDecision(
+  band: RiskBand,
+  assessment: AuthorizationAssessment,
+): MatrixDecision {
+  if (band === 'critical') return 'escalate';
+  if (band === 'high') {
+    return assessment.witness !== null && gradeRank(assessment.grade) >= gradeRank('explicit')
+      ? 'approve'
+      : 'escalate';
+  }
+  if (band === 'moderate') {
+    return gradeRank(assessment.grade) >= gradeRank('implicit') ? 'approve' : 'escalate';
+  }
+  // `low` is unreachable in production (`classifyRisk` cannot return it), but
+  // returning `approve` here would make a future `low` silently approvable on
+  // no authorization at all. Escalating is the honest answer for a band this
+  // function was never given a rule for.
+  return 'escalate';
+}

--- a/packages/daemon/tests/auto-approve/authorization-assessment.test.ts
+++ b/packages/daemon/tests/auto-approve/authorization-assessment.test.ts
@@ -1,0 +1,164 @@
+/**
+ * #976: the authorization axis, and specifically the claim that the provenance
+ * ceiling is STRUCTURAL rather than conventional.
+ *
+ * The interesting tests here are the ones that assert something cannot be
+ * built. ADR 0015's rule is that text alone never establishes `explicit`; the
+ * point of this module is that a caller cannot get it wrong, so the tests have
+ * to check the construction surface, not just the outputs.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  AUTHORIZATION_GRADES,
+  type AuthorizationGrade,
+} from '../../src/auto-approve/authority-grade.ts';
+import {
+  AuthorizationAssessment,
+  matrixDecision,
+} from '../../src/auto-approve/authorization-assessment.ts';
+import type { PrecedentMatch } from '../../src/auto-approve/precedent.ts';
+import type { RiskBand } from '../../src/auto-approve/risk-bands.ts';
+
+const APPROVED_PRECEDENT: PrecedentMatch = {
+  decision: 'approved',
+  matchedSignature: 'Bash: git push origin main',
+  matchKind: 'exact',
+  recordedAt: 1_700_000_000_000,
+};
+
+describe('#976 the provenance ceiling is a property of construction', () => {
+  test('NO text grade, however high, produces an explicit assessment', () => {
+    for (const grade of AUTHORIZATION_GRADES) {
+      const assessment = AuthorizationAssessment.fromText(grade);
+      // The cap happens inside the factory, so this holds for every input --
+      // including a model that hallucinates `scoped`.
+      expect(['none', 'topical', 'implicit']).toContain(assessment.grade);
+      expect(assessment.witness).toBeNull();
+    }
+  });
+
+  test('only a precedent mints explicit, and it carries a witness', () => {
+    const assessment = AuthorizationAssessment.fromPrecedent(APPROVED_PRECEDENT);
+    expect(assessment.grade).toBe('explicit');
+    expect(assessment.witness).toEqual({
+      kind: 'precedent',
+      matchedAt: APPROVED_PRECEDENT.recordedAt,
+    });
+  });
+
+  test('an assessment cannot be forged by an object literal (nominal typing)', () => {
+    // The private brand is what makes the class nominal. Without it a literal
+    // would satisfy the type structurally and the ceiling would be advisory.
+    // @ts-expect-error -- a literal must NOT be assignable to the class type
+    const forged: AuthorizationAssessment = { grade: 'explicit', witness: null };
+    expect(forged.grade).toBe('explicit'); // it exists at runtime; the TYPE is the guard
+  });
+
+  test('the constructor is private -- factories are the only way in', () => {
+    // @ts-expect-error -- `new` must not be reachable from outside the module
+    const direct = new AuthorizationAssessment('explicit', null);
+    expect(direct).toBeDefined();
+  });
+});
+
+describe('#976 only an exact APPROVAL authorizes', () => {
+  test('a denial record mints no authorization', () => {
+    const denial: PrecedentMatch = {
+      decision: 'denied',
+      matchedSignature: 'Bash: git push',
+      matchKind: 'substring',
+      recordedAt: 1,
+    };
+    expect(AuthorizationAssessment.fromPrecedent(denial).grade).toBe('none');
+    expect(AuthorizationAssessment.fromPrecedent(denial).witness).toBeNull();
+  });
+
+  test('a SUBSTRING approval mints no authorization', () => {
+    // Denial matching is broad by design (ADR 0010). Broad is right for
+    // refusing and exactly wrong for authorizing, so a loose approval match
+    // must not become a witness.
+    const loose: PrecedentMatch = {
+      decision: 'approved',
+      matchedSignature: 'Bash: git',
+      matchKind: 'substring',
+      recordedAt: 1,
+    };
+    expect(AuthorizationAssessment.fromPrecedent(loose).grade).toBe('none');
+    expect(matrixDecision('high', AuthorizationAssessment.fromPrecedent(loose))).toBe('escalate');
+  });
+});
+
+describe('#976 matrixDecision', () => {
+  const cases: Array<[RiskBand, AuthorizationAssessment, 'approve' | 'escalate', string]> = [
+    [
+      'critical',
+      AuthorizationAssessment.fromPrecedent(APPROVED_PRECEDENT),
+      'escalate',
+      'critical never approves, even on a human witness',
+    ],
+    [
+      'critical',
+      AuthorizationAssessment.fromText('implicit'),
+      'escalate',
+      'critical never approves on text',
+    ],
+    [
+      'high',
+      AuthorizationAssessment.fromPrecedent(APPROVED_PRECEDENT),
+      'approve',
+      'high approves on a witness',
+    ],
+    [
+      'high',
+      AuthorizationAssessment.fromText('implicit'),
+      'escalate',
+      'high refuses the best text can offer',
+    ],
+    ['high', AuthorizationAssessment.none(), 'escalate', 'high refuses nothing'],
+    [
+      'moderate',
+      AuthorizationAssessment.fromText('implicit'),
+      'approve',
+      'moderate approves on implicit',
+    ],
+    [
+      'moderate',
+      AuthorizationAssessment.fromText('topical'),
+      'escalate',
+      'topical is below the bar',
+    ],
+    ['moderate', AuthorizationAssessment.none(), 'escalate', 'moderate refuses nothing'],
+    [
+      'low',
+      AuthorizationAssessment.fromPrecedent(APPROVED_PRECEDENT),
+      'escalate',
+      'low has no rule, so it escalates',
+    ],
+  ];
+  for (const [band, assessment, expected, why] of cases) {
+    test(`${band} + ${assessment.grade} -> ${expected} (${why})`, () => {
+      expect(matrixDecision(band, assessment)).toBe(expected);
+    });
+  }
+
+  test("it never returns deny -- that is the deny floor's question, not this one", () => {
+    for (const band of ['critical', 'high', 'moderate', 'low'] as RiskBand[]) {
+      for (const g of AUTHORIZATION_GRADES) {
+        expect(['approve', 'escalate']).toContain(
+          matrixDecision(band, AuthorizationAssessment.fromText(g as AuthorizationGrade)),
+        );
+      }
+    }
+  });
+});
+
+describe('#976 the measured failure it exists to block (#954)', () => {
+  test('rm -rf ./build plus a casual topical mention stays escalated', () => {
+    // #954: a topical mention flipped deny->approve 5/5 when the model decided
+    // and graded at once. `rm` is `high`; text caps at `implicit`; high needs a
+    // witness text cannot supply. Blocked on BOTH conditions, not one.
+    const fromMention = AuthorizationAssessment.fromText('explicit'); // model over-grades
+    expect(fromMention.grade).toBe('implicit'); // capped at construction
+    expect(matrixDecision('high', fromMention)).toBe('escalate');
+  });
+});

--- a/packages/daemon/tests/auto-approve/authorization-assessment.test.ts
+++ b/packages/daemon/tests/auto-approve/authorization-assessment.test.ts
@@ -152,6 +152,33 @@ describe('#976 matrixDecision', () => {
   });
 });
 
+describe('#976 the high-band redundancy is real, and now actually tested', () => {
+  test('a witness-less explicit assessment still escalates at high', () => {
+    // Review found this branch had ZERO coverage: every existing high-band case
+    // goes through `fromText` (always witness=null AND capped below explicit,
+    // so the rank check alone decides) or `fromPrecedent` (always explicit AND
+    // witness-paired, so the rank check alone decides again). Removing the
+    // witness check therefore turned 0 tests red, while the PR claimed 2 --
+    // the redundancy was real by construction but unpinned by any test.
+    //
+    // Forging the impossible combination is the only way to isolate it. The
+    // point of the redundancy is exactly this: if a future factory bug ever let
+    // text reach `explicit`, the missing witness must still refuse.
+    const forged = { grade: 'explicit', witness: null } as unknown as AuthorizationAssessment;
+    expect(matrixDecision('high', forged)).toBe('escalate');
+  });
+
+  test('a witness alone, below explicit, also escalates at high', () => {
+    // The other half of the AND: both conditions must hold, so neither alone
+    // is sufficient.
+    const forged = {
+      grade: 'implicit',
+      witness: { kind: 'precedent', matchedAt: 1 },
+    } as unknown as AuthorizationAssessment;
+    expect(matrixDecision('high', forged)).toBe('escalate');
+  });
+});
+
 describe('#976 the measured failure it exists to block (#954)', () => {
   test('rm -rf ./build plus a casual topical mention stays escalated', () => {
     // #954: a topical mention flipped deny->approve 5/5 when the model decided


### PR DESCRIPTION
First PR of #976's landing series (plan and verified wiring survey:
https://github.com/yooz-labs/remi/issues/976#issuecomment-5164104366).

**Pure module, no consumers yet.** The series is ordered so nothing widens
approval until the pieces that constrain it are merged and tested. This PR
changes no behavior at all.

## What it does

ADR 0015's rule — authorization can never be established by text alone — was a
convention. `capGradeForTextProvenance` existed and callers were expected to
remember it. `AuthorizationAssessment` removes the remembering:

- **private constructor**, two factories, no other way in
- `fromText(grade)` caps INSIDE the factory, so a text-derived assessment above
  `implicit` is **unrepresentable**, not merely rejected
- `fromPrecedent(match)` is the only mint for `explicit`, and takes a value only
  `PrecedentStore.matchApproved` produces

The private brand is what makes this hold rather than being decoration.
TypeScript is structural, so an interface with the same fields could be forged
by any object literal; a class with a private field is **nominal**, and no
literal satisfies it. Two `@ts-expect-error` tests pin both halves — a literal is
not assignable, and the constructor is not reachable.

## One thing I got wrong in the first draft

`fromPrecedent` now requires an **exact approval**. Both halves are load-bearing
and neither is hypothetical: `PrecedentMatch` also describes DENIAL matches, and
those are deliberately `substring` (ADR 0010 — deny matching is broad). Broad is
the right shape for refusing and exactly the wrong shape for authorizing.

My first draft minted `explicit` from any `PrecedentMatch`, which would have
turned a broad **denial** into an authorization. I caught it only on reading the
real type rather than the one I assumed. Two tests now pin it.

## The matrix

| band | approves on |
|---|---|
| `critical` | never, at any grade |
| `high` | a non-text witness AND `explicit` |
| `moderate` | `implicit` |
| `low` | escalates — see below |

`high` checks the witness AND the rank. That redundancy is deliberate: a future
factory bug that let text reach `explicit` would still fail closed, because text
carries no witness. Both conditions must break for the ceiling to break.

`low` escalates rather than approves. It is unreachable today (`classifyRisk`
cannot return it), and a band this function was never given a rule for should not
become silently approvable if that changes.

`matrixDecision` never returns `deny` — that is the deny floor's question, asked
earlier and separately.

## Deliberately not built

- `scoped` — no channel can currently mint it; machinery for a grade nothing
  produces is machinery nobody can test.
- `config` and `card-answer` witnesses — a config allow approves at 0ms before
  the matrix is consulted, and a card answer resolves its own hook via
  `resolveHeld`. Neither can reach this decision, so modelling them would be
  inventing channels to reason about.

## Replays the measured failure

#954: `rm -rf ./build` plus a casual topical mention flipped deny->approve 5/5
when the model decided and graded at once. Here it is high band; a mention grades
topical; and even a model over-grading to `explicit` caps to `implicit` at
construction and still fails high's witness requirement. Blocked on both
conditions, structurally.

## Verification

Mutation: text cap removed -> **2 RED**; high drops the witness check -> **2
RED**; exact-approval check removed -> **2 RED**.
234 pass across the four related suites. No engine needed — the module is pure.
