### PR TITLE
Clear terminal row before held-question cue

### DIFF
--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -44,6 +44,26 @@ export interface AttachClientResult {
   reason: 'detached' | 'session_ended' | 'error' | 'timeout' | 'connection_closed';
 }
 
+/**
+ * #1026: pure formatter for the held-question terminal cue, pinned by a byte-
+ * sequence test. Leads with `\r\x1b[2K` (return to column 0, erase the whole
+ * line) instead of a bare `\r\n`: a held permission blocks Claude inside the
+ * hook call, but the TUI spinner keeps animating on its own timer regardless
+ * (elapsed-time display), so the row this cue lands on can already hold a
+ * half-drawn spinner frame. `\r\n` alone moved past that row without erasing
+ * it, so the next spinner repaint and this cue's text could occupy the same
+ * row. Clearing first means the cue always takes the row cleanly; every
+ * following line (and the last) still ends `\r\n`, so the spinner resumes on
+ * its own fresh row below the cue block, same as before.
+ */
+export function formatQuestionBanner(question: Question): string {
+  const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
+  const lines = [`\r\x1b[2K\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
+  if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
+  lines.push(`\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`);
+  return lines.join('');
+}
+
 export async function runAttachClient(opts: AttachClientOptions): Promise<AttachClientResult> {
   const { host, port, sessionId, timeout = 5000, outputFd = 1 } = opts;
   const url = `ws://${host}:${port}/ws`;
@@ -273,22 +293,18 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
    * `question` messages per visible prompt cycle (hook bridge + PTY parser,
    * different ids), so bannering those would double- or triple-print around
    * the native prompt — the exact noise the old blanket suppression avoided.
-   * Held questions also guarantee an idle PTY, so the banner can never
-   * interleave mid-ANSI-sequence with streaming output. Plain text through
-   * writeOutput (raw mode: \r\n), cyan so it stands apart from Claude's own
-   * output.
+   * #1026 correction: a held permission blocking Claude's hook call does NOT
+   * guarantee an idle PTY — the TUI spinner keeps animating on its own timer
+   * while the hook is pending, and a live session showed the cue's old bare
+   * `\r\n` lead interleaving with that spinner's redraw on the same row.
+   * `formatQuestionBanner` now clears the row first (see its own docstring).
+   * Cyan so it stands apart from Claude's own output.
    */
   function renderQuestionBanner(question: Question): void {
     if (question.held !== true) return;
     if (banneredQuestionIds.has(question.id)) return;
     banneredQuestionIds.add(question.id);
-    const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
-    const lines = [`\r\n\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
-    if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
-    lines.push(
-      `\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`,
-    );
-    writeOutput(lines.join(''));
+    writeOutput(formatQuestionBanner(question));
   }
 
   /**

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -28,7 +28,7 @@ import type {
   RemiStatus,
   UUID,
 } from '@remi/shared';
-import { runAttachClient } from '../../src/cli/attach-client.ts';
+import { formatQuestionBanner, runAttachClient } from '../../src/cli/attach-client.ts';
 
 const TEST_PORT = 9873;
 
@@ -308,6 +308,31 @@ describe('runAttachClient', () => {
       ...(held ? { held: true } : {}),
     };
   }
+
+  // #1026: pin the exact byte sequence so the clear-line lead (`\r\x1b[2K`)
+  // and the trailing `\r\n` on every line — the shape that keeps the TUI
+  // spinner off the cue's row and lets it resume on a fresh row below —
+  // can't regress back to a bare `\r\n` lead without this test failing.
+  test('formatQuestionBanner clears the current row before the cue text', () => {
+    const question = makeQuestion('Allow file edit?');
+    const banner = formatQuestionBanner(question);
+
+    expect(banner).toBe(
+      '\r\x1b[2K\x1b[36m[remi] pending question: Allow file edit?\x1b[0m\r\n' +
+        '\x1b[36m[remi] options: 1) Yes  2) No\x1b[0m\r\n' +
+        "\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n",
+    );
+  });
+
+  test('formatQuestionBanner omits the options line when there are none', () => {
+    const question: Question = { ...makeQuestion('Allow file edit?'), options: [] };
+    const banner = formatQuestionBanner(question);
+
+    expect(banner).toBe(
+      '\r\x1b[2K\x1b[36m[remi] pending question: Allow file edit?\x1b[0m\r\n' +
+        "\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n",
+    );
+  });
 
   // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
   // raw PTY bytes for the prompt ever exist — the LIVE question message is


### PR DESCRIPTION
## Summary

The held-question cue (`renderQuestionBanner` in `packages/daemon/src/cli/attach-client.ts`) writes directly to the attached client's `outputFd` — the same fd Claude's raw PTY output (including the TUI spinner) streams into. The old lead-in was a bare `\r\n`, which moves the cursor past the current row without erasing it.

A held permission (Model B) blocks Claude inside the hook call, but the TUI spinner keeps animating on its own timer regardless (elapsed-time display), so the row the cue lands on can already hold a half-drawn spinner frame — a stale assumption in the function's own docstring ("held questions guarantee an idle PTY... can never interleave") that a live session on 2026-08-08 proved wrong, garbling the row into `✶rCanoodling…g que59ion: Allow Bash: ...` (#1026).

## Change

- Extracted the pure line-building logic out of `renderQuestionBanner` into a new exported, testable `formatQuestionBanner(question): string`.
- Changed the lead-in from `\r\n` to `\r\x1b[2K` (return to column 0, erase the whole line) so the cue always takes over its row cleanly instead of appending past whatever the spinner left there. Every cue line (including the last) still ends `\r\n`, so the spinner resumes on its own fresh row below the block — same as before.
- Corrected the `renderQuestionBanner` docstring's now-falsified "idle PTY" claim, per this repo's ADR 0011 ("verify before you describe").
- No change to *when* the cue fires — only its byte formatting. ADR 0020 (cue totality over a gate's end paths) is unaffected: `renderQuestionBanner`'s own held/dedup gating (`question.held !== true`, `banneredQuestionIds`) is untouched.

## Tests

- `packages/daemon/tests/cli/attach-client.test.ts`: two new unit tests pin `formatQuestionBanner`'s exact byte sequence (with and without an options line), plus the existing end-to-end banner tests still assert on the printed substrings.
- `bun test packages/daemon/tests/cli/attach-client.test.ts` — 22 pass, 0 fail.
- `bun run typecheck` — clean.
- `bunx biome check packages/daemon/src/cli/attach-client.ts packages/daemon/tests/cli/attach-client.test.ts` — clean.

Closes #1026