### PR TITLE
fix: surface a deny instead of refusing silently (#1015)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1664,7 +1664,7 @@ export class AutoApproveGate {
     // The reconciliation NEVER pushes again — a late escalate just leaves the
     // existing hold in place (guarded by the pendingHolds membership check
     // inside reconcileLateVerdict), and pushHeldHook is itself idempotent.
-    void this.reconcileLateVerdict(safeEval, questionId);
+    void this.reconcileLateVerdict(input, safeEval, questionId);
     return heldDecision;
   }
 
@@ -1678,6 +1678,7 @@ export class AutoApproveGate {
    * double-resolve.
    */
   private async reconcileLateVerdict(
+    input: PermissionRequestHookInput,
     safeEval: Promise<{ ok: true; result: AutoApproveResult } | { ok: false; err: unknown }>,
     qid: UUID | undefined,
   ): Promise<void> {
@@ -1702,6 +1703,18 @@ export class AutoApproveGate {
       this.notifyResolved(qid, 'auto_approved');
       this.resolveHeld(qid, 'allow');
     } else if (result.decision === 'deny') {
+      // #1015: the THIRD deny path, and the least visible of the three. The
+      // user already has a card on their lock screen saying "needs your
+      // permission"; this dismisses it with a quiet content-available push
+      // carrying no title and no body. Without the report, the card simply
+      // vanishes and the refusal is invisible — worse than the synchronous
+      // deny, because the user saw a prompt and then saw it disappear.
+      //
+      // Found in review of this change, not by writing it: `reportDeny` was
+      // wired at the two SYNCHRONOUS deny returns and this async one was
+      // missed. It needed `input` threaded down a level, which is exactly why
+      // it was easy to miss and why the parameter now exists.
+      this.reportDeny(input, result);
       this.notifyResolved(qid, 'auto_denied');
       this.resolveHeld(qid, 'deny');
     } else if (result.decision === 'cancelled') {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -95,7 +95,7 @@ import { type DeliveryOutcome, isDelivered } from '../notifications/notification
 import type { SessionRegistry } from '../session/index.ts';
 import { buildDenyMessage } from './deny-floor.ts';
 import { isDesignQuestion, isMultiChoicePermission } from './multichoice.ts';
-import type { AutoApproveResult } from './types.ts';
+import type { AutoApproveResult, DenySource } from './types.ts';
 
 /** Hard cap on `parkedInputs` (#814). One entry per parked subagent
  *  permission awaiting a PTY render; a real agent fleet holds a handful at
@@ -358,6 +358,24 @@ export interface AutoApproveGateDeps {
    * is logged and absorbed, never propagated into the hook response.
    */
   onSubagentPassthrough?: (input: PermissionRequestHookInput) => void;
+  /**
+   * Every `deny` this gate returns to the hook (#1015), reported for
+   * observation ONLY — like `onSubagentPassthrough` above, the decision is
+   * already made by the time this fires and a sink cannot influence it.
+   *
+   * A deny is the one verdict with no user-facing surface of its own: it
+   * creates no `Question`, so no card is pushed and no `question_resolved`
+   * broadcast follows. Claude is told why (`buildDenyMessage`) and the human
+   * is told nothing. This dep is the human's channel.
+   *
+   * `source` says which mechanism refused, so the sink can treat the user's
+   * own standing `config.toml` rule differently from a model deny that merely
+   * survived the floor — see `DenySource`.
+   *
+   * Fire-and-forget and throw-safe, like the cosmetic cues: a sink that throws
+   * is logged and absorbed, never propagated into the hook response.
+   */
+  onAutoDenied?: (input: PermissionRequestHookInput, source: DenySource, reasoning: string) => void;
   /** Escalate to the user (wraps `handlers.onPermissionRequest`). Returns the id
    *  of the `Question` it created (#573), so a binary escalation can hold the
    *  hook keyed by that id and resolve it when the user answers; `undefined`
@@ -1475,6 +1493,7 @@ export class AutoApproveGate {
     }
     if (result.decision === 'deny') {
       this.markHandled(isSubagent);
+      this.reportDeny(input, result);
       // #976: carry the reason to Claude instead of a bare refusal, so it can
       // route around or ask the user rather than guess. `interrupt` is left
       // unset (false) so the turn continues and it can act on the message.
@@ -1536,6 +1555,7 @@ export class AutoApproveGate {
       if (second.decision === 'deny') {
         log(`[AutoApprove ${this.sessionTag}] escalate_model (${escalateModel}) denied`);
         this.markHandled(isSubagent);
+        this.reportDeny(input, second);
         // #976: same reasoned deny as the primary path above, carrying the
         // SECOND opinion's reasoning since that is the verdict being applied.
         return { behavior: 'deny', message: buildDenyMessage(second.reasoning) };
@@ -2169,6 +2189,39 @@ export class AutoApproveGate {
       fn();
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] ${label} cue threw (cosmetic; ignored):`, err);
+    }
+  }
+
+  /**
+   * Report a `deny` this gate is about to return to the hook (#1015).
+   *
+   * Called from BOTH deny returns — the primary verdict and the
+   * `escalate_model` second opinion — because both are equally invisible to
+   * the user, and a second-opinion deny is if anything the more surprising of
+   * the two (the fast model wanted to ask; the heavy one refused outright).
+   *
+   * Deliberately reads `denySource` off the result rather than re-deriving it:
+   * the service knows which mechanism refused, and a second derivation here is
+   * the drift this module has been bitten by repeatedly (see `DenySource`).
+   *
+   * A result with NO `denySource` is reported as a `model-floor` deny with an
+   * empty pattern rather than being dropped. That combination should be
+   * unreachable — every `return { decision: 'deny' }` in `evaluate` tags
+   * itself — but "the tag went missing" must not silently restore the exact
+   * invisibility this dep exists to end. Reporting too much is a nuisance;
+   * reporting nothing is the bug.
+   */
+  private reportDeny(input: PermissionRequestHookInput, result: AutoApproveResult): void {
+    const fn = this.deps.onAutoDenied;
+    if (!fn) return;
+    const source: DenySource =
+      'denySource' in result && result.denySource !== undefined
+        ? result.denySource
+        : { kind: 'model-floor', pattern: '' };
+    try {
+      fn(input, source, result.reasoning);
+    } catch (err) {
+      logError(`[AutoApprove ${this.sessionTag}] onAutoDenied sink threw (ignored):`, err);
     }
   }
 

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -12,7 +12,7 @@
 import { errorToString } from '@remi/shared';
 import { reconcileCounterfactual, shouldCounterfactual } from './authority-counterfactual.ts';
 import { enforceAuthorityBoundary } from './authority.ts';
-import { enforceDenyFloor } from './deny-floor.ts';
+import { denySourceForFloor, enforceDenyFloor } from './deny-floor.ts';
 import { fileActivityRecord } from './engine-activity.ts';
 import type { EngineHost } from './engine-host.ts';
 import { clearModelCache, pullModel, unloadModel } from './engine-models.ts';
@@ -695,7 +695,13 @@ export class AutoApproveService {
       if (denyMatch !== null) {
         const reasoning = `deny-matched pattern: "${denyMatch}"`;
         this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return { decision: 'deny', reasoning, durationMs: 0, model };
+        return {
+          decision: 'deny',
+          reasoning,
+          durationMs: 0,
+          model,
+          denySource: { kind: 'config', pattern: denyMatch },
+        };
       }
       // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
       // command to be covered and is right for the allow question below; asking
@@ -705,7 +711,13 @@ export class AutoApproveService {
       if (denyGroupMatch !== null) {
         const reasoning = `deny-matched group: "${denyGroupMatch}"`;
         this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return { decision: 'deny', reasoning, durationMs: 0, model };
+        return {
+          decision: 'deny',
+          reasoning,
+          durationMs: 0,
+          model,
+          denySource: { kind: 'config', pattern: denyGroupMatch },
+        };
       }
 
       // Allow list + approve groups: bypass the LLM for known-safe operations.
@@ -934,6 +946,14 @@ export class AutoApproveService {
             this.logFn(
               `${prefix} DENY FLOOR ${toolName}: deny -> escalate (no catastrophic pattern) (${durationMs}ms)`,
             );
+          } else {
+            // The deny STANDS: the model refused and the floor's pattern list
+            // agreed. That is the one deny nobody configured, and #997 measured
+            // the floor matching prose 7 times out of 8 on real traffic, so it
+            // is also the one most likely to be wrong. Tag it (#1015) so
+            // `cli.ts` can tell the user instead of the refusal vanishing.
+            const denySource = denySourceForFloor(floored);
+            if (denySource !== null) result = { ...result, denySource };
           }
         }
 

--- a/packages/daemon/src/auto-approve/deny-floor.ts
+++ b/packages/daemon/src/auto-approve/deny-floor.ts
@@ -41,6 +41,7 @@
  */
 
 import { matchSubstringPattern } from './pattern-matcher.ts';
+import type { DenySource } from './types.ts';
 
 /**
  * Catastrophic-operation patterns, mirroring the DENY FLOOR bullets in
@@ -389,6 +390,37 @@ export function enforceDenyFloor(
 }
 
 /**
+ * Which `DenySource` a `enforceDenyFloor` result implies (#1015), or `null`
+ * when what is being returned is not a deny.
+ *
+ * Split out of the call site in `auto-approve-service.ts` for one reason: the
+ * only way to reach that call site is through a live LLM verdict, so the
+ * branch was reachable in tests only with an engine running. As a pure
+ * function it can be probed with real `enforceDenyFloor` output in CI, which
+ * is where this repo's defects have actually been caught.
+ *
+ * The test is the DECISION, and only the decision. A first draft also returned
+ * null when `overridden` was set — which reads as "an overridden deny became a
+ * visible escalate, so there is nothing to report" and is true of every result
+ * `enforceDenyFloor` can actually produce, since it sets `overridden` only on
+ * the escalate branch. Mutation-testing caught that the clause was therefore
+ * unreachable: deleting it turned ZERO tests red. Worse, on the one shape that
+ * would reach it (`{decision:'deny', overridden:true}`, incoherent but
+ * type-legal) it suppresses the report on a deny that IS standing — failing
+ * toward the silence this function exists to end. Removed rather than pinned:
+ * a redundant check is tolerable, one whose only reachable effect is wrong is
+ * not.
+ */
+export function denySourceForFloor(result: DenyFloorResult): DenySource | null {
+  if (result.decision !== 'deny') return null;
+  // `matchedPattern` is set by `enforceDenyFloor` exactly when it leaves a deny
+  // standing, so the fallback never fires in practice. It exists because the
+  // type permits absence, and a report naming no pattern still beats the
+  // silence this whole path exists to end.
+  return { kind: 'model-floor', pattern: result.matchedPattern ?? '' };
+}
+
+/**
  * Cap on the reason text echoed to Claude. The model's own `reasoning` can run
  * long, and this rides in a hook response Claude Code parses on the blocking
  * path — bounded beats verbose.
@@ -411,10 +443,33 @@ const DENY_MESSAGE_REASON_MAX = 300;
  *   2. asking the user to authorize explicitly.
  *
  * A message that said only "ask the user" would push Claude to interrupt even
- * when a safe alternative existed. The second exit also closes the #976 loop:
- * the user's answer arrives via `UserPromptSubmit` as genuine EXPLICIT
- * authorization from a channel text cannot forge, which is the only way to get
- * above `implicit` under the ADR 0015 amendment.
+ * when a safe alternative existed.
+ *
+ * ## What the second exit does and does not close (corrected, #976)
+ *
+ * This doc previously claimed the second exit "closes the #976 loop: the
+ * user's answer arrives via `UserPromptSubmit` as genuine EXPLICIT
+ * authorization from a channel text cannot forge." **That is wrong, and it is
+ * wrong in the direction that matters.** A reply typed in chat IS text — it
+ * reaches the daemon on exactly the channel `capGradeForTextProvenance` caps,
+ * so it buys at most `implicit`, never `explicit`. The sentence conflated the
+ * CHAT channel with the CARD channel; only the card is a non-text channel.
+ *
+ * The consequence is band-dependent, and worth stating because it decides
+ * whether this message is useful at all:
+ *
+ * - **`moderate`** — the loop DOES close. `matrixDecision` approves moderate on
+ *   `implicit`, which is exactly what a chat reply can supply.
+ * - **`high`** — the loop CANNOT close, by construction. High demands a witness
+ *   text cannot produce, so the reply grades `implicit`, falls below the bar,
+ *   and the next attempt is refused for the same reason as the first. Only a
+ *   card answer or a session precedent gets there.
+ *
+ * The message is still right to offer the exit — a user told "ask me" can go
+ * and answer a card, or simply run the command themselves — but nothing here
+ * should be read as a promise that asking in chat will unblock a high-band
+ * operation. ADR 0015's amendment carries the same conflation and is corrected
+ * alongside this.
  *
  * Deliberately does NOT claim Claude will ask. The docs guarantee only that it
  * is not stopped and has been told why; what it does next is its own choice.
@@ -427,4 +482,64 @@ export function buildDenyMessage(reasoning?: string): string {
       : trimmed;
   const why = reason ? ` Reason: ${reason}` : '';
   return `Remi's auto-approve did not have authorization to approve this operation.${why} Either use a different approach that does not require it, or ask the user to authorize this explicitly before retrying.`;
+}
+
+/**
+ * How much of the refused command rides in the notification body (#1015).
+ * Sized like `SubagentAlerter`'s own detail cap for the same reason: iOS
+ * truncates hard, and a banner is a pointer to the log line, not a transcript.
+ */
+const DENIED_DETAIL_MAX = 160;
+
+/** The operation a deny notification is about — enough to say what was
+ *  refused without the caller reaching back into the raw hook input. */
+export interface DeniedOperation {
+  readonly toolName: string;
+  readonly detail: string;
+  readonly pattern: string;
+}
+
+/**
+ * Extract the human-readable operation from a refused tool call (#1015).
+ *
+ * Falls back to the bare tool name when there is no `command` string, which is
+ * every non-Bash tool. That is deliberately less informative than
+ * `HookEventBridge.summarizeToolInput` (which digs out `file_path`, `url`, and
+ * friends): this text goes on a lock screen, and the tool name plus the matched
+ * pattern already answers "what got refused, and why". Reaching for the richer
+ * summarizer would couple the notification path to the question-building path
+ * for a cosmetic gain.
+ */
+export function deniedOperation(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  pattern: string,
+): DeniedOperation {
+  const raw = typeof toolInput['command'] === 'string' ? toolInput['command'] : toolName;
+  const detail = raw.length > DENIED_DETAIL_MAX ? `${raw.slice(0, DENIED_DETAIL_MAX)}...` : raw;
+  return { toolName, detail, pattern };
+}
+
+/** Notification title for a refused operation. Short: iOS truncates hard, and
+ *  the one thing that must survive truncation is that something was BLOCKED. */
+export function deniedTitle(op: DeniedOperation): string {
+  return `Blocked ${op.toolName}`;
+}
+
+/**
+ * Notification body. States plainly that the operation did NOT run and that
+ * there is nothing to answer — the mirror of `alertBody`'s "was allowed to
+ * run", and load-bearing for the same reason: this banner carries no
+ * `category` and no `options`, so a user who reads it as a prompt would wait
+ * for an affordance that never appears.
+ *
+ * Names the matched pattern because that is the actionable part. #997 measured
+ * this floor matching prose 7 times in 8 on real traffic, so the most likely
+ * reader of this notification is someone whose `gh issue create` was refused
+ * for quoting a dangerous string — and "matched `rm -rf /`" is what makes that
+ * diagnosable in one read instead of one debugging session.
+ */
+export function deniedBody(op: DeniedOperation): string {
+  const why = op.pattern ? `Matched "${op.pattern}". ` : '';
+  return `${why}It did not run, and there is nothing to answer: ${op.detail}`;
 }

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -19,6 +19,28 @@ import type { AutoApproveLevel } from './levels.ts';
 export type AutoApproveDecision = 'approve' | 'deny' | 'escalate' | 'pick' | 'cancelled';
 
 /**
+ * What produced a `deny`, and what it matched (#1015). The distinction is the
+ * whole point of carrying it: it decides whether the user gets told.
+ *
+ * - `config` — the user's own `deny` / `deny_groups` matched, at 0ms, before
+ *   any model ran. Their standing rule fired as written; an audit line is
+ *   warranted, a push is not.
+ * - `model-floor` — the MODEL said deny and `enforceDenyFloor` let it stand
+ *   because `matchesCatastrophicPattern` matched. Nobody configured this one,
+ *   and the floor's match is measurably wrong most of the time it fires (7 of
+ *   8 hits on 918 real commands were prose that merely QUOTED a dangerous
+ *   string — #997). This is the class that must not be silent.
+ *
+ * `pattern` is what matched in either case (the config entry, the group name,
+ * or the catastrophic label), so a report can say WHY without re-running any
+ * matcher.
+ */
+export interface DenySource {
+  readonly kind: 'config' | 'model-floor';
+  readonly pattern: string;
+}
+
+/**
  * LLM-produced (or pattern-matched) decision. `model` is the model that
  * produced the verdict (or the configured model for pattern-matched
  * decisions, since downstream telemetry treats them uniformly).
@@ -38,6 +60,17 @@ export type AutoApproveDecisionResult =
        *  title/body instead of the raw "Allow Bash: <command>". Absent for
        *  approve/deny, pattern-matched verdicts, or when the model omits it. */
       readonly summary?: string | undefined;
+      /** #1015: which mechanism produced a `deny`. Present on `deny` results
+       *  only; absent on approve/escalate.
+       *
+       *  Carried structurally rather than left to be re-derived downstream. The
+       *  reasoning strings ARE currently distinguishable (`deny-matched
+       *  pattern:` / `deny-matched group:` vs the model's own prose), so a
+       *  consumer could sniff them — and that is exactly the defect shape this
+       *  module has hit repeatedly: two pieces of code independently deriving
+       *  the same judgement and drifting apart the first time one side's
+       *  wording changes. The site that decides is the site that reports. */
+      readonly denySource?: DenySource | undefined;
     }
   | {
       readonly decision: 'pick';

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -125,6 +125,9 @@ import { loadOrCreateAnswerKey } from './auth/answer-key.ts';
 import { Authenticator } from './auth/authenticator.ts';
 import { loadOrCreateCapabilityToken } from './auth/capability-token.ts';
 import { IdentityStore } from './auth/identity-store.ts';
+// #976 prerequisite: not re-exported from auto-approve/index.ts on purpose
+// (that barrel is being edited concurrently by other work on the same epic).
+import { deniedBody, deniedOperation, deniedTitle } from './auto-approve/deny-floor.ts';
 import {
   AutoApproveService,
   EngineHost,
@@ -133,9 +136,8 @@ import {
   alertTitle,
   resolveProviderUrl,
 } from './auto-approve/index.ts';
-// #976 prerequisite: not re-exported from auto-approve/index.ts on purpose
-// (that barrel is being edited concurrently by other work on the same epic).
 import type { PrecedentStore } from './auto-approve/precedent.ts';
+import type { DenySource } from './auto-approve/types.ts';
 import { detectAutostartState } from './cli/autostart-state.ts';
 import { resolveClaudeBinding } from './cli/claude-binding.ts';
 import { runConfigCommand } from './cli/cmd-config.ts';
@@ -1289,6 +1291,59 @@ function onSubagentPassthrough(input: PermissionRequestHookInput): void {
   }
 }
 
+/**
+ * Report an auto-approve `deny` (#1015).
+ *
+ * A deny is the only verdict with no user-facing surface of its own: it builds
+ * no `Question`, so nothing is pushed, nothing is broadcast, and nothing lands
+ * in history to scroll back to. Claude gets `buildDenyMessage` and the human
+ * gets nothing at all.
+ *
+ * Two channels, deliberately asymmetric:
+ *
+ * - **Log, always, both sources.** Unconditional and NOT gated on
+ *   `log_decisions` — that flag governs the routine per-decision trace, and a
+ *   refusal is not routine. Same reasoning as `onSubagentPassthrough` above:
+ *   the push can fail or be throttled downstream, so the local record is what
+ *   makes the decision auditable at all.
+ * - **Push, `model-floor` only.** A `config` deny is the user's own standing
+ *   rule in `config.toml` firing exactly as written; notifying them about it
+ *   is telling them what they already decided. A `model-floor` deny is the
+ *   opposite — the model refused and `matchesCatastrophicPattern` happened to
+ *   agree, which #997 measured going wrong 7 times in 8 on real traffic. That
+ *   is the one nobody chose.
+ *
+ * Fire-and-forget: the gate has already answered the hook, so this must never
+ * delay or throw into it.
+ */
+function onAutoDenied(
+  input: PermissionRequestHookInput,
+  source: DenySource,
+  reasoning: string,
+): void {
+  const op = deniedOperation(input.tool_name, input.tool_input, source.pattern);
+  const title = deniedTitle(op);
+  const body = deniedBody(op);
+  log(`[AutoDenied ${source.kind}] ${title} - ${body} (${reasoning})`);
+
+  if (source.kind !== 'model-floor') return;
+  if (deviceTokens.size === 0) return;
+  const signalingUrl = cliSignalingUrl ?? remiConfig.network.signaling_url;
+  for (const dt of deviceTokens.values()) {
+    // Deliberately no `category` / `options` / `questionId`: the operation is
+    // already refused and there is nothing for the user to answer. Same
+    // dismiss-only convention as the subagent alert above.
+    void sendPushTrigger(signalingUrl, dt.token, {
+      title,
+      body,
+      ...(cliPushSecret !== undefined ? { pushSecret: cliPushSecret } : {}),
+      kind: 'auto_denied',
+    }).catch((err) => {
+      logError('[AutoDenied] push failed:', err);
+    });
+  }
+}
+
 // Daemon-wide turn-duration tracker (#914). Fed from HookServer's onAnyEvent
 // for every hook event (see the two HookServer constructions below), keyed
 // on `prompt_id` -- present on every hook payload's common fields. Originally
@@ -1704,6 +1759,7 @@ async function createNewSession(
         statusWriter,
         foreignSessionEscalator,
         onSubagentPassthrough,
+        onAutoDenied,
         // #573: classify holdable escalations + the hold / slow-eval-push budgets
         // (seconds; the gate converts to ms and treats <=0 as disabled).
         alwaysEscalateTools: new Set(remiConfig.auto_approve.always_escalate_tools),

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -106,6 +106,7 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 // scope: that barrel is being edited concurrently by other work on the same
 // epic). Imported directly from its own module instead.
 import { PrecedentStore } from '../../auto-approve/precedent.ts';
+import type { DenySource } from '../../auto-approve/types.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type {
   ForeignSessionEscalator,
@@ -257,6 +258,17 @@ export interface HookBridgeDeps {
    * `foreignSessionEscalator` above). Absent => no alert, no audit line.
    */
   onSubagentPassthrough?: (input: PermissionRequestHookInput) => void;
+  /**
+   * Observer for every `deny` the gate returns to the hook (#1015). Forwarded
+   * verbatim to the gate's `onAutoDenied`; see that dep's doc for why a deny
+   * is the one verdict with no user-facing surface of its own.
+   *
+   * Supplied by `cli.ts`, which owns the push transport — same reasoning as
+   * `onSubagentPassthrough` above. Absent => a deny stays invisible, which is
+   * the pre-#1015 behavior and is correct for tests that build their own
+   * bridge without push wiring.
+   */
+  onAutoDenied?: (input: PermissionRequestHookInput, source: DenySource, reasoning: string) => void;
 }
 
 export interface HookBridgeArgs {
@@ -717,6 +729,7 @@ export function setupHookBridge(
         return question.id;
       },
       ...(deps.onSubagentPassthrough ? { onSubagentPassthrough: deps.onSubagentPassthrough } : {}),
+      ...(deps.onAutoDenied ? { onAutoDenied: deps.onAutoDenied } : {}),
       // #484: buffer the PTY prompt while the eval runs; release it only on an
       // escalate verdict, so silently auto-approved permissions never push APNS.
       // #560: the same lifecycle drives the auto-approve cue in Claude's native

--- a/packages/daemon/src/notifications/push-client.ts
+++ b/packages/daemon/src/notifications/push-client.ts
@@ -17,7 +17,7 @@ const DEFAULT_SIGNALING_URL = 'https://remi-signaling.yooz.workers.dev';
  * (per-device filtering, `push-preferences.ts`) and the client (labelling,
  * routing) act on it.
  */
-export type PushKind = 'question' | 'turn_complete' | 'subagent_alert' | 'dismiss';
+export type PushKind = 'question' | 'turn_complete' | 'subagent_alert' | 'dismiss' | 'auto_denied';
 
 /** Options for sendPushTrigger */
 export interface PushTriggerOptions {

--- a/packages/daemon/src/notifications/push-preferences.ts
+++ b/packages/daemon/src/notifications/push-preferences.ts
@@ -17,8 +17,15 @@
  *   - `subagent_alert` is not filtered either. It already has a user-facing
  *     control — it fires only on the patterns the user put in
  *     `auto_approve.subagent_alert` — so a second mute would be redundant.
+ *   - `auto_denied` (#1015) is not filtered either, for a stronger reason than
+ *     either of those: it is the ONLY signal that an operation was refused. A
+ *     deny creates no `Question`, so there is no card to find later and no
+ *     history entry to scroll back to — muting it restores exactly the
+ *     invisibility the notification exists to end. It is also rare by
+ *     construction (a model deny that `matchesCatastrophicPattern` agreed
+ *     with, or the user's own `deny_groups`), so there is little noise to mute.
  *
- * Both are enumerated explicitly rather than defaulted, so adding a new
+ * All three are enumerated explicitly rather than defaulted, so adding a new
  * `PushKind` is a type error here instead of a silent "unfiltered".
  */
 
@@ -88,6 +95,8 @@ export function wantsPush(entry: DeviceTokenEntry, kind: PushKind): boolean {
     case 'subagent_alert':
       return true;
     case 'dismiss':
+      return true;
+    case 'auto_denied':
       return true;
   }
 }

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -7,7 +7,7 @@ import {
   AutoApproveGate,
   autoAnswerValue,
 } from '../../src/auto-approve/auto-approve-gate.ts';
-import type { AutoApproveResult } from '../../src/auto-approve/types.ts';
+import type { AutoApproveResult, DenySource } from '../../src/auto-approve/types.ts';
 import { __resetLoggerForTests, configureLogger } from '../../src/cli/logger.ts';
 import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
 import type { DeliveryOutcome } from '../../src/notifications/notification-dispatcher.ts';
@@ -4100,5 +4100,186 @@ describe('#1005 end-to-end: a retired escalation registers no card via the real 
     expect(pushes).toHaveLength(0);
     // The whole point: nothing accumulates in the store that no sweep can clear.
     expect(registry.getSession(sid)?.currentQuestions.size).toBe(0);
+  });
+});
+
+/**
+ * #1015: every `deny` the gate returns must reach the `onAutoDenied` sink.
+ *
+ * A deny is the one verdict with no user-facing surface of its own -- no
+ * Question, so no card, no push, no `question_resolved`. This sink is the
+ * human's only channel, so what matters is that NOTHING reaching the hook as a
+ * deny bypasses it, and that a broken sink cannot break the decision.
+ */
+describe('AutoApproveGate onAutoDenied (#1015)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let denied: Array<{ tool: string; source: DenySource; reasoning: string }>;
+
+  const denyFromConfig: AutoApproveResult = {
+    decision: 'deny',
+    reasoning: 'deny-matched group: "fs-write"',
+    durationMs: 0,
+    model: 'm',
+    denySource: { kind: 'config', pattern: 'fs-write' },
+  };
+  const denyFromFloor: AutoApproveResult = {
+    decision: 'deny',
+    reasoning: 'the model refused',
+    durationMs: 12,
+    model: 'm',
+    denySource: { kind: 'model-floor', pattern: 'rm -rf /' },
+  };
+  const approveResult: AutoApproveResult = {
+    decision: 'approve',
+    reasoning: 't',
+    durationMs: 0,
+    model: 'm',
+  };
+  const escalateResult: AutoApproveResult = {
+    decision: 'escalate',
+    reasoning: 't',
+    durationMs: 0,
+    model: 'm',
+  };
+
+  function makeGate(
+    result: AutoApproveResult,
+    opts: { secondOpinion?: AutoApproveResult; sinkThrows?: boolean } = {},
+  ): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const service: AutoApproveEvaluator = {
+      evaluate: async (_t, _i, _tag, _s, modelOverride) =>
+        modelOverride === 'big-model' ? (opts.secondOpinion ?? result) : result,
+      cancel: () => true,
+    };
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => undefined),
+        isInSubagentContext: () => false,
+        escalate: () => generateId(),
+        onAutoDenied: (input, source, reasoning) => {
+          if (opts.sinkThrows) throw new Error('test: sink synthetic failure');
+          denied.push({ tool: input.tool_name, source, reasoning });
+        },
+        ...(opts.secondOpinion ? { escalateModel: 'big-model' } : {}),
+      },
+      SID,
+    );
+  }
+
+  function pr(): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf /' },
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    denied = [];
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('a primary deny reaches the sink, carrying source and reasoning verbatim', async () => {
+    const d = await makeGate(denyFromFloor).resolvePermission(pr());
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
+    expect(denied).toEqual([
+      {
+        tool: 'Bash',
+        source: { kind: 'model-floor', pattern: 'rm -rf /' },
+        reasoning: 'the model refused',
+      },
+    ]);
+  });
+
+  test('a config deny reaches the sink too -- filtering is the sink’s call, not the gate’s', async () => {
+    // cli.ts logs both and pushes only for model-floor. Deciding that HERE
+    // would put the policy in two places, and the gate is the wrong one: it
+    // cannot see the user's config.
+    await makeGate(denyFromConfig).resolvePermission(pr());
+    expect(denied).toHaveLength(1);
+    expect(denied[0]?.source.kind).toBe('config');
+  });
+
+  test('a SECOND-OPINION deny reaches the sink: it is equally invisible', async () => {
+    // The primary escalates, the heavy escalate_model refuses. This return is
+    // as silent as the primary one and was the easier of the two to miss.
+    const d = await makeGate(escalateResult, { secondOpinion: denyFromFloor }).resolvePermission(
+      pr(),
+    );
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
+    expect(denied).toHaveLength(1);
+    expect(denied[0]?.source).toEqual({ kind: 'model-floor', pattern: 'rm -rf /' });
+  });
+
+  test('an untagged deny is still reported, not dropped', async () => {
+    // Unreachable today (every deny return in `evaluate` tags itself) but the
+    // type permits it. A missing tag must degrade the report, never silence
+    // it -- silence is the bug.
+    const untagged: AutoApproveResult = {
+      decision: 'deny',
+      reasoning: 'no source field',
+      durationMs: 0,
+      model: 'm',
+    };
+    await makeGate(untagged).resolvePermission(pr());
+    expect(denied).toHaveLength(1);
+    expect(denied[0]?.source).toEqual({ kind: 'model-floor', pattern: '' });
+  });
+
+  test('an approve never reaches the sink', async () => {
+    await makeGate(approveResult).resolvePermission(pr());
+    expect(denied).toEqual([]);
+  });
+
+  test('an escalate never reaches the sink', async () => {
+    await makeGate(escalateResult).resolvePermission(pr());
+    expect(denied).toEqual([]);
+  });
+
+  test('a sink that throws is absorbed: the deny still reaches the hook', async () => {
+    // Same contract as the cosmetic cues. An observer must never be able to
+    // turn a decided permission into an unanswered hook.
+    const d = await makeGate(denyFromFloor, { sinkThrows: true }).resolvePermission(pr());
+    expect(d).toEqual({ behavior: 'deny', message: expect.stringContaining('ask the user') });
+  });
+
+  test('an absent sink is fine: the gate does not require one', async () => {
+    registry.registerSession(SID, '/d', fakePTY([]), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const gate = new AutoApproveGate(
+      {
+        service: { evaluate: async () => denyFromFloor, cancel: () => true },
+        sessionRegistry: registry,
+        tracker: new QuestionPresenceTracker(() => undefined),
+        isInSubagentContext: () => false,
+        escalate: () => generateId(),
+      },
+      SID,
+    );
+    expect(await gate.resolvePermission(pr())).toEqual({
+      behavior: 'deny',
+      message: expect.stringContaining('ask the user'),
+    });
   });
 });

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -1442,7 +1442,17 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
 
   function gate(
     service: AutoApproveEvaluator,
-    opts: { holdMs?: number; pushHoldMs?: number } = {},
+    opts: {
+      holdMs?: number;
+      pushHoldMs?: number;
+      /** #1015: records every deny reported to the observer, so a Part B late
+       *  deny can be checked for the report it must produce. */
+      onAutoDenied?: (
+        input: PermissionRequestHookInput,
+        source: DenySource,
+        reasoning: string,
+      ) => void;
+    } = {},
   ): AutoApproveGate {
     registry.registerSession(SID, '/d', fakePTY([]), {
       handleMessage: () => {},
@@ -1463,6 +1473,7 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
         holdMs: opts.holdMs ?? 60_000,
         pushHoldMs: opts.pushHoldMs ?? 0,
         alwaysEscalateTools: new Set(),
+        ...(opts.onAutoDenied ? { onAutoDenied: opts.onAutoDenied } : {}),
       },
       SID,
     );
@@ -1518,6 +1529,55 @@ describe('AutoApproveGate slow-eval push (#573 Part B)', () => {
     release(deny);
     expect(await pending).toBe('deny');
     expect(escalations).toHaveLength(1);
+  });
+
+  test('#1015: a slow eval whose late verdict is deny REPORTS it', async () => {
+    // The third deny path, and the least visible of the three: the user is
+    // already looking at a pushed card saying "needs your permission", and
+    // this resolution makes it vanish via a quiet content-available dismiss
+    // that carries no title and no body. Without the report the refusal is
+    // worse than invisible -- the user saw a prompt and then saw it disappear.
+    //
+    // Found in review, not in writing: `reportDeny` was wired at the two
+    // SYNCHRONOUS deny returns and this async one needed `input` threaded down
+    // a level, which is exactly why it was missed.
+    const denied: DenySource[] = [];
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, {
+      pushHoldMs: 20,
+      onAutoDenied: (_input, source) => denied.push(source),
+    });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    expect(escalations).toHaveLength(1); // the early card is on screen
+
+    release({
+      decision: 'deny',
+      reasoning: 'the model refused',
+      durationMs: 90_000,
+      model: 'm',
+      denySource: { kind: 'model-floor', pattern: 'rm -rf /' },
+    });
+    expect(await pending).toBe('deny');
+    // The reconciliation is fired-and-forgotten off the hook response, so the
+    // report can land a microtask later than the hook resolves.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(denied).toEqual([{ kind: 'model-floor', pattern: 'rm -rf /' }]);
+  });
+
+  test('#1015: a slow eval whose late verdict is APPROVE reports nothing', async () => {
+    const denied: DenySource[] = [];
+    const { service, release } = deferredEvaluator();
+    const g = gate(service, {
+      pushHoldMs: 20,
+      onAutoDenied: (_input, source) => denied.push(source),
+    });
+    const pending = g.resolvePermission(pr());
+    await new Promise((r) => setTimeout(r, 40));
+    release(approve);
+    expect(await pending).toBe('allow');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(denied).toEqual([]);
   });
 
   test('a slow eval whose late verdict is escalate keeps the existing hold (no double push)', async () => {

--- a/packages/daemon/tests/auto-approve/deny-floor.test.ts
+++ b/packages/daemon/tests/auto-approve/deny-floor.test.ts
@@ -10,6 +10,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
   buildDenyMessage,
+  deniedBody,
+  deniedOperation,
+  deniedTitle,
+  denySourceForFloor,
   enforceDenyFloor,
   matchesCatastrophicPattern,
 } from '../../src/auto-approve/deny-floor.ts';
@@ -378,5 +382,120 @@ describe('buildDenyMessage (#976)', () => {
     const m = buildDenyMessage('x'.repeat(5000));
     expect(m.length).toBeLessThan(700);
     expect(m).toContain('…');
+  });
+});
+
+/**
+ * #1015: a model deny is invisible to the user unless something reports it.
+ *
+ * These drive `denySourceForFloor` from REAL `enforceDenyFloor` output rather
+ * than from hand-built result literals. That is the whole reason the function
+ * was split out of `auto-approve-service.ts`: at the original call site the
+ * only way in was a live LLM verdict, so the branch was engine-gated and never
+ * ran in CI. Composing the two real functions here is what makes it testable
+ * at all, so a literal would throw away the point.
+ */
+describe('denySourceForFloor (#1015)', () => {
+  test('a deny the floor LEAVES STANDING is tagged model-floor, with what matched', () => {
+    // The genuine article: `enforceDenyFloor` returns overridden=false and
+    // names the pattern, so the report can say why.
+    const floored = enforceDenyFloor('Bash', bash('rm -rf /'), 'deny');
+    expect(floored.overridden).toBe(false);
+    expect(denySourceForFloor(floored)).toEqual({ kind: 'model-floor', pattern: 'rm -rf /' });
+  });
+
+  test('the #997 false positive is tagged too — that is the population this exists for', () => {
+    // 7 of 8 floor hits on 918 real commands were prose quoting a dangerous
+    // string. The floor still refuses them (narrowing it is #997's own
+    // question); this change is that the refusal stops being silent.
+    const prose = bash('gh issue comment 976 --body "patterns: rm -rf /, sudo rm, chmod 777"');
+    const floored = enforceDenyFloor('Bash', prose, 'deny');
+    expect(floored.overridden).toBe(false);
+    expect(denySourceForFloor(floored)?.kind).toBe('model-floor');
+  });
+
+  test('a deny the floor OVERRODE yields no source: it became a visible escalate', () => {
+    const floored = enforceDenyFloor('Bash', bash('git push origin main'), 'deny');
+    expect(floored.overridden).toBe(true);
+    // The DECISION is what makes this null -- an escalate is not a deny. An
+    // earlier draft also tested `overridden` and this test appeared to cover
+    // that clause; deleting the clause turned nothing red, because
+    // `enforceDenyFloor` sets `overridden` only when it has ALSO rewritten the
+    // decision to escalate. Asserting both here is the point: they move
+    // together, so only one of them can be doing the work.
+    expect(floored.decision).toBe('escalate');
+    // Reporting here would notify the user about a card they are ALSO getting.
+    expect(denySourceForFloor(floored)).toBeNull();
+  });
+
+  test('a standing deny is reported even if a caller marks it overridden', () => {
+    // The incoherent shape the removed `|| result.overridden` clause was the
+    // only reachable guard against: type-legal, unproducible by
+    // `enforceDenyFloor`, and the direction matters. A deny is being returned
+    // to the hook, so it must be reported -- suppressing it here would restore
+    // the silence for the one case where a caller's bookkeeping disagreed with
+    // its own verdict.
+    expect(
+      denySourceForFloor({ decision: 'deny', overridden: true, matchedPattern: 'rm -rf /' }),
+    ).toEqual({ kind: 'model-floor', pattern: 'rm -rf /' });
+  });
+
+  test('approve and escalate yield no source', () => {
+    for (const decision of ['approve', 'escalate'] as const) {
+      const floored = enforceDenyFloor('Bash', bash('rm -rf /'), decision);
+      expect(denySourceForFloor(floored)).toBeNull();
+    }
+  });
+
+  test('a standing deny with no matched pattern still reports, with an empty pattern', () => {
+    // Unreachable through `enforceDenyFloor` (it always names the pattern when
+    // it leaves a deny standing), so this forges the shape deliberately. The
+    // direction is the assertion: a missing pattern must degrade the report,
+    // never suppress it — suppressing restores the exact invisibility this
+    // function exists to end.
+    expect(denySourceForFloor({ decision: 'deny', overridden: false })).toEqual({
+      kind: 'model-floor',
+      pattern: '',
+    });
+  });
+});
+
+describe('deniedOperation / deniedTitle / deniedBody (#1015)', () => {
+  test('carries the real command, not the tool name, for Bash', () => {
+    const op = deniedOperation('Bash', bash('rm -rf /'), 'rm -rf /');
+    expect(op).toEqual({ toolName: 'Bash', detail: 'rm -rf /', pattern: 'rm -rf /' });
+  });
+
+  test('falls back to the tool name when there is no command string', () => {
+    // Every non-Bash tool, plus a Bash call with a malformed input.
+    expect(deniedOperation('Write', { file_path: '/etc/passwd' }, 'p').detail).toBe('Write');
+    expect(deniedOperation('Bash', { command: 42 }, 'p').detail).toBe('Bash');
+  });
+
+  test('bounds the detail: this lands on a lock screen', () => {
+    const op = deniedOperation('Bash', bash(`echo ${'x'.repeat(500)}`), 'p');
+    expect(op.detail.length).toBeLessThanOrEqual(163);
+    expect(op.detail.endsWith('...')).toBe(true);
+  });
+
+  test('the body says the operation did NOT run and has nothing to answer', () => {
+    // Load-bearing, not cosmetic: this push carries no `category` and no
+    // `options`, so a user who read it as a prompt would wait for an
+    // affordance that never arrives.
+    const body = deniedBody(deniedOperation('Bash', bash('rm -rf /'), 'rm -rf /'));
+    expect(body).toContain('did not run');
+    expect(body).toContain('nothing to answer');
+    // And names what matched -- the actionable part, given #997's false rate.
+    expect(body).toContain('rm -rf /');
+  });
+
+  test('the body omits the match clause when no pattern is known', () => {
+    const body = deniedBody(deniedOperation('Bash', bash('x'), ''));
+    expect(body).not.toContain('Matched');
+    expect(body).toContain('did not run');
+  });
+
+  test('the title leads with BLOCKED, which is what must survive truncation', () => {
+    expect(deniedTitle(deniedOperation('Bash', bash('rm -rf /'), 'p'))).toBe('Blocked Bash');
   });
 });

