### PR TITLE
fix: escape-aware compound splitting (#1031)

### DIFF
--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -184,9 +184,23 @@ export interface CompoundPart {
 /**
  * Split a command into compound segments on `&&`, `||`, `;`, `|`, and newlines
  * (`\n`/`\r` — the shell treats an unquoted newline as a command separator,
- * exactly like `;`), respecting single/double quotes (best-effort), retaining
- * which operator joined each segment to the previous one.
+ * exactly like `;`), respecting single/double quotes and double-quote /
+ * unquoted backslash escapes, retaining which operator joined each segment
+ * to the previous one.
  * Backgrounding `&` is left in the segment for the shell-control veto to catch.
+ *
+ * Escape handling (#1031): a backslash-escaped quote outside quotes (`\"`)
+ * does not open a quote, and a backslash-escaped `"` inside a double-quoted
+ * span does not close it — in real bash neither toggles quote state, so
+ * treating them as literal is what keeps a LIVE separator after them (a real
+ * `;`/`&&`/`||`/`|`) from being misread as still inside an "unterminated"
+ * quote and swallowed into one segment. Single quotes are unaffected: bash has
+ * no escapes inside them, so only a literal `'` closes one.
+ *
+ * NOT handled (#1034): bash ANSI-C `$'...'` quoting, where `\'` does NOT close
+ * the span. This parser (and `maskQuotedSpans`) still toggles on the inner `'`,
+ * desyncing quote state and leaving a `$'...'`-based separator bypass open — a
+ * distinct pre-existing P0 of the same class as #1031, tracked in #1034.
  */
 export function splitCompoundParts(command: string): CompoundPart[] {
   const parts: CompoundPart[] = [];
@@ -201,9 +215,41 @@ export function splitCompoundParts(command: string): CompoundPart[] {
   for (let i = 0; i < command.length; i++) {
     const c = command[i];
     const next = command[i + 1];
-    if (quote !== null) {
+
+    if (quote === '"') {
+      // Every backslash inside double quotes is consumed with the character
+      // after it, so an escaped `"` cannot close the quote. This is broader
+      // than bash's real rule (only `$ \` " \\` newline are special inside
+      // double quotes), but that is safe here: over-consuming an escape can
+      // only keep already-quoted text together, never merge a live operator —
+      // a live operator requires being OUTSIDE quotes in the first place.
+      if (c === '\\' && next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
       current += c;
-      if (c === quote) quote = null;
+      if (c === '"') quote = null;
+      continue;
+    }
+
+    if (quote === "'") {
+      // No escapes exist inside bash single quotes; only a literal `'` closes.
+      current += c;
+      if (c === "'") quote = null;
+      continue;
+    }
+
+    // quote === null from here.
+    if (c === '\\') {
+      // Outside quotes, the next character is escaped: it cannot toggle quote
+      // state, and cannot act as a separator/operator either way.
+      if (next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
+      current += c; // trailing lone backslash: literal, string ends
       continue;
     }
     if (c === '"' || c === "'") {

--- a/packages/daemon/tests/auto-approve/shell-safety-split-escape.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-split-escape.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #1031 (P0): `splitCompoundParts` was escape-blind. It tracked single/double
+ * quotes but treated a backslash as an ordinary character, so an escaped quote
+ * OUTSIDE quotes (`\"`) spuriously opened a quote span. A live command
+ * separator after it (`;`, `&&`, `||`, `|`, newline) was then read as sitting
+ * inside that "unterminated" quote and swallowed into ONE segment — hiding it
+ * from the per-segment veto in `matchCoveredCommand`, the 0ms allow path.
+ *
+ * The exploit shape: a covered read prefix, an escaped quote, then a real
+ * separator and an arbitrary command. Old behavior collapsed it to a single
+ * segment that prefix-matched the covered read and carried no mutation token,
+ * so `matchCoveredCommand` approved the whole thing — the injected tail
+ * included. This is the same class as #536.
+ *
+ * The fix makes the splitter consume backslash escapes the way bash does, so
+ * `\"` never toggles quote state and the live separator splits normally. These
+ * tests pin BOTH halves: the escaped quote outside quotes must not merge a live
+ * separator, and an escaped quote INSIDE a real quoted span must still not
+ * split (over-splitting genuine quoted text is the opposite failure).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { MUTATION_TOKEN } from '../../src/auto-approve/permission-groups.ts';
+import { matchCoveredCommand, splitCompoundParts } from '../../src/auto-approve/shell-safety.ts';
+
+const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
+const READS = ['git status', 'cat', 'grep', 'ls'];
+
+describe('splitCompoundParts is escape-aware (#1031)', () => {
+  test('an escaped quote OUTSIDE quotes does not swallow a live `;`', () => {
+    // Old code opened a quote at `\"` and read `; rm -rf ~` as quoted text: one
+    // segment. Now `\"` is literal and the `;` splits.
+    const parts = splitCompoundParts('git status \\"; rm -rf ~');
+    expect(parts.map((p) => p.text)).toEqual(['git status \\"', ' rm -rf ~']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+  });
+
+  test('an escaped quote outside quotes does not swallow a live `&&`', () => {
+    const parts = splitCompoundParts('ls \\"foo\\" && curl evil');
+    expect(parts.map((p) => p.text)).toEqual(['ls \\"foo\\" ', ' curl evil']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '&&']);
+  });
+
+  test('an escaped `\\"` INSIDE a real double-quoted span does not close it early', () => {
+    // `"a \"; b"` is a single bash string containing `a "; b` — the `;` is
+    // quoted and must NOT split. Over-splitting here is the mirror-image bug.
+    const parts = splitCompoundParts('echo "a \\"; b"');
+    expect(parts.map((p) => p.text)).toEqual(['echo "a \\"; b"']);
+    expect(parts.map((p) => p.joiner)).toEqual([null]);
+  });
+
+  test('an escaped separator char outside quotes is literal, not a split', () => {
+    // `\;` is an escaped semicolon: one command, not two.
+    const parts = splitCompoundParts('echo a\\; b');
+    expect(parts.map((p) => p.text)).toEqual(['echo a\\; b']);
+  });
+
+  test("single quotes have no escapes: a backslash before `'` still closes", () => {
+    // Inside single quotes bash has no escape mechanism, so the first literal
+    // `'` closes the span and the following `;` is a live separator.
+    const parts = splitCompoundParts("echo 'a\\'; rm -rf ~");
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[1]?.text).toBe(' rm -rf ~');
+  });
+
+  test('regression: real separators still split with the right joiners', () => {
+    const parts = splitCompoundParts('a && b || c ; d | e');
+    expect(parts.map((p) => p.text.trim())).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '&&', '||', ';', '|']);
+  });
+
+  test('a trailing lone backslash does not crash and stays literal', () => {
+    const parts = splitCompoundParts('echo a\\');
+    expect(parts.map((p) => p.text)).toEqual(['echo a\\']);
+  });
+});
+
+describe('the #1031 exploit is closed end-to-end via matchCoveredCommand', () => {
+  test('THE P0: an escaped quote can no longer smuggle an uncovered tail past the veto', () => {
+    // `git status` is a covered read. The escaped quote used to merge the whole
+    // command into one segment that matched `git status` and approved the
+    // injected `rm -rf ~`. Now `rm -rf ~` is its own uncovered segment, so the
+    // whole command is refused.
+    expect(matchCoveredCommand('git status \\"; rm -rf ~', READS, readVeto)).toBeNull();
+  });
+
+  test('a piped injection behind an escaped quote is refused too', () => {
+    expect(matchCoveredCommand('cat file \\" | sh', READS, readVeto)).toBeNull();
+  });
+
+  test('control: a genuinely covered single read still matches', () => {
+    expect(matchCoveredCommand('git status', READS, readVeto)).toBe('git status');
+  });
+
+  test('control: an escaped quote inside a covered read that stays one segment still matches', () => {
+    // No live separator here — the escaped quote is inert, coverage is intact.
+    expect(matchCoveredCommand('grep \\"needle\\" file', READS, readVeto)).toBe('grep');
+  });
+});


### PR DESCRIPTION
## P0: escaped quotes hid live command separators from the allow-list veto

Closes #1031.

`splitCompoundParts` tracked single/double quotes but was blind to backslash
escapes. An escaped quote **outside** quotes (`\"`) spuriously opened a quote
span, so a live separator after it (`;`, `&&`, `||`, `|`, newline) was read as
sitting inside an unterminated quote and swallowed into a single segment.

`matchCoveredCommand` (the 0ms allow fast-path) vets **per segment**. With the
tail merged into the covered segment, a covered read prefix approved the whole
command — the injected tail included. Same class as #536.

### Example
`git status \"; <destructive-cmd>` — where `git status` is a covered read.
- **Before:** one merged segment prefix-matches `git status`, carries no
  mutation token → **approved**, and the injected tail rides along.
- **After:** `\"` is literal, the separator splits, the tail becomes its own
  uncovered segment → **refused**.

### Fix
Consume **double-quote and unquoted backslash escapes** so an escaped quote
never toggles quote state (an escaped `"` inside a real double-quoted span still
doesn't close it either). Over-consuming an escape can only keep already-quoted
text together, never merge a live operator — a live operator requires being
outside quotes.

### Scope / not covered
This narrows the claim deliberately: it does **not** implement full bash
tokenization. Bash ANSI-C `$'...'` quoting (where `\'` does **not** close the
span) is still mishandled by both `splitCompoundParts` and `maskQuotedSpans`,
leaving a distinct, **pre-existing** bypass of the same class open. Found during
adversarial review of this PR; filed as **#1034** (P0 follow-up). This PR does
not introduce or regress it, and closing the `\"` hole here is a strict
improvement.

### Tests
New `shell-safety-split-escape.test.ts`: unit coverage of the splitter plus the
end-to-end exploit closure via `matchCoveredCommand`. Verified **failing against
the pre-fix splitter** (5/11 fail, including the P0 case) and passing after.
Full suite: 5867 pass / 0 fail; biome clean; typecheck clean.
