### PR TITLE
feat: log the risk band and authority presence on every decision

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -31,6 +31,7 @@ import {
 import { matchAllowPattern, matchSubstringPattern } from './pattern-matcher.ts';
 import { matchGroups } from './permission-groups.ts';
 import { buildPrompt } from './prompt-builder.ts';
+import { classifyRisk, formatMatrixContext } from './risk-bands.ts';
 import { enforceRiskCeiling } from './risk-ceiling.ts';
 import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
 
@@ -1054,8 +1055,20 @@ export class AutoApproveService {
 
         if (this.logDecisions) {
           const denyPrefix = result.decision === 'deny' ? `${prefix} DENIED` : prefix;
+          // #976 instrumentation. The matrix's WIDENING half is only worth
+          // building if a meaningful share of final escalates are
+          // (band=moderate + authority present) -- that is the sole population
+          // a text-derived grade could decide, since critical never approves
+          // and high needs a witness text cannot supply. Nobody has counted it.
+          //
+          // Emitted on every decision rather than only on escalates so the
+          // denominator is visible too: "12% of escalates are eligible" means
+          // nothing without knowing how many escalates there were.
           this.logFn(
-            `${denyPrefix} ${toolName}: ${result.decision} (${durationMs}ms) - ${result.reasoning}`,
+            `${denyPrefix} ${toolName}: ${result.decision} (${durationMs}ms) ${formatMatrixContext(
+              classifyRisk(toolName, toolInput),
+              authorityPresent,
+            )} - ${result.reasoning}`,
           );
         }
 

--- a/packages/daemon/src/auto-approve/risk-bands.ts
+++ b/packages/daemon/src/auto-approve/risk-bands.ts
@@ -869,3 +869,23 @@ export function classifyRisk(
 
   return classifyCommandMax(command, 0);
 }
+
+/**
+ * The matrix context a decision was taken in, for the decision log (#976).
+ *
+ * Extracted as a pure function rather than inlined into the template so the
+ * FORMAT is testable without an engine. The service's decision log only fires
+ * after a real LLM round-trip, and the repo forbids mocks, so an inline
+ * template string would be effectively untestable — and this string is not
+ * decoration, it is the measurement the decision to build (or not build) the
+ * matrix's widening half rests on.
+ *
+ * Both fields matter and neither is sufficient alone. `band` says whether a
+ * grade could ever be decisive (`critical` never approves; `high` needs a
+ * witness text cannot supply; only `moderate` is in play). `authority` says
+ * whether there was any text to grade. The eligible population is the
+ * intersection, and it has never been counted.
+ */
+export function formatMatrixContext(band: RiskBand, authorityPresent: boolean): string {
+  return `[band=${band} authority=${authorityPresent ? 'yes' : 'no'}]`;
+}

--- a/packages/daemon/tests/auto-approve/risk-bands.test.ts
+++ b/packages/daemon/tests/auto-approve/risk-bands.test.ts
@@ -13,6 +13,7 @@ import {
   RISK_BANDS,
   bandForGroupMatch,
   classifyRisk,
+  formatMatrixContext,
   riskBandAtLeast,
   riskBandRank,
 } from '../../src/auto-approve/risk-bands.ts';
@@ -464,5 +465,29 @@ describe('RISK_BANDS / riskBandRank / riskBandAtLeast', () => {
     expect(riskBandAtLeast('moderate', 'high')).toBe(false);
     expect(riskBandAtLeast('critical', 'low')).toBe(true);
     expect(riskBandAtLeast('low', 'critical')).toBe(false);
+  });
+});
+
+/**
+ * #976 instrumentation. This string is the measurement the decision to build
+ * (or abandon) the matrix's widening half rests on, so its format is pinned
+ * rather than left to a template literal nobody can test — the service's
+ * decision log only fires after a real LLM round-trip, and mocks are forbidden.
+ */
+describe('#976 formatMatrixContext', () => {
+  test('carries both axes, because neither is sufficient alone', () => {
+    expect(formatMatrixContext('moderate', true)).toBe('[band=moderate authority=yes]');
+    expect(formatMatrixContext('moderate', false)).toBe('[band=moderate authority=no]');
+    expect(formatMatrixContext('critical', true)).toBe('[band=critical authority=yes]');
+    expect(formatMatrixContext('high', false)).toBe('[band=high authority=no]');
+  });
+
+  test('the eligible population is greppable as one token', () => {
+    // The whole point: `band=moderate authority=yes` is the ONLY combination a
+    // text-derived grade could decide -- critical never approves, and high
+    // needs a witness text cannot supply. A field log has to be countable with
+    // one grep, or the measurement will not get taken.
+    const line = `AutoApprove Bash: escalate (5000ms) ${formatMatrixContext('moderate', true)} - reason`;
+    expect(line).toContain('band=moderate authority=yes');
   });
 });


### PR DESCRIPTION
#976 PR 2 of the landing series (plan:
https://github.com/yooz-labs/remi/issues/976#issuecomment-5164104366).

**Instrumentation only. No behavior change, nothing widens.**

## Why this exists

The matrix's widening half is only worth building if a meaningful share of final
escalates are **(band=moderate + authority present)**. That is the sole
population a text-derived grade could decide:

| band | can a text grade decide it? |
|---|---|
| `critical` | no — never approves at any grade |
| `high` | no — needs a witness text cannot supply |
| `moderate` | **yes** |
| `low` | no — never reaches the model |

Nobody has counted that slice. The landing plan deliberately defers the
build/don't-build decision until this measurement exists, and PR 6 is judged by
it. If the slice turns out to be small, the honest end state is to ship the
tightening half plus precedent and stop.

Emitted on **every** decision rather than only escalates, so the denominator is
visible. "12% of escalates are eligible" means nothing without knowing how many
escalates there were.

## Why the format is a function

`formatMatrixContext` is exported and pure rather than an inline template
literal. That is not tidiness:

- the service's decision log only fires after a real LLM round-trip
- this repo forbids mocks

so an inline template would be effectively untestable — and this string is not
decoration, it is the evidence a build/don't-build decision rests on. Two tests
pin the format, including that `band=moderate authority=yes` is greppable as a
single token. A measurement that needs a parser will not get taken.

## Deliberately not in this PR

Threading a read-only `PrecedentReader` through gate -> service, and the
`matchDenied` -> escalate consult. Those are plumbing with their own review
surface. This stands alone and is useful the moment it ships — it starts
collecting the data while the rest of the series is still in review.