--- a/packages/daemon/tests/notifications/push-preferences.test.ts
+++ b/packages/daemon/tests/notifications/push-preferences.test.ts
@@ -95,7 +95,13 @@ describe('sanitizePushPreferences', () => {
 describe('wantsPush', () => {
   test('an entry with no stored preferences wants every class', () => {
     const legacy = entry('t');
-    const kinds: PushKind[] = ['question', 'turn_complete', 'subagent_alert', 'dismiss'];
+    const kinds: PushKind[] = [
+      'question',
+      'turn_complete',
+      'subagent_alert',
+      'dismiss',
+      'auto_denied',
+    ];
     for (const kind of kinds) {
       expect(wantsPush(legacy, kind)).toBe(true);
     }
@@ -125,6 +131,15 @@ describe('wantsPush', () => {
     // user put in `auto_approve.subagent_alert`.
     const muted = entry('t', { questions: false, turnComplete: false });
     expect(wantsPush(muted, 'subagent_alert')).toBe(true);
+  });
+
+  test('auto_denied is never filtered, even with everything muted (#1015)', () => {
+    // The strongest of the three exemptions. A deny builds no Question, so
+    // there is no card to find later and no history entry to scroll back to --
+    // this push IS the record. Muting it does not reduce noise; it restores
+    // the invisibility the notification exists to end.
+    const muted = entry('t', { questions: false, turnComplete: false });
+    expect(wantsPush(muted, 'auto_denied')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #1015. Splits the harm half off #997; #997 stays open for the matching.

## What changed

A `deny` is the only auto-approve verdict with no user-facing surface of its
own. It builds no `Question`, so nothing is pushed, nothing is broadcast, and
nothing lands in history to scroll back to. Claude gets `buildDenyMessage` and
the human gets nothing at all.

- `AutoApproveDecisionResult` carries a `denySource` on `deny` results,
  structurally, set by the site that decides. The reasoning strings ARE
  currently distinguishable, so a consumer could sniff them — that is exactly
  the defect shape this module has been bitten by five times: two pieces of
  code deriving the same judgement and drifting.
- `AutoApproveGate` gets an `onAutoDenied` observer, wired at BOTH deny returns
  (primary and `escalate_model` second opinion). Throw-safe like the cues.
- `cli.ts` logs both sources unconditionally — deliberately NOT gated on
  `log_decisions`, which governs the routine per-decision trace; a refusal is
  not routine — and pushes only for `model-floor`. A `config` deny is the
  user's own standing rule in `config.toml` firing as written.
- New `PushKind` `auto_denied`, exempt from muting. Stronger reason than the
  other two exemptions: this push IS the record, so muting it restores exactly
  the invisibility it exists to end. The Worker forwards `kind` verbatim and
  does not validate it (`signaling/src/index.ts:333`), so **no redeploy**.

## What it deliberately does NOT do

Changes no matching. The #997 false positives still refuse a doc-writing
command — they now refuse it visibly, naming what matched. Narrowing
`matchesCatastrophicPattern` is #997's own question and is the dangerous
direction (ADR 0010): a floor that stops matching fails silently.

## Probed against the real functions

```
DENY -> model-floor  Matched "rm -rf /". It did not run, and there is nothing to answer: rm -rf /
DENY -> model-floor  Matched "rm -rf /". ... gh issue comment 976 --body "the guard blocks rm -rf / at the floor"
DENY -> model-floor  Matched "rm -rf /". ... git commit -m "docs: explain why rm -rf / is refused"
ESCALATE (card)      rm -rf dist && bun run build > /tmp/relbuild.log 2>&1
ESCALATE (card)      rm -rf ./build
DENY -> model-floor  Matched "| sh". ... curl -sSL https://x.sh | sh
```

Rows 2 and 3 are #997's measured false positives. They are still refused; the
difference is that "Matched `rm -rf /`" now makes it diagnosable in one read
instead of one debugging session.

## A doc correction that is part of this change

`buildDenyMessage`'s doc claimed its second exit "closes the #976 loop: the
user's answer arrives via `UserPromptSubmit` as genuine EXPLICIT authorization
from a channel text cannot forge."

That is wrong, in the direction that matters. A reply typed in chat IS text —
it reaches the daemon on exactly the channel `capGradeForTextProvenance` caps,
so it buys `implicit` at most. The sentence conflated the CHAT channel with the
CARD channel. Consequence is band-dependent: the loop closes for `moderate`
(which approves on `implicit`), and provably cannot for `high` (which demands a
witness text cannot produce). ADR 0015's amendment carries the same conflation
and is corrected in the #976 PR.

Fixed in the same change per AGENTS.md rule 3.

## Testing

`bun test` on `auto-approve/`, `notifications/`, `cli/`: 2924 pass, 0 fail.

Mutation-tested, since a green suite is not evidence (this repo's own rule):

| mutation | result |
|---|---|
| gate: drop the primary deny report | 3 RED |
| gate: drop the second-opinion report | 1 RED |
| gate: drop the untagged-result fallback | 1 RED |
| gate: let a throwing sink escape | 1 RED |
| `denySourceForFloor` always null | 4 RED |
| `denySourceForFloor` suppress when pattern missing | 1 RED |
| `wantsPush('auto_denied')` honors the questions pref | 1 RED |

`denySourceForFloor` exists as a separate pure function specifically so it can
be probed in CI: at its original inline call site the only way in was a live
LLM verdict, so the branch was engine-gated and never ran.

**One mutation found a defect in my own first draft.** The guard read
`if (result.decision !== 'deny' || result.overridden) return null`. Deleting
the second clause turned ZERO tests red — `enforceDenyFloor` sets `overridden`
only when it has also rewritten the decision to `escalate`, so the clause was
unreachable. On the one shape that WOULD reach it it suppresses the report on a
deny that is standing, failing toward silence. Removed rather than pinned, and
the test that appeared to cover it now says why it could not.
