### PR TITLE
fix: statusline reports hub's repo/branch, not the session's

### DIFF
--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -777,6 +777,14 @@ if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliDir && !cliHo
   process.chdir(dirResult.resolved);
 }
 
+// #1025: `gitInfo` above was computed from process.cwd() at module load,
+// before args were parsed — a hub-spawned child inherits the hub's cwd, so
+// that snapshot named the hub's repo/branch. The --resume/--recent/--dir
+// chdirs above (if any) have now settled process.cwd() on the real session
+// directory; refresh the status snapshot from it. `remi serve` never chdirs
+// here, so this is a no-op and the hub keeps reporting its own cwd.
+updateRemiStatus(detectGitInfo());
+
 // Every read-only / remote-client subcommand (ls, recent, kill, detach, attach,
 // code, start/stop/status/logs, keys, autostart, --host remote-new) has already
 // exited above. Everything past this point boots a daemon or a local wrapper

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -14,6 +14,7 @@ import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
 import { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { rotateIfNeeded } from './log-rotation.ts';
+import { resolveExistingDirectory } from './path-resolver.ts';
 import { formatVersionDrift } from './version-drift.ts';
 
 // Re-exported for existing importers/tests; the definition moved to
@@ -560,12 +561,19 @@ export async function spawnRemiDaemon(
   // own ~/.remi/daemon-status.json.
   childEnv['REMI_SPAWNED_CHILD'] = '1';
 
+  // #1025: without this, the child inherits OUR cwd (the hub's, for a
+  // hub-spawned child), so anything the child reads from process.cwd()
+  // before its own --dir chdir logic runs — e.g. gitInfo at module load —
+  // names the wrong project.
+  const childCwd = resolveExistingDirectory(directory);
+
   let child: ReturnType<typeof spawn>;
   try {
     child = spawn(command, spawnArgs, {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       env: childEnv,
+      ...(childCwd !== undefined && { cwd: childCwd }),
     });
   } catch (err) {
     fs.closeSync(logFd);

--- a/packages/daemon/src/cli/handlers/create-session-events.ts
+++ b/packages/daemon/src/cli/handlers/create-session-events.ts
@@ -17,6 +17,7 @@ import type { SessionRegistryFile } from '../../session/index.ts';
 import { findAvailableTcpPort as defaultFindAvailableTcpPort } from '../../session/port-utils.ts';
 import { spawnRemiDaemon as defaultSpawnRemiDaemon } from '../daemon-manager.ts';
 import { log, logError } from '../logger.ts';
+import { resolveRequestedSessionDirectory } from '../path-resolver.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SpawnResult {
@@ -93,10 +94,14 @@ export function createCreateSessionHandlers(deps: CreateSessionHandlerDeps) {
           return;
         }
 
-        log(`Spawning new daemon on port ${freePort} for directory ${directory || '(cwd)'}`);
+        // #1025: no/empty/whitespace directory means "home", never the
+        // hub's own cwd (an accident of where `remi serve` was started) —
+        // see resolveRequestedSessionDirectory for the full rationale.
+        const resolvedDirectory = resolveRequestedSessionDirectory(directory);
+        log(`Spawning new daemon on port ${freePort} for directory ${resolvedDirectory}`);
         spawningPorts.add(freePort);
         try {
-          const result = await spawnDaemon(freePort, directory, [...inheritedArgs()]);
+          const result = await spawnDaemon(freePort, resolvedDirectory, [...inheritedArgs()]);
           send(
             connectionId,
             createCreateSessionResponse(

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -55,12 +55,31 @@ export function resolveDirectory(inputPath: string | null | undefined): ResolveD
  * process's `cwd` option, or `undefined` if it isn't a real, existing
  * directory. Unlike `resolveDirectory`, silent on failure by design: the
  * caller (`spawnRemiDaemon`) uses this only as a best-effort belt-and-braces
- * fix (#1025) and leaves invalid input for the child's OWN `--dir` handling
- * — which calls `resolveDirectory` and reports the error — to catch.
+ * fix (#1025). A non-empty but invalid directory is left for the child's OWN
+ * `--dir` handling — which calls `resolveDirectory` and reports the error —
+ * to catch; falsy input (no directory requested) is handled upstream by
+ * `resolveRequestedSessionDirectory` for a remote request, so by the time a
+ * LOCAL spawn reaches here with no directory, "inherit the parent's cwd" is
+ * the intended behavior, not an error to catch.
  */
 export function resolveExistingDirectory(inputPath: string | null | undefined): string | undefined {
   if (!inputPath) return undefined;
   const resolved = normalizeProjectPath(inputPath);
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return undefined;
   return resolved;
+}
+
+/**
+ * Resolve the directory for a REMOTE create-session request (#1025): no
+ * directory, or an empty/whitespace-only string, means "home" — the
+ * contract `NewSessionModal.tsx` documents ("empty string = home/cwd") and
+ * what `RecentProjects`'s default entry sends. The hub's own cwd is an
+ * accident of wherever `remi serve` happened to be started and is never a
+ * meaningful default for a request that arrived over the wire, unlike a
+ * LOCAL `remi new` from a shell, which correctly inherits the invoking
+ * shell's cwd — this helper is for the remote path only, never the local one.
+ */
+export function resolveRequestedSessionDirectory(directory: string | undefined): string {
+  const trimmed = directory?.trim();
+  return trimmed || os.homedir();
 }

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -49,3 +49,18 @@ export function resolveDirectory(inputPath: string | null | undefined): ResolveD
   }
   return { resolved };
 }
+
+/**
+ * Resolve a directory to an absolute path suitable for a spawned child
+ * process's `cwd` option, or `undefined` if it isn't a real, existing
+ * directory. Unlike `resolveDirectory`, silent on failure by design: the
+ * caller (`spawnRemiDaemon`) uses this only as a best-effort belt-and-braces
+ * fix (#1025) and leaves invalid input for the child's OWN `--dir` handling
+ * — which calls `resolveDirectory` and reports the error — to catch.
+ */
+export function resolveExistingDirectory(inputPath: string | null | undefined): string | undefined {
+  if (!inputPath) return undefined;
+  const resolved = normalizeProjectPath(inputPath);
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return undefined;
+  return resolved;
+}

--- a/packages/daemon/tests/cli/handlers/create-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/create-session-events.test.ts
@@ -109,6 +109,29 @@ describe('createCreateSessionHandlers', () => {
     expect(spawningPorts.has(20005)).toBe(false);
   });
 
+  test('maps a missing directory to the home directory, not the hub cwd (#1025)', async () => {
+    const spawnHistory: Array<string | undefined> = [];
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async () => 20008,
+      spawnDaemon: async (port, directory) => {
+        spawnHistory.push(directory);
+        return { sessionId: 's', port, pid: 1 };
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+    await handlers.onCreateSessionRequest(CID, '', REQ);
+    await handlers.onCreateSessionRequest(CID, '   ', REQ);
+
+    expect(spawnHistory).toEqual([os.homedir(), os.homedir(), os.homedir()]);
+  });
+
   test('reserves the port during spawn then releases it', async () => {
     let sawReservedDuringSpawn = false;
     const handlers = createCreateSessionHandlers({

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeProjectPath,
   resolveDirectory,
   resolveExistingDirectory,
+  resolveRequestedSessionDirectory,
 } from '../../src/cli/path-resolver.ts';
 
 describe('resolveDirectory', () => {
@@ -111,6 +112,30 @@ describe('resolveExistingDirectory (#1025)', () => {
     const file = path.join(sandbox, 'file.txt');
     fs.writeFileSync(file, 'hello');
     expect(resolveExistingDirectory(file)).toBeUndefined();
+  });
+});
+
+describe('resolveRequestedSessionDirectory (#1025)', () => {
+  test('maps undefined to the home directory', () => {
+    expect(resolveRequestedSessionDirectory(undefined)).toBe(os.homedir());
+  });
+
+  test('maps an empty string to the home directory', () => {
+    expect(resolveRequestedSessionDirectory('')).toBe(os.homedir());
+  });
+
+  test('maps a whitespace-only string to the home directory', () => {
+    expect(resolveRequestedSessionDirectory('   ')).toBe(os.homedir());
+  });
+
+  test('passes a real path through, trimmed', () => {
+    expect(resolveRequestedSessionDirectory('  /tmp/some-project  ')).toBe('/tmp/some-project');
+  });
+
+  test("does not expand `~` — that is the child daemon's own --dir job", () => {
+    expect(resolveRequestedSessionDirectory('~/Documents/git/project')).toBe(
+      '~/Documents/git/project',
+    );
   });
 });
 

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { normalizeProjectPath, resolveDirectory } from '../../src/cli/path-resolver.ts';
+import {
+  normalizeProjectPath,
+  resolveDirectory,
+  resolveExistingDirectory,
+} from '../../src/cli/path-resolver.ts';
 
 describe('resolveDirectory', () => {
   let sandbox: string;
@@ -71,6 +75,42 @@ describe('resolveDirectory', () => {
     if ('error' in result) {
       expect(result.error).toStartWith('Not a directory: ');
     }
+  });
+});
+
+describe('resolveExistingDirectory (#1025)', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-existing-dir-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('returns undefined for null / undefined / empty string', () => {
+    expect(resolveExistingDirectory(null)).toBeUndefined();
+    expect(resolveExistingDirectory(undefined)).toBeUndefined();
+    expect(resolveExistingDirectory('')).toBeUndefined();
+  });
+
+  test('returns the resolved path for an existing directory', () => {
+    expect(resolveExistingDirectory(sandbox)).toBe(sandbox);
+  });
+
+  test('expands `~` before checking existence', () => {
+    expect(resolveExistingDirectory('~')).toBe(os.homedir());
+  });
+
+  test('returns undefined for a non-existent path', () => {
+    expect(resolveExistingDirectory(path.join(sandbox, 'nope'))).toBeUndefined();
+  });
+
+  test('returns undefined when the path is a file, not a directory', () => {
+    const file = path.join(sandbox, 'file.txt');
+    fs.writeFileSync(file, 'hello');
+    expect(resolveExistingDirectory(file)).toBeUndefined();
   });
 });
 

--- a/packages/daemon/tests/cli/startup-env.test.ts
+++ b/packages/daemon/tests/cli/startup-env.test.ts
@@ -45,6 +45,22 @@ describe('detectGitInfo', () => {
     expect(info.repo).toBe(path.basename(sandbox));
     expect(info.branch).toBe('?');
   });
+
+  // #1025: a session daemon spawned by the hub inherits the hub's cwd, so
+  // calling detectGitInfo() with no argument (defaulting to process.cwd())
+  // before the session directory is resolved reports the HUB's repo/branch.
+  // Pins that an explicit dir argument always wins over the ambient cwd.
+  test('an explicit dir overrides process.cwd(), even when both are git repos', () => {
+    fs.mkdirSync(path.join(sandbox, '.git'));
+    fs.writeFileSync(path.join(sandbox, '.git', 'HEAD'), 'ref: refs/heads/session-branch\n');
+
+    const info = detectGitInfo(sandbox);
+    expect(info.repo).toBe(path.basename(sandbox));
+    expect(info.branch).toBe('session-branch');
+    // The sandbox is a fresh mkdtemp dir, never process.cwd() during a test
+    // run — this would fail if the argument were ever silently ignored.
+    expect(info.repo).not.toBe(path.basename(process.cwd()));
+  });
 });
 
 describe('parseEnvLine', () => {

--- a/packages/daemon/tests/integration/hub-lifecycle.test.ts
+++ b/packages/daemon/tests/integration/hub-lifecycle.test.ts
@@ -1,15 +1,20 @@
 /**
  * Integration tests for the hub lifecycle races and CLI round-trip (#542,
  * #731 review): the PID-file split-brain branches, `remi start`/`remi stop`
- * through the real CLI, and REMI_SPAWNED_CHILD per-port status routing.
+ * through the real CLI, REMI_SPAWNED_CHILD per-port status routing, and
+ * (#1025) the hub's own status.repo/branch staying cwd-based.
  *
  * Same harness as hub-serve.test.ts: REAL cli.ts subprocesses under an
  * isolated $HOME, no mocks.
  *
  * NOT covered here (covered by on-machine verification instead): a hub
- * spawning a real `--daemon` session child and `remi stop` sparing it — the
- * child wraps a real `claude` process, which CI does not have, and a stub
- * claude binary would violate the no-mocks rule.
+ * spawning a real `--daemon` session child and `remi stop` sparing it, or
+ * that child reporting its OWN directory's repo/branch (#1025) rather than
+ * the hub's — the child wraps a real `claude` process, which CI does not
+ * have, and a stub claude binary would violate the no-mocks rule. Verified
+ * manually (isolated $HOME, real `claude`): hub cwd A ("hub-repo-A"/"main"),
+ * child requested for cwd B ("session-repo-B"/a feature branch) — the
+ * child's status-<port>.json reported B's repo/branch, not A's.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -225,6 +230,32 @@ describe('cleanupFiles ownership guard (#740 review)', () => {
     await runCleanupFiles(home, 4242);
     expect(fs.readFileSync(pidFile, 'utf-8')).toBe('5555');
     expect(JSON.parse(fs.readFileSync(statusFile, 'utf-8')).pid).toBe(5555);
+  }, 30000);
+});
+
+describe('hub status reports its own cwd git info, unaffected (#1025)', () => {
+  // The #1025 fix refreshes the status snapshot's repo/branch from the
+  // resolved SESSION directory after --dir/--recent/--resume chdirs. Hub
+  // (serve) mode never chdirs, so it must keep reporting its own cwd exactly
+  // as before. A hub-spawned child correctly reporting ITS OWN directory
+  // instead of the hub's is covered by on-machine verification only (see
+  // file header): the child wraps a real `claude` process CI does not have,
+  // and it exits (PTY spawn ENOENT) before the debounced status write can
+  // ever reach disk without one.
+  test('serve mode reports the repo/branch of its own working directory', async () => {
+    const { home, work } = makeIsolatedDirs();
+    extraDirs.push(home, work);
+    fs.mkdirSync(path.join(work, '.git'));
+    fs.writeFileSync(path.join(work, '.git', 'HEAD'), 'ref: refs/heads/hub-own-branch\n');
+
+    const hub = await spawnHub({ home, work });
+    hubs.push(hub);
+
+    const status = JSON.parse(
+      fs.readFileSync(path.join(home, '.remi', 'daemon-status.json'), 'utf-8'),
+    );
+    expect(status.repo).toBe(path.basename(work));
+    expect(status.branch).toBe('hub-own-branch');
   }, 30000);
 });
 


### PR DESCRIPTION
## Root cause

`cli.ts:67` computed `const gitInfo = detectGitInfo();` at module load,
before arguments were parsed. `detectGitInfo` defaults to `process.cwd()`.
Hub-spawned children (`spawnRemiDaemon`, `daemon-manager.ts:532`) inherit
the hub's cwd, so every child reported whatever repo/branch the hub
happened to be running from, regardless of its own `--dir`.

## Fix

1. **Primary** (`cli.ts`): after the `--resume`/`--recent`/`--dir` chdirs
   settle `process.cwd()` on the real session directory, refresh the
   status snapshot with `updateRemiStatus(detectGitInfo())`. `remi serve`
   (hub mode) never chdirs here, so this is a no-op for it and the hub
   keeps reporting its own cwd, as designed.
2. **Belt-and-braces** (`daemon-manager.ts`): `spawnRemiDaemon` now sets
   the child process's `cwd` directly to the session directory (via a new
   `resolveExistingDirectory` helper in `path-resolver.ts`), so anything
   else in the child that reads `process.cwd()` before its own `--dir`
   chdir logic runs is correct too. Falls back to leaving `cwd` unset for
   an invalid directory, so the child's own `--dir` validation still
   reports that case cleanly.

## Tests

- `packages/daemon/tests/cli/startup-env.test.ts`: new regression test
  pinning that `detectGitInfo(dir)` never leaks `process.cwd()` when an
  explicit dir is given.
- `packages/daemon/tests/cli/path-resolver.test.ts`: new coverage for
  `resolveExistingDirectory` (existing dir, `~` expansion, non-existent
  path, file-not-directory, null/undefined/empty).
- `packages/daemon/tests/integration/hub-lifecycle.test.ts`: new real-
  subprocess test pinning that hub (serve) mode's `daemon-status.json`
  still reports its own cwd's repo/branch — the no-op path this fix must
  not break.
- A hub-spawned child correctly reporting **its own** directory (the
  actual bug scenario) is not covered by an automated test: the child
  wraps a real `claude` process, which CI does not have. I confirmed CI
  would in fact always lose this race — with `claude` stripped from
  `PATH`, the child's PTY spawn fails with ENOENT and the process exits
  before the debounced status write ever reaches disk (`status-<port>.json`
  is never created). This matches the precedent already documented in
  `hub-lifecycle.test.ts`'s file header for the sibling `--daemon`-child
  scenario. Verified manually instead, with an isolated `$HOME` (never
  touching `~/.remi`) and the real `claude` binary present: hub spawned in
  a dir named `hub-repo-A` on branch `main`; a `create_session_request`
  for a directory named `session-repo-B` on branch
  `feature/issue-1025-statusline-session-dir`; the child's
  `status-<port>.json` correctly reported `session-repo-B` /
  `feature/issue-1025-statusline-session-dir`, not the hub's values.

Test commands run (foreground, all passing):
- `bun test packages/daemon/tests/cli/startup-env.test.ts packages/daemon/tests/cli/path-resolver.test.ts packages/daemon/tests/cli/daemon-manager.test.ts` — 52 pass, 0 fail
- `bun test packages/daemon/tests/integration/hub-lifecycle.test.ts` — 7 pass, 0 fail
- `bun test packages/daemon/tests/cli/` — 1116 pass, 0 fail (no `shell-path.test.ts` flakes this run)
- `bun test packages/daemon/tests/integration/` — 17 pass, 0 fail
- `bun run typecheck` — clean
- `bunx biome check` on all changed files — clean

## Follow-up: undefined-directory gap (review finding)

Fresh-context review confirmed the fix above for the reported scenario,
but found the two fixes so far only cover a create-session request that
names a directory. When `directory === undefined`, `daemon-manager.ts:545`
never pushes `--dir` at all, so no chdir happens and the child inherits
the hub's cwd verbatim — the same bug, reachable today via `remi new
--host <host>` with no path, and via the web UI's `RecentProjects`
default entry (`NewSessionModal.tsx` documents "empty string =
home/cwd").

Fixed at the remote-request layer, not inside `spawnRemiDaemon`:
`onCreateSessionRequest` (`create-session-events.ts`) now resolves
`directory` through a new `resolveRequestedSessionDirectory` helper
before calling `spawnDaemon` — no directory, or an empty/whitespace-only
string, maps to `os.homedir()`; anything else passes through trimmed,
unchanged. The default lives here and not in `spawnRemiDaemon` itself,
because a **local** `remi new` from a shell (no directory, no `--host`)
correctly inherits the invoking shell's cwd — that's real, no-directory
input reaching `spawnRemiDaemon` for a *different* reason, and a blanket
homedir default there would break it. Only a request that arrived over
the wire has no meaningful cwd to fall back to.

Also reworded the `resolveExistingDirectory` JSDoc (flagged as
overclaiming): it previously said invalid input is "left for the
child's own `--dir` handling to catch", which was only true for a
non-empty invalid string — falsy input never reached that handling at
all. Now states both cases, and notes that after this follow-up the
remote path never reaches it with falsy input in the first place.

New tests: `resolveRequestedSessionDirectory` unit coverage
(undefined/empty/whitespace → `os.homedir()`, a real path passes
through trimmed, no `~` expansion — that stays the child's own `--dir`
job) plus a wiring test in `create-session-events.test.ts` asserting
`spawnDaemon` receives `os.homedir()` for all three missing-directory
shapes. Verified manually again (isolated `$HOME`, real `claude`): a
directory-less `create_session_request` against a hub running from a
repo named `hub-repo-C` landed the child in the home directory, not
`hub-repo-C`.

Remaining known non-issue, not a bug: a **local** `remi new` (typed
directly in a shell, no `--host`) with no `--dir` intentionally
inherits the invoking shell's cwd — untouched by either fix, by design.

Test commands run for this follow-up (foreground, all passing):
- `bun test packages/daemon/tests/cli/path-resolver.test.ts packages/daemon/tests/cli/handlers/create-session-events.test.ts` — 29 pass, 0 fail
- `bun test packages/daemon/tests/cli/` — 1122 pass, 0 fail
- `bun run typecheck` — clean
- `bunx biome check` on all changed files — clean

Commit: `1e66fe17`

Closes #1025
