### PR TITLE
Answer deterministic subagent permissions at hook time

### DIFF
--- a/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
+++ b/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
@@ -35,8 +35,117 @@ status-churn can wipe a main-eval buffered prompt (#769).
 - **Suppress all subagent escalations:** silent denials; violates "my agent
   needs me. Yes or No."
 
+## Amended 2026-08-08: a deterministic config approve answers at hook time; the LLM still never runs there
+
+**Status of this amendment:** accepted. It NARROWS the original rule rather
+than reversing it — the LLM is still never consulted at hook time for a
+subagent-tagged request, on any authorization. What changes is which
+subagent requests reach the park path at all.
+
+### Why the original rule could not stand unchanged
+
+A live transit session (2026-08-08, `c77ba8f8`) fired 69 subagent
+PermissionRequests: ~40 Bash calls from one review agent (`review-479`) in
+12 minutes, plus 11 WebFetch calls from research agents in 4 minutes. Every
+one of those parked, exactly per the pre-amendment rule, and every parked
+render WAS evaluated once it rendered — no "not evaluated" pushes. But the
+verdicts routinely lost the race against prompt churn: the log fills with
+`Parked render <id> is no longer the prompt on screen; NOT typing "1"` — the
+LLM approved, the inject was refused because a DIFFERENT prompt had already
+taken the screen, and the outcome degraded into a user escalation (and
+sometimes a dropped push). With several agents running in parallel, the main
+PTY prompt turns over faster than a GPU-backed eval round-trip can complete.
+The GPU is also serialized (one model, one queue): a burst of parked
+renders queues its evals behind each other, which is what pushed several
+main-context evals past `push_hold_timeout` and produced "escalated
+directly to user" symptoms that had nothing to do with the main agent's own
+work.
+
+None of this was an LLM-accuracy problem. The review agent's ~40 Bash calls
+were `read-only`-group reads; the WebFetch calls were plain user `allow`
+tool-name matches. The config had already decided every one of them before
+the park-unconditionally rule ever asked the model anything — the cost was
+purely the render-time race, paid on traffic the daemon could have settled
+at 0ms and never rendered at all.
+
+### What licensed the change
+
+The original ADR's own rationale was **GPU cost per background call and
+unknowable render state** — "Claude blocks on this hook response, so at
+decision time we cannot know whether the prompt will ever render on the
+main PTY... evaluating them all meant one GPU-backed LLM call per background
+tool call." Both halves of that rationale are properties of the LLM
+specifically: a 0ms, config-authorized match has no GPU cost and needs no
+render-state knowledge, because it does not depend on what the user would
+have decided — the user already decided it, in `config.toml`, when they
+wrote the `allow` list or picked a `level`. ADR 0015's amendment already
+established that config-sourced authorization (a human's own `config.toml`)
+is a non-text channel that may decide outright, unlike text-derived
+authority; ADR 0016 established that the permissive half of policy is
+level-gated group membership, checkable without a model. Both apply
+directly to `approve_groups`/`allow` matches on a subagent request — nothing
+about being subagent-tagged changes what those matches already mean for a
+main-context request evaluated by the identical code path.
+
+### The amended rule
+
+At hook time, for a subagent-tagged (`agent_id`-present) PermissionRequest,
+run ONLY `AutoApproveService.evaluateDeterministic` — the exact deny/allow/
+approve_groups matcher calls, in the exact order, `evaluate()` itself runs
+before ever considering the LLM (extracted so the two share one
+implementation and cannot drift, per ADR 0015/0017's shared-list caution):
+
+- **Deterministic approve** (no deny match, and `allow` or `approve_groups`
+  covers the call): the gate answers the hook `{behavior: 'allow'}`
+  directly. No park, no PTY render, no LLM call, no queue wait. The
+  `onSubagentPassthrough` observation cue still fires — unchanged from the
+  park path — so `subagent_alert` visibility does not depend on how the hook
+  was answered.
+- **Deny-covered, or no deterministic verdict**: parks + passes through
+  exactly as the pre-amendment rule did. A hook-time deny is still not
+  produced for a subagent match: unlike a main-context deny (which can carry
+  `buildDenyMessage` back to Claude), a subagent's config-level deny has no
+  human-visible channel until a render happens, so it stays on the
+  render-time PTY-arbiter path this ADR already governs.
+
+**The LLM is still never invoked at hook time for a subagent request, on
+any path.** That was the original decision's core claim and it is
+untouched: only a 0ms, config-authorized match — the same match a
+main-context request already gets for free — can decide here. Everything
+the original ADR said about the LLM (GPU cost, unknowable render state,
+phantom-question risk) still governs every subagent request the config does
+not deterministically approve.
+
+### What this does NOT change
+
+- Parked records, the eval-in-flight buffer window, and `arbitrateParkedRender`
+  (#814) are untouched for every request that still parks.
+- A model-produced verdict, for a subagent or otherwise, still only ever
+  happens at render time (`arbitrateParkedRender`) or in the main-context
+  synchronous path — never at subagent hook time.
+- The gate does not call `markHandled()` for a deterministic hook-time
+  approve. Every existing `markHandled(true)` call site pairs with its own
+  prior `onEvalStart({isSubagent:true})` (see `arbitrateParkedRender`),
+  which is what keeps the shared per-session `inFlight` eval counter
+  (#560/#576) balanced; this path never opens that counter, so firing only
+  the "end" half risked decrementing a genuinely in-flight MAIN eval's count
+  — the class of miscounted cue [ADR 0020](0020-client-status-cue-totality.md)
+  exists to catch. Both effects `markHandled` would otherwise produce are
+  already no-ops for a subagent permission (`onAutoApproveHandled` returns
+  early on `isSubagent`; the client broadcast is skipped the same way), so
+  omitting the call costs nothing.
+
 ## Receipts
 
 Issues #751, #763, #767, #756; PRs #762, #764, #768 (0.6.19). Detail
 formerly in `.context/subagent-aa-routing.md` (pruned 2026-07-10; the live
 proposal is on #756).
+
+**2026-08-08 amendment:** issue #1024 (evidence: transit session `c77ba8f8`,
+69 subagent PermissionRequests, ~40 Bash/12min from `review-479`, 11
+WebFetch/4min, all parked renders evaluated but routinely losing the
+prompt-lifetime race). `packages/daemon/src/auto-approve/auto-approve-service.ts`
+— `evaluateDeterministic`. `packages/daemon/src/auto-approve/auto-approve-gate.ts`
+— `resolvePermission`'s subagent branch. ADR 0015 (config as a non-text
+authorization channel), ADR 0016 (groups as checkable policy), ADR 0020
+(the `markHandled` omission reasoning above).

--- a/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
+++ b/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
@@ -134,6 +134,17 @@ not deterministically approve.
   already no-ops for a subagent permission (`onAutoApproveHandled` returns
   early on `isSubagent`; the client broadcast is skipped the same way), so
   omitting the call costs nothing.
+- **A bare tool-name `allow` entry (`allow = ["Write"]`, `["Edit"]`) now
+  grants a subagent silent, hook-time, unrendered approval to sensitive
+  destinations a curated group would veto.** `matchAllowPattern` applies no
+  destination check by design (ADR 0010: "a user allow entry may legitimately
+  be a write"), unlike `approve_groups`, whose write groups carry
+  `vetoSensitiveToolPath`. This was already true for main-context requests;
+  #1024 is the first time it applies to subagent traffic with zero chance of
+  a human ever seeing the prompt. Not a defect in this change — it faithfully
+  extends existing allow semantics, and the config validator already warns on
+  tool-name-shaped allow entries — but the blast radius of a loose config is
+  now wider and quieter. Tracked as #1032.
 
 ## Receipts
 

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -19,7 +19,7 @@ add a row below.
 | [0001](0001-transcript-path-source-of-truth.md) | Transcript path is the session source of truth |
 | [0002](0002-model-b-hold-the-hook-notifications.md) | Hold-the-hook notification model |
 | [0003](0003-synchronous-permission-decisions.md) | Synchronous permission decisions |
-| [0004](0004-pty-as-arbiter-subagent-questions.md) | PTY is the arbiter for subagent questions |
+| [0004](0004-pty-as-arbiter-subagent-questions.md) | PTY is the arbiter for subagent questions — amended 2026-08-08: a config-deterministic approve answers at hook time, the LLM still never runs there |
 | [0005](0005-hub-and-attach-only-clients.md) | Hub mode and attach-only clients |
 | [0006](0006-cc-ref-disavowed.md) | `cc-ref` is not ground truth for Claude Code |
 | [0007](0007-release-automation-and-pins.md) | Release automation and toolchain pins |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,20 +167,31 @@ See `.context/notification-and-session-flow.md` for the full flow diagram.
 - `HookEventBridge` — emits questions from `PermissionRequest` hooks; suppresses redundant notifications.
 - `OutputProcessor` — PTY-output parsing (fallback when hooks are unavailable).
 
-**Subagent permissions: the PTY is the arbiter** (#756 policy, #807 + #814):
+**Subagent permissions: the PTY is the arbiter** (#756 policy, #807 + #814;
+amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-subagent-questions.md)):
 
-- An `agent_id`-tagged `PermissionRequest` is NEVER evaluated at hook time. `AutoApproveGate`
-  parks it (`parkForPTY` → `QuestionPresenceTracker.parkAwaitingPTY`) and answers the hook
-  `passthrough` immediately. Claude blocks on that response, so at hook time nothing can know
-  whether the prompt will ever render — and most never do (16 hooks → 2 renders in a live
-  0.6.22 session).
-- If the prompt DOES render, `arbitrateParkedRender` evaluates it then: `approve`/`deny`/`pick`
-  are typed into the prompt on screen (never a persisting "always" option), and only an
-  `escalate` verdict pushes a card. Every failure direction escalates; nothing is ever
+- An `agent_id`-tagged `PermissionRequest` NEVER reaches the LLM at hook time — that part of
+  the original policy is unchanged. `AutoApproveGate` first asks ONLY the deterministic
+  pre-LLM layers (`AutoApproveService.evaluateDeterministic`: deny — list + groups — checked
+  first, then user `allow`, then the level's `approve_groups`; the exact matcher calls
+  `evaluate()` itself runs, shared so the two can never drift). A deterministic **approve**
+  (no deny match) answers the hook `{behavior:'allow'}` immediately — no park, no render, no
+  LLM, no GPU queue. Everything else — no deterministic verdict, or a **deny** match — parks
+  it (`parkForPTY` → `QuestionPresenceTracker.parkAwaitingPTY`) and answers the hook
+  `passthrough`, exactly as before #1024. A subagent's config-level deny is never turned into
+  a hook-time deny: it has no human-visible channel until a render happens, so it stays on the
+  render-time path below. Claude blocks on the hook response, so for anything that parks,
+  nothing can know whether the prompt will ever render — and most never do (16 hooks → 2
+  renders in a live 0.6.22 session).
+- If the prompt DOES render, `arbitrateParkedRender` evaluates it then (LLM included): `approve`/
+  `deny`/`pick` are typed into the prompt on screen (never a persisting "always" option), and
+  only an `escalate` verdict pushes a card. Every failure direction escalates; nothing is ever
   auto-answered by guess.
-- An allowlist-covered subagent command never renders and so is never evaluated; the
-  `subagent_alert` informational push (`auto-approve/subagent-alert.ts`) is the visibility
-  path for those, deliberately alerting rather than blocking.
+- An allowlist-covered subagent command — whether answered at hook time (#1024) or absorbed
+  silently after parking — never surfaces to a human by itself; the `subagent_alert`
+  informational push (`auto-approve/subagent-alert.ts`) is the visibility path for both cases,
+  fired via the same `onSubagentPassthrough` cue regardless of which path answered the hook,
+  deliberately alerting rather than blocking.
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,11 @@ amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-
   informational push (`auto-approve/subagent-alert.ts`) is the visibility path for both cases,
   fired via the same `onSubagentPassthrough` cue regardless of which path answered the hook,
   deliberately alerting rather than blocking.
+- A bare tool-name `allow` entry (`allow = ["Write"]`, `["Edit"]`) carries no destination veto
+  by design (ADR 0010) and, since #1024, now grants a subagent silent hook-time write access to
+  sensitive destinations a curated `approve_groups` write group would block. Already true for
+  main-context requests; #1024 is the first time it applies with zero chance of a human ever
+  seeing the prompt. Tracked as #1032 (not yet decided).
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -297,6 +297,25 @@ export interface AutoApproveEvaluator {
    *  legitimate wait. Returns the number drained. Optional: a minimal
    *  evaluator under test may omit it. */
   drainScope?(scope: string, opts?: { mainOnly?: boolean }): number;
+  /**
+   * #1024: the deterministic, pre-LLM portion of `evaluate()` ONLY -- deny
+   * (list + groups) checked first, then `allow`, then `approve_groups`. No
+   * network, no model, no queue. Lets `resolvePermission`'s subagent branch
+   * answer a config-authorized request at hook time without ever reaching
+   * the LLM (ADR 0004 still forbids that unconditionally).
+   *
+   * Optional: a minimal test double that never exercises the hook-time
+   * subagent shortcut may omit it, in which case the gate treats every
+   * subagent-tagged event as having no deterministic verdict -- i.e. the
+   * pre-#1024 park-unconditionally behavior.
+   */
+  evaluateDeterministic?(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ):
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null;
 }
 
 export interface AutoApproveGateDeps {
@@ -1341,22 +1360,31 @@ export class AutoApproveGate {
    *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
    *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
    *     prompt; the user answers).
-   *   - ANY SUBAGENT-TAGGED event (`agent_id` present) -> park the rich
-   *     question in the presence tracker + 'passthrough' (#751 PTY-arbiter)
-   *     WITHOUT evaluating it (#807), and REGARDLESS of
-   *     `isInSubagentContext()` (the tracker only brackets synchronous
-   *     Task/Agent spawns, so team members and async/background subagents
-   *     always observe it false — the tag on the event itself is the truth).
-   *     Claude then runs its NORMAL permission flow: the session allowlist
-   *     may absorb the request silently, or the native prompt renders on the
-   *     main PTY — where `arbitrateParkedRender` (#814) evaluates it and
-   *     either answers it on screen or pushes the merged card (answers
-   *     inject; nothing is held). Replaces three prior behaviors:
-   *     silent default-deny (sync-Task shape, broke teammates with no trace),
-   *     hold+push-as-main (async/team shape, pushed cards for prompts the
-   *     user never saw asked), and evaluate-then-route (#751's shape, which
-   *     spent a GPU-backed LLM call per background tool call and silently
-   *     applied its allow/deny verdict to a prompt no human ever saw).
+   *   - a SUBAGENT-TAGGED event (`agent_id` present) the config's own
+   *     deterministic layers already APPROVE (deny checked first, then
+   *     `allow`, then `approve_groups` -- `service.evaluateDeterministic`,
+   *     #1024) -> answer the hook 'allow' directly. No park, no PTY render,
+   *     no LLM: ADR 0004 still holds, this is a 0ms config match, not a
+   *     model evaluation.
+   *   - every OTHER subagent-tagged event (config does not deterministically
+   *     approve it -- including one its `deny`/`deny_groups` covers, which
+   *     is NOT turned into a hook-time deny; see `evaluateDeterministic`'s
+   *     doc for why) -> park the rich question in the presence tracker +
+   *     'passthrough' (#751 PTY-arbiter) WITHOUT ever running the LLM at
+   *     hook time (#807), and REGARDLESS of `isInSubagentContext()` (the
+   *     tracker only brackets synchronous Task/Agent spawns, so team members
+   *     and async/background subagents always observe it false — the tag on
+   *     the event itself is the truth). Claude then runs its NORMAL
+   *     permission flow: the session allowlist may absorb the request
+   *     silently, or the native prompt renders on the main PTY — where
+   *     `arbitrateParkedRender` (#814) evaluates it and either answers it on
+   *     screen or pushes the merged card (answers inject; nothing is held).
+   *     Replaces three prior behaviors: silent default-deny (sync-Task
+   *     shape, broke teammates with no trace), hold+push-as-main (async/team
+   *     shape, pushed cards for prompts the user never saw asked), and
+   *     evaluate-then-route (#751's shape, which spent a GPU-backed LLM call
+   *     per background tool call and silently applied its allow/deny verdict
+   *     to a prompt no human ever saw).
    *   - a MAIN-tagged event (no `agent_id`) with `isInSubagentContext()` true
    *     -> this is the #710 tracker-leak signature (a PostToolUse(Task/Agent)
    *     completion tagged with the spawned agent's own agent_id was dropped
@@ -1375,28 +1403,61 @@ export class AutoApproveGate {
     // subagent/team-member (`agent_id` present) or the main agent.
     const isSubagent = this.isSubagentEvent(input);
 
-    // #807: a subagent-tagged permission NEVER reaches the evaluator, with or
-    // without auto-approve configured.
+    // #807: a subagent-tagged permission NEVER reaches the LLM at hook time,
+    // with or without auto-approve configured.
     //
     // Claude blocks on this hook response, so at decision time we cannot know
     // whether the prompt will ever render on the main PTY — and empirically
     // most never do (a live 0.6.22 session logged 16 subagent
-    // PermissionRequests against 2 renders). Evaluating them all meant one
-    // GPU-backed LLM call per background tool call, and every approve/deny
-    // verdict was applied to a prompt no human ever saw and no card ever
-    // recorded.
+    // PermissionRequests against 2 renders). Evaluating them ALL with the LLM
+    // meant one GPU-backed call per background tool call, and every
+    // approve/deny verdict was applied to a prompt no human ever saw and no
+    // card ever recorded.
     //
-    // So park + passthrough unconditionally: Claude runs its own permission
-    // flow, and either its allowlist absorbs the request silently or the
-    // native prompt renders on the main PTY, where the parked record merges
-    // onto it and pushes a card. The PTY — not the hook — decides whether a
-    // human is asked, which is the arbiter policy #756 asked for.
+    // #1024 amendment: that reasoning applies to the LLM specifically (GPU
+    // cost + unknowable render state), not to a 0ms config-authorized match.
+    // So before parking, ask ONLY the deterministic layers -- deny, then
+    // allow, then approve_groups, the exact matcher calls `evaluate()` itself
+    // runs first (`evaluateDeterministic`, shared so the two can never drift).
+    // A deterministic APPROVE answers the hook directly, no park, no render,
+    // no LLM. Anything else -- no deterministic verdict, OR the config's own
+    // deny layer covers it -- parks + passthroughs exactly as before #1024:
+    // a hook-time deny still has no human-visible channel for a subagent (no
+    // render has happened yet to carry `buildDenyMessage`), so ADR 0004's
+    // PTY-arbiter policy still owns that case.
     //
-    // The evaluation itself is not skipped, only DEFERRED: if this prompt does
-    // render, `arbitrateParkedRender` (#814) evaluates it at that point and
-    // answers it by PTY inject, or pushes a card the phone can answer. That is
-    // the async route this hook response could never take.
+    // Either way, the evaluation itself is not skipped, only DEFERRED for
+    // anything not deterministically approved: if the prompt renders,
+    // `arbitrateParkedRender` (#814) evaluates it at that point (LLM
+    // included) and answers it by PTY inject, or pushes a card the phone can
+    // answer. That is the async route this hook response could never take.
     if (isSubagent) {
+      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      if (deterministic?.decision === 'approve') {
+        log(
+          `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
+        );
+        // Observation only, the SAME cue the park path fires below:
+        // subagent_alert visibility must not depend on whether this call was
+        // ALSO deterministically approved -- e.g. a `curl` command an
+        // approve group covers still deserves the same audit trail a parked
+        // one gets (subagent-alert.ts matches on the raw input, not on how
+        // the hook was answered).
+        //
+        // Deliberately NOT `markHandled()`: every existing `markHandled(true)`
+        // call site (see `arbitrateParkedRender`) is preceded by its own
+        // `onEvalStart({isSubagent:true})`, which is what keeps the shared
+        // per-session `inFlight` eval count (#560/#576, `status-writer.ts`)
+        // balanced. This path never opens that counter -- firing only the
+        // "end" half here could decrement a genuinely in-flight MAIN eval's
+        // count if one happens to be running concurrently, which is exactly
+        // the kind of miscounted cue ADR 0020 exists to catch. Nothing else
+        // `markHandled` does applies here either: the tracker's
+        // `onAutoApproveHandled(isSubagent=true)` and the client status
+        // broadcast are both already no-ops for a subagent permission.
+        this.safeCueWithArg('onSubagentPassthrough', this.deps.onSubagentPassthrough, input);
+        return 'allow';
+      }
       log(
         `[Hooks] Subagent PermissionRequest passed through UNEVALUATED (PTY arbitrates): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
       );

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -35,7 +35,7 @@ import { type PrecedentReader, precedentMayAuthorize, signatureForOperation } fr
 import { buildPrompt } from './prompt-builder.ts';
 import { classifyRisk, formatMatrixContext } from './risk-bands.ts';
 import { enforceRiskCeiling } from './risk-ceiling.ts';
-import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
+import type { AutoApproveConfig, AutoApproveResult, DenySource, MultiChoiceMode } from './types.ts';
 
 type BinaryDecision = 'approve' | 'deny' | 'escalate';
 const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate']);
@@ -627,6 +627,80 @@ export class AutoApproveService {
   }
 
   /**
+   * The deterministic, pre-LLM portion of `evaluate()` ONLY: the user's own
+   * `deny`/`deny_groups` (checked first, always win), then `allow`
+   * (`matchAllowPattern`), then the level's `approve_groups` (`matchGroups`)
+   * -- the exact matcher calls, in the exact order, `evaluate()` runs before
+   * it ever considers precedent or the LLM. A pure function of (toolName,
+   * toolInput) and this service's own config: no network, no model, no
+   * queue, no precedent, no design-question routing.
+   *
+   * #1024: extracted so a caller that must decide BEFORE the LLM may ever
+   * run (the gate's subagent-tagged hook-time path, which ADR 0004 forbids
+   * from reaching the LLM at all) can reuse these checks instead of
+   * re-implementing them -- the exact drift ADR 0015/0017 warn about for
+   * the shared catastrophic-pattern list, here avoided by construction:
+   * `evaluate()` below calls this and must never duplicate its checks
+   * inline.
+   *
+   * Returns:
+   *   - `{decision: 'approve', reasoning}` -- the user's own `allow` list or
+   *     `approve_groups` covers this call. Safe to act on directly; this is
+   *     the same 0ms verdict `evaluate()` returns for the identical match.
+   *   - `{decision: 'deny-covered', reasoning, denySource}` -- the user's own
+   *     `deny` list or `deny_groups` covers this call. NOT a verdict a
+   *     hook-time caller may act on by itself: `evaluate()` turns this into
+   *     a full `deny` `AutoApproveResult` because a MAIN-context deny has a
+   *     human-visible channel (`buildDenyMessage` tells Claude why). A
+   *     subagent-tagged hook-time caller has no such channel before the
+   *     prompt renders, so ADR 0004's PTY-arbiter policy requires this case
+   *     to fall through to the render-time path exactly like `null` below --
+   *     it exists as its own variant (rather than folding into `null`) only
+   *     so a caller that DOES want the reasoning (`evaluate()`) does not have
+   *     to re-run the deny matchers to get it.
+   *   - `null` -- nothing here decides it; the caller falls back to whatever
+   *     handles the undecided case (the LLM, for `evaluate()`; parking for
+   *     PTY arbitration, for the gate's subagent branch).
+   */
+  evaluateDeterministic(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ):
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null {
+    const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
+    if (denyMatch !== null) {
+      return {
+        decision: 'deny-covered',
+        reasoning: `deny-matched pattern: "${denyMatch}"`,
+        denySource: { kind: 'config', pattern: denyMatch },
+      };
+    }
+    // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
+    // command to be covered and is right for the allow question below; asking
+    // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
+    // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
+    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
+    if (denyGroupMatch !== null) {
+      return {
+        decision: 'deny-covered',
+        reasoning: `deny-matched group: "${denyGroupMatch}"`,
+        denySource: { kind: 'config', pattern: denyGroupMatch },
+      };
+    }
+    const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
+    if (allowMatch !== null) {
+      return { decision: 'approve', reasoning: `allow-matched pattern: "${allowMatch}"` };
+    }
+    const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
+    if (approveGroupMatch !== null) {
+      return { decision: 'approve', reasoning: `approve-matched group: "${approveGroupMatch}"` };
+    }
+    return null;
+  }
+
+  /**
    * Evaluate a permission request. Never throws.
    * On any error, returns escalate so the user gets the question as normal.
    *
@@ -712,52 +786,25 @@ export class AutoApproveService {
     // Entire body wrapped in try/catch so the "never throws" contract holds
     // even if the matchers or other sync code fail (e.g. malformed config).
     try {
-      // Deny list + deny groups: checked first, always win. No LLM call.
-      const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
-      if (denyMatch !== null) {
-        const reasoning = `deny-matched pattern: "${denyMatch}"`;
-        this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return {
-          decision: 'deny',
-          reasoning,
-          durationMs: 0,
-          model,
-          denySource: { kind: 'config', pattern: denyMatch },
-        };
-      }
-      // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
-      // command to be covered and is right for the allow question below; asking
-      // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
-      // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
-      const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
-      if (denyGroupMatch !== null) {
-        const reasoning = `deny-matched group: "${denyGroupMatch}"`;
-        this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return {
-          decision: 'deny',
-          reasoning,
-          durationMs: 0,
-          model,
-          denySource: { kind: 'config', pattern: denyGroupMatch },
-        };
-      }
-
-      // Allow list + approve groups: bypass the LLM for known-safe operations.
-      const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
-      if (allowMatch !== null) {
-        const reasoning = `allow-matched pattern: "${allowMatch}"`;
-        if (this.logDecisions) {
-          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
+      // Deny/allow/group: checked first, always win, no LLM call. Shared with
+      // the gate's subagent hook-time path (#1024) via `evaluateDeterministic`
+      // so the two can never drift apart -- see that method's doc.
+      const deterministic = this.evaluateDeterministic(toolName, toolInput);
+      if (deterministic !== null) {
+        if (deterministic.decision === 'deny-covered') {
+          this.logFn(`${prefix} DENIED ${toolName}: ${deterministic.reasoning} (0ms)`);
+          return {
+            decision: 'deny',
+            reasoning: deterministic.reasoning,
+            durationMs: 0,
+            model,
+            denySource: deterministic.denySource,
+          };
         }
-        return { decision: 'approve', reasoning, durationMs: 0, model };
-      }
-      const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
-      if (approveGroupMatch !== null) {
-        const reasoning = `approve-matched group: "${approveGroupMatch}"`;
         if (this.logDecisions) {
-          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
+          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${deterministic.reasoning}`);
         }
-        return { decision: 'approve', reasoning, durationMs: 0, model };
+        return { decision: 'approve', reasoning: deterministic.reasoning, durationMs: 0, model };
       }
 
       // #976 PRECEDENT, approve direction: the user already answered YES to

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -625,6 +625,195 @@ describe('AutoApproveGate', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1024: a subagent-tagged PermissionRequest that the config's own
+// deterministic layers (deny, then allow, then approve_groups --
+// `evaluateDeterministic`) already approve is answered 'allow' at hook time
+// instead of parked. The LLM must still never run for a subagent at hook
+// time (ADR 0004); anything not deterministically approved -- including a
+// deny match -- parks + passthroughs exactly as before this issue.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate subagent hook-time deterministic answer (#1024)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let parks: PermissionRequestHookInput[];
+  let observed: PermissionRequestHookInput[];
+  let evaluateCalls: number;
+  let tracker: QuestionPresenceTracker;
+
+  type Deterministic =
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null;
+
+  function gateWithDeterministic(det: Deterministic): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const service: AutoApproveEvaluator = {
+      evaluate: async () => {
+        evaluateCalls++;
+        return approve;
+      },
+      cancel: () => true,
+      evaluateDeterministic: () => det,
+    };
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: (i) => {
+          parks.push(i);
+          return undefined;
+        },
+        onSubagentPassthrough: (i) => observed.push(i),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'grep foo src/' },
+      agent_id: 'agent-1',
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    parks = [];
+    observed = [];
+    evaluateCalls = 0;
+    tracker = new QuestionPresenceTracker(() => undefined);
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve_groups-covered command answers "allow", does not park, LLM never runs', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'approve-matched group: "read-only:Bash"',
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(parks).toHaveLength(0);
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(evaluateCalls).toBe(0);
+  });
+
+  test('user allow-covered tool name (WebFetch) answers "allow"', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'allow-matched pattern: "WebFetch"',
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(
+      pr({ tool_name: 'WebFetch', tool_input: { url: 'https://example.com' } }),
+    );
+    expect(d).toBe('allow');
+    expect(parks).toHaveLength(0);
+    expect(evaluateCalls).toBe(0);
+  });
+
+  test('deterministic approve still fires the subagent_alert observation cue', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'approve-matched group: "read-only:Bash"',
+    };
+    const input = pr({ tool_input: { command: 'curl https://example.com' } });
+    const d = await gateWithDeterministic(det).resolvePermission(input);
+    expect(d).toBe('allow');
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.tool_input).toEqual({ command: 'curl https://example.com' });
+  });
+
+  test('deny-covered match parks (deny wins; no hook-time allow)', async () => {
+    const det: Deterministic = {
+      decision: 'deny-covered',
+      reasoning: 'deny-matched pattern: "rm -rf /"',
+      denySource: { kind: 'config', pattern: 'rm -rf /' },
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(
+      pr({ tool_input: { command: 'rm -rf /tmp/x' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+    // Still observed via the same park-path cue, exactly as before #1024.
+    expect(observed).toHaveLength(1);
+  });
+
+  test('no deterministic verdict parks + passthrough exactly as before #1024', async () => {
+    const d = await gateWithDeterministic(null).resolvePermission(
+      pr({ tool_input: { command: 'npm install' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+    expect(observed).toHaveLength(1);
+  });
+
+  test('a test double omitting evaluateDeterministic parks exactly as before #1024', async () => {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const minimal: AutoApproveEvaluator = {
+      evaluate: async () => {
+        evaluateCalls++;
+        return approve;
+      },
+      cancel: () => true,
+    };
+    const g = new AutoApproveGate(
+      {
+        service: minimal,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: (i) => {
+          parks.push(i);
+          return undefined;
+        },
+        onSubagentPassthrough: (i) => observed.push(i),
+      },
+      SID,
+    );
+    const d = await g.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Lifecycle callbacks that drive the terminal cue (#513). They must fire on the
 // matching verdict and never cross-fire (a leaked spinner / missed notification
 // would be the symptom).

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -655,6 +655,92 @@ describe('AutoApproveService - permission groups (#494)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// evaluateDeterministic (#1024) — the shared pre-LLM layer `evaluate()` and
+// the gate's subagent hook-time shortcut both call. No network involved, so
+// these do not need the unreachable-base_url trick the tests above use.
+// ---------------------------------------------------------------------------
+
+describe('AutoApproveService - evaluateDeterministic (#1024)', () => {
+  function detService(over: Partial<AutoApproveConfig>): AutoApproveService {
+    return new AutoApproveService(makeConfig({ base_url: 'http://10.255.255.1', ...over }), logFn);
+  }
+
+  test('allow pattern match returns approve', () => {
+    const service = detService({ allow: ['git push'] });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'cd /foo && git push origin main',
+    });
+    expect(result?.decision).toBe('approve');
+    expect(result && 'reasoning' in result ? result.reasoning : '').toContain('allow-matched');
+  });
+
+  test('approve_groups match returns approve', () => {
+    const service = detService({ approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('Grep', { pattern: 'foo' });
+    expect(result?.decision).toBe('approve');
+    expect(result && 'reasoning' in result ? result.reasoning : '').toContain(
+      'approve-matched group',
+    );
+  });
+
+  test('deny pattern match returns deny-covered, never approve', () => {
+    const service = detService({ deny: ['rm -rf /'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'rm -rf /tmp/foo' });
+    expect(result?.decision).toBe('deny-covered');
+    if (result?.decision === 'deny-covered') {
+      expect(result.reasoning).toContain('deny-matched pattern');
+      expect(result.denySource).toEqual({ kind: 'config', pattern: 'rm -rf /' });
+    }
+  });
+
+  test('deny_groups match returns deny-covered with a group denySource', () => {
+    const service = detService({ deny_groups: ['build-test'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'bun test' });
+    expect(result?.decision).toBe('deny-covered');
+    if (result?.decision === 'deny-covered') {
+      expect(result.reasoning).toContain('deny-matched group');
+      expect(result.denySource.kind).toBe('config');
+    }
+  });
+
+  test('deny wins over allow: a command matching both returns deny-covered', () => {
+    const service = detService({ allow: ['git'], deny: ['git push --force'] });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'git push --force origin main',
+    });
+    expect(result?.decision).toBe('deny-covered');
+  });
+
+  test('no match returns null', () => {
+    const service = detService({ allow: [], deny: [], approve_groups: [], deny_groups: [] });
+    const result = service.evaluateDeterministic('Bash', { command: 'npm install' });
+    expect(result).toBeNull();
+  });
+
+  test('agrees with evaluate() on the same allow-matched input (no drift)', async () => {
+    const service = detService({ allow: ['git push'] });
+    const direct = service.evaluateDeterministic('Bash', { command: 'git push origin main' });
+    const viaEvaluate = await service.evaluate('Bash', { command: 'git push origin main' });
+    expect(direct?.decision).toBe('approve');
+    expect(viaEvaluate.decision).toBe('approve');
+    expect(viaEvaluate.reasoning).toBe(direct && 'reasoning' in direct ? direct.reasoning : '');
+    expect(viaEvaluate.durationMs).toBe(0);
+  });
+
+  test('agrees with evaluate() on the same deny-matched input (no drift)', async () => {
+    const service = detService({ deny: ['rm -rf /'] });
+    const direct = service.evaluateDeterministic('Bash', { command: 'rm -rf /tmp/foo' });
+    const viaEvaluate = await service.evaluate('Bash', { command: 'rm -rf /tmp/foo' });
+    expect(direct?.decision).toBe('deny-covered');
+    expect(viaEvaluate.decision).toBe('deny');
+    expect(viaEvaluate.reasoning).toBe(direct && 'reasoning' in direct ? direct.reasoning : '');
+    expect(viaEvaluate.decision === 'deny' ? viaEvaluate.denySource : undefined).toEqual(
+      direct?.decision === 'deny-covered' ? direct.denySource : undefined,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Instructions injected into LLM prompt (behavioral - uses the real engine)
 // ---------------------------------------------------------------------------
 describeEngine('AutoApproveService - instructions affect LLM decision', () => {


### PR DESCRIPTION
## Summary

At `PermissionRequest` hook time, a subagent-tagged (`agent_id`-present)
request unconditionally parked for PTY arbitration (#751/#807, ADR 0004),
even when the user's own `config.toml` already decides it via `deny`,
`allow`, or `approve_groups`. Every parked request still had to render on
the main PTY and win an LLM eval before the user's own standing rule ever
took effect.

**Before:** every subagent-tagged `PermissionRequest` parks, regardless of
config. If the prompt renders, `arbitrateParkedRender` evaluates it
(LLM included) and types the verdict into the prompt on screen.

**After:** at hook time, `AutoApproveGate` first asks ONLY the
deterministic pre-LLM layers (`AutoApproveService.evaluateDeterministic`:
deny checked first, then `allow`, then `approve_groups` — the exact
matcher calls, in the exact order, `evaluate()` itself runs before ever
considering the LLM). A deterministic **approve** answers the hook
`allow` directly: no park, no PTY render, no LLM call, no GPU queue.
Everything else — no deterministic verdict, or a **deny** match — still
parks + passthroughs exactly as before. The LLM is still never invoked
at hook time for a subagent request, on any path; ADR 0004's core claim
is unchanged, only narrowed.

A subagent-tagged deny is deliberately NOT turned into a hook-time deny:
unlike a main-context deny (which carries `buildDenyMessage` back to
Claude), a subagent's config-level deny has no human-visible channel
until a render happens, so it stays on the render-time PTY-arbiter path.

`onSubagentPassthrough` (the `subagent_alert` observation cue) fires on
BOTH paths with the same input, so subagent_alert visibility is
unchanged — a `curl` call an approve group covers still gets the same
audit trail a parked one did.

## Why ADR 0004 needed amending

ADR 0004's original rationale for parking unconditionally was GPU cost
per background call and unknowable render state — both properties of the
LLM specifically. Neither applies to a 0ms, config-authorized match: the
user already decided it when they wrote the `allow` list or picked a
`level` (ADR 0015: config is a non-text authorization channel that may
decide outright; ADR 0016: groups are checkable policy, not prose).
Amended ADR 0004 in the same change (ADR 0011: docs must state what
ships), plus the ADR index line and the AGENTS.md "Subagent permissions:
the PTY is the arbiter" section.

## Evidence (issue #1024)

Live transit session, 2026-08-08 (`c77ba8f8`): 69 subagent
PermissionRequests — ~40 Bash calls from one review agent (`review-479`)
in 12 minutes, plus 11 WebFetch calls from research agents in 4 minutes.
Every parked render WAS evaluated (no "not evaluated" pushes), but
verdicts routinely lost the race against prompt churn: repeated `Parked
render <id> is no longer the prompt on screen; NOT typing "1"` — the LLM
approved, the inject was refused, and the outcome decayed into a user
escalation. The GPU is also serialized, so a burst of parked renders
queued their evals behind each other, pushing unrelated main-context
evals past `push_hold_timeout`. None of this was an accuracy problem —
the review agent's Bash calls were `read-only`-group reads and the
WebFetch calls were plain `allow` tool-name matches the config had
already decided.

## Design notes

- `AutoApproveService.evaluateDeterministic` is a new method extracted
  from `evaluate()`'s existing deny/allow/group checks (same matcher
  calls, same order, same return values) — `evaluate()` now calls it, so
  the two can never drift apart.
- `AutoApproveEvaluator.evaluateDeterministic` is OPTIONAL on the gate's
  consumed interface, so every existing minimal test double (`{evaluate,
  cancel}`) keeps compiling and behaving exactly as before — the gate
  treats a missing method as "no deterministic verdict," i.e. the
  pre-#1024 park-unconditionally behavior.
- The new hook-time-allow path deliberately does NOT call
  `markHandled()`. Every existing `markHandled(true)` call site (see
  `arbitrateParkedRender`) is preceded by its own
  `onEvalStart({isSubagent:true})`, which keeps the shared per-session
  `inFlight` eval counter (#560/#576) balanced. This path never opens
  that counter — firing only the "end" half risked decrementing a
  genuinely in-flight MAIN eval's count if one happened to be running
  concurrently, exactly the class of miscounted client-status cue
  ADR 0020 exists to catch. Both effects `markHandled` would otherwise
  produce are already no-ops for a subagent permission, so omitting the
  call costs nothing.

## Testing

Constructed the real `AutoApproveService`/`AutoApproveGate` throughout —
no mocks, per ADR 0014.

- `bun run typecheck` — clean.
- `bunx biome check packages/daemon/src/auto-approve/ packages/daemon/tests/auto-approve/` — clean.
- `SKIP_LLM_TESTS=1 bun test packages/daemon/tests/auto-approve/auto-approve-gate.test.ts packages/daemon/tests/auto-approve/auto-approve-service.test.ts packages/daemon/tests/auto-approve/subagent-alert.test.ts` — 304 pass, 8 skip (LLM-gated), 0 fail.
- `SKIP_LLM_TESTS=1 bun test packages/daemon/tests/auto-approve/` (full directory) — 1724 pass, 71 skip (engine/LLM-gated), 0 fail.
- `SKIP_LLM_TESTS=1 bun test packages/daemon/tests/cli/session-phases/hook-bridge-setup.test.ts packages/daemon/tests/api/question-identity.test.ts` (other structural consumers of `AutoApproveEvaluator`) — 106 pass, 0 fail.

New tests added (both files, no mocks):
- `evaluateDeterministic`: allow-pattern approve, approve_groups approve,
  deny-pattern deny-covered, deny_groups deny-covered, deny-wins-over-
  allow, no-match null, and two no-drift checks against `evaluate()`'s
  own output for the same inputs.
- Gate: approve_groups-covered subagent command answers `allow` with no
  park and the LLM never called; user-`allow`-covered tool name (WebFetch)
  answers `allow`; the `onSubagentPassthrough` cue still fires on a
  deterministic approve; a deny-covered match still parks (deny wins, no
  hook-time allow); no deterministic verdict still parks exactly as
  before; a test double omitting `evaluateDeterministic` still parks
  exactly as before (backward-compat proof).

All pre-existing subagent tests in `auto-approve-gate.test.ts` (park
behavior, #710 tracker-leak recovery, #522 escalate_model exclusion, the
`#807: a subagent-tagged permission is NEVER evaluated` LLM-call-count
assertion) pass unmodified.

Closes #1024.