### PR TITLE
fix: escape-aware ANSI-C $'...' quoting (#1034)

### DIFF
--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -197,16 +197,18 @@ export interface CompoundPart {
  * quote and swallowed into one segment. Single quotes are unaffected: bash has
  * no escapes inside them, so only a literal `'` closes one.
  *
- * NOT handled (#1034): bash ANSI-C `$'...'` quoting, where `\'` does NOT close
- * the span. This parser (and `maskQuotedSpans`) still toggles on the inner `'`,
- * desyncing quote state and leaving a `$'...'`-based separator bypass open — a
- * distinct pre-existing P0 of the same class as #1031, tracked in #1034.
+ * ANSI-C handling (#1034): bash `$'...'` applies C-style escapes inside, so
+ * `\'` does NOT close the span — only an unescaped `'` does. This parser (and
+ * `maskQuotedSpans`) recognizes `$'...'` and consumes those escapes, so an
+ * escaped `'` cannot close early and desync quote state, which would otherwise
+ * leave a live separator after the real closing quote swallowed into one
+ * segment (the bypass #1033 left open, same class as #1031).
  */
 export function splitCompoundParts(command: string): CompoundPart[] {
   const parts: CompoundPart[] = [];
   let current = '';
   let joiner: CompoundJoiner = null;
-  let quote: '"' | "'" | null = null;
+  let quote: '"' | "'" | "$'" | null = null;
   const push = (nextJoiner: CompoundJoiner) => {
     parts.push({ text: current, joiner });
     current = '';
@@ -240,6 +242,22 @@ export function splitCompoundParts(command: string): CompoundPart[] {
       continue;
     }
 
+    if (quote === "$'") {
+      // ANSI-C quoting (`$'...'`): bash applies C-style escapes inside, so a
+      // backslash-escaped `'` does NOT close the span — only an UNescaped `'`
+      // does (#1034). Consuming the backslash with its next char is what keeps
+      // an escaped `'` from ending the span early and leaving a LIVE separator
+      // after the real closing quote misread as still inside it.
+      if (c === '\\' && next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
+      current += c;
+      if (c === "'") quote = null;
+      continue;
+    }
+
     // quote === null from here.
     if (c === '\\') {
       // Outside quotes, the next character is escaped: it cannot toggle quote
@@ -250,6 +268,17 @@ export function splitCompoundParts(command: string): CompoundPart[] {
         continue;
       }
       current += c; // trailing lone backslash: literal, string ends
+      continue;
+    }
+    if (c === '$' && next === "'") {
+      // ANSI-C `$'...'` opens here, recognized explicitly: unlike a plain
+      // single quote it honours backslash escapes inside, so parsing it as a
+      // plain `'...'` span desyncs from bash and can swallow a live separator
+      // that actually sits OUTSIDE the quotes (#1034). `$"..."` needs no such
+      // case — its `"` opens a real double-quote span either way.
+      quote = "$'";
+      current += c + next;
+      i++;
       continue;
     }
     if (c === '"' || c === "'") {
@@ -431,6 +460,28 @@ export function maskQuotedSpans(segment: string): string {
       out[i] = '_';
       out[i + 1] = '_';
       i += 2;
+      continue;
+    }
+
+    if (c === '$' && segment[i + 1] === "'") {
+      // ANSI-C `$'...'`: bash honours C-style escapes inside, so `\'` does NOT
+      // close — only an UNescaped `'` does (#1034). A plain-single-quote scan
+      // ends at the escaped `'` and desyncs, corrupting the mask here and (in
+      // `splitCompoundParts`) hiding a live separator. The whole span is a
+      // string literal, so mask it all — masking only removes proven-literal
+      // text, never a live operator.
+      const start = i;
+      let j = i + 2;
+      while (j < n && segment[j] !== "'") {
+        if (segment[j] === '\\' && segment[j + 1] !== undefined) {
+          j += 2;
+          continue;
+        }
+        j++;
+      }
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = '_';
+      i = j + 1;
       continue;
     }
 

--- a/packages/daemon/tests/auto-approve/shell-safety-ansic-quoting.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-ansic-quoting.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #1034 (P0): bash ANSI-C `$'...'` quoting desynced `splitCompoundParts` and
+ * `maskQuotedSpans`. Both treated `$'...'` as a plain single-quoted span, but
+ * bash applies C-style escapes INSIDE `$'...'`, so `\'` does NOT close it —
+ * only an unescaped `'` does. `$'\''` is the standard idiom for a literal
+ * single quote; after it bash is OUTSIDE quotes.
+ *
+ * The old parsers toggled quote state on the escaped `'`, ending up INSIDE a
+ * wrongly-opened span. A live separator after the real closing quote
+ * (`git status $'\'' ; <cmd>`) was then swallowed into one segment, and the 0ms
+ * allow fast-path (`matchCoveredCommand`) approved the covered read with the
+ * injected tail riding along — the same class as #536 / #1031.
+ *
+ * Follow-up to #1033, which closed the `\"` variant but explicitly did not
+ * handle `$'...'`. These tests pin the splitter, the mask, and the end-to-end
+ * closure.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { MUTATION_TOKEN } from '../../src/auto-approve/permission-groups.ts';
+import {
+  hasShellControl,
+  maskQuotedSpans,
+  matchCoveredCommand,
+  splitCompoundParts,
+} from '../../src/auto-approve/shell-safety.ts';
+
+const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
+const READS = ['git status', 'cat', 'grep', 'ls'];
+
+describe("splitCompoundParts handles ANSI-C $'...' quoting (#1034)", () => {
+  test("an escaped `'` inside $'...' no longer swallows a live `;`", () => {
+    // `$'\''` is a literal single quote; after it we are OUTSIDE quotes, so the
+    // `;` is a real separator. Old code closed the span early on the escaped
+    // `'` and read `; touch ...` as still quoted: one segment.
+    const parts = splitCompoundParts("git status $'\\'' ; touch /tmp/x");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[1]?.text.trim()).toBe('touch /tmp/x');
+  });
+
+  test("an escaped `'` inside $'...' no longer swallows a live `|`", () => {
+    const parts = splitCompoundParts("cat file $'\\'' | sh");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '|']);
+    expect(parts[1]?.text.trim()).toBe('sh');
+  });
+
+  test("a benign $'...' with no escaped quote still splits normally after it", () => {
+    const parts = splitCompoundParts("echo $'foo' ; bar");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[0]?.text).toContain("$'foo'");
+  });
+
+  test("an escaped backslash inside $'...' is consumed; balanced span is one segment", () => {
+    // `$'a\\b'` — the `\\` is an escaped backslash, the closing `'` still
+    // closes, and there is no separator, so it stays a single segment.
+    const parts = splitCompoundParts("echo $'a\\\\b'");
+    expect(parts.length).toBe(1);
+  });
+});
+
+describe("maskQuotedSpans + hasShellControl handle $'...' (#1034)", () => {
+  test("$'...' prose with >, & inside does not veto (contents are literal)", () => {
+    expect(maskQuotedSpans("echo $'a > b & c'")).toBe('echo ____________');
+    expect(hasShellControl("echo $'a > b & c'")).toBe(false);
+  });
+
+  test("MUST STILL VETO: real command substitution after a $'...' span", () => {
+    // The `$'x'` is inert, but the trailing `$(...)` is real control and must
+    // still veto the whole segment.
+    expect(hasShellControl("echo $'x' $(touch y)")).toBe(true);
+  });
+});
+
+describe('the #1034 exploit is closed end-to-end via matchCoveredCommand', () => {
+  test("THE P0: $'\\'' can no longer smuggle an uncovered tail past the veto", () => {
+    expect(matchCoveredCommand("git status $'\\'' ; touch /tmp/x", READS, readVeto)).toBeNull();
+  });
+
+  test('a piped injection behind the ANSI-C escape is refused too', () => {
+    expect(matchCoveredCommand("cat file $'\\'' | sh", READS, readVeto)).toBeNull();
+  });
+
+  test("control: a covered read with a benign $'...' arg still matches", () => {
+    expect(matchCoveredCommand("grep $'foo' file", READS, readVeto)).toBe('grep');
+  });
+});


### PR DESCRIPTION
## P0: ANSI-C `$'...'` quoting bypassed the allow-list veto

Closes #1034. Follow-up to #1033 (which closed the `\"` variant and explicitly
flagged this one).

`splitCompoundParts` and `maskQuotedSpans` treated bash ANSI-C `$'...'` as a
plain single-quoted span. But bash applies C-style escapes **inside** `$'...'`,
so `\'` does **not** close it — only an unescaped `'` does. `$'\''` is the
standard idiom for a literal single quote, after which bash is **outside**
quotes.

### The bypass
`git status $'\'' ; <cmd>` — `git status` is a covered read.
- **Before:** the parser closed the span on the escaped `'`, ending up inside a
  wrongly-opened quote, so the `;` was read as quoted and the whole thing
  collapsed to one segment that prefix-matched `git status` → **approved**, with
  `<cmd>` riding along. `hasShellControl` also missed it (`maskQuotedSpans`
  failed closed and found no `$(`/backtick/`&`).
- **After:** `\'` is consumed as an escape, the real `'` closes the span, the
  `;` splits, and `<cmd>` becomes its own uncovered segment → **refused**.

Same class as #536 / #1031.

### Fix
Recognize `$'...'` explicitly in both parsers and consume backslash escapes
inside it so an escaped `'` never closes early. Mirrors the ANSI-C handling
already in `shellWords`. (`$"..."` needs no special case — its `"` opens a real
double-quote span either way.)

### Tests
New `shell-safety-ansic-quoting.test.ts`: the splitter, `maskQuotedSpans` /
`hasShellControl` (real control after a `$'...'` still vetoes; quoted prose does
not), and the end-to-end closure via `matchCoveredCommand`. Verified **failing
against the pre-fix code** (5/9 fail, including the P0 case) and passing after.
biome + typecheck clean; full suite green.
