### PR TITLE
Release 0.7.5

### DIFF
--- a/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
+++ b/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
@@ -35,8 +35,117 @@ status-churn can wipe a main-eval buffered prompt (#769).
 - **Suppress all subagent escalations:** silent denials; violates "my agent
   needs me. Yes or No."
 
+## Amended 2026-08-08: a deterministic config approve answers at hook time; the LLM still never runs there
+
+**Status of this amendment:** accepted. It NARROWS the original rule rather
+than reversing it — the LLM is still never consulted at hook time for a
+subagent-tagged request, on any authorization. What changes is which
+subagent requests reach the park path at all.
+
+### Why the original rule could not stand unchanged
+
+A live transit session (2026-08-08, `c77ba8f8`) fired 69 subagent
+PermissionRequests: ~40 Bash calls from one review agent (`review-479`) in
+12 minutes, plus 11 WebFetch calls from research agents in 4 minutes. Every
+one of those parked, exactly per the pre-amendment rule, and every parked
+render WAS evaluated once it rendered — no "not evaluated" pushes. But the
+verdicts routinely lost the race against prompt churn: the log fills with
+`Parked render <id> is no longer the prompt on screen; NOT typing "1"` — the
+LLM approved, the inject was refused because a DIFFERENT prompt had already
+taken the screen, and the outcome degraded into a user escalation (and
+sometimes a dropped push). With several agents running in parallel, the main
+PTY prompt turns over faster than a GPU-backed eval round-trip can complete.
+The GPU is also serialized (one model, one queue): a burst of parked
+renders queues its evals behind each other, which is what pushed several
+main-context evals past `push_hold_timeout` and produced "escalated
+directly to user" symptoms that had nothing to do with the main agent's own
+work.
+
+None of this was an LLM-accuracy problem. The review agent's ~40 Bash calls
+were `read-only`-group reads; the WebFetch calls were plain user `allow`
+tool-name matches. The config had already decided every one of them before
+the park-unconditionally rule ever asked the model anything — the cost was
+purely the render-time race, paid on traffic the daemon could have settled
+at 0ms and never rendered at all.
+
+### What licensed the change
+
+The original ADR's own rationale was **GPU cost per background call and
+unknowable render state** — "Claude blocks on this hook response, so at
+decision time we cannot know whether the prompt will ever render on the
+main PTY... evaluating them all meant one GPU-backed LLM call per background
+tool call." Both halves of that rationale are properties of the LLM
+specifically: a 0ms, config-authorized match has no GPU cost and needs no
+render-state knowledge, because it does not depend on what the user would
+have decided — the user already decided it, in `config.toml`, when they
+wrote the `allow` list or picked a `level`. ADR 0015's amendment already
+established that config-sourced authorization (a human's own `config.toml`)
+is a non-text channel that may decide outright, unlike text-derived
+authority; ADR 0016 established that the permissive half of policy is
+level-gated group membership, checkable without a model. Both apply
+directly to `approve_groups`/`allow` matches on a subagent request — nothing
+about being subagent-tagged changes what those matches already mean for a
+main-context request evaluated by the identical code path.
+
+### The amended rule
+
+At hook time, for a subagent-tagged (`agent_id`-present) PermissionRequest,
+run ONLY `AutoApproveService.evaluateDeterministic` — the exact deny/allow/
+approve_groups matcher calls, in the exact order, `evaluate()` itself runs
+before ever considering the LLM (extracted so the two share one
+implementation and cannot drift, per ADR 0015/0017's shared-list caution):
+
+- **Deterministic approve** (no deny match, and `allow` or `approve_groups`
+  covers the call): the gate answers the hook `{behavior: 'allow'}`
+  directly. No park, no PTY render, no LLM call, no queue wait. The
+  `onSubagentPassthrough` observation cue still fires — unchanged from the
+  park path — so `subagent_alert` visibility does not depend on how the hook
+  was answered.
+- **Deny-covered, or no deterministic verdict**: parks + passes through
+  exactly as the pre-amendment rule did. A hook-time deny is still not
+  produced for a subagent match: unlike a main-context deny (which can carry
+  `buildDenyMessage` back to Claude), a subagent's config-level deny has no
+  human-visible channel until a render happens, so it stays on the
+  render-time PTY-arbiter path this ADR already governs.
+
+**The LLM is still never invoked at hook time for a subagent request, on
+any path.** That was the original decision's core claim and it is
+untouched: only a 0ms, config-authorized match — the same match a
+main-context request already gets for free — can decide here. Everything
+the original ADR said about the LLM (GPU cost, unknowable render state,
+phantom-question risk) still governs every subagent request the config does
+not deterministically approve.
+
+### What this does NOT change
+
+- Parked records, the eval-in-flight buffer window, and `arbitrateParkedRender`
+  (#814) are untouched for every request that still parks.
+- A model-produced verdict, for a subagent or otherwise, still only ever
+  happens at render time (`arbitrateParkedRender`) or in the main-context
+  synchronous path — never at subagent hook time.
+- The gate does not call `markHandled()` for a deterministic hook-time
+  approve. Every existing `markHandled(true)` call site pairs with its own
+  prior `onEvalStart({isSubagent:true})` (see `arbitrateParkedRender`),
+  which is what keeps the shared per-session `inFlight` eval counter
+  (#560/#576) balanced; this path never opens that counter, so firing only
+  the "end" half risked decrementing a genuinely in-flight MAIN eval's count
+  — the class of miscounted cue [ADR 0020](0020-client-status-cue-totality.md)
+  exists to catch. Both effects `markHandled` would otherwise produce are
+  already no-ops for a subagent permission (`onAutoApproveHandled` returns
+  early on `isSubagent`; the client broadcast is skipped the same way), so
+  omitting the call costs nothing.
+
 ## Receipts
 
 Issues #751, #763, #767, #756; PRs #762, #764, #768 (0.6.19). Detail
 formerly in `.context/subagent-aa-routing.md` (pruned 2026-07-10; the live
 proposal is on #756).
+
+**2026-08-08 amendment:** issue #1024 (evidence: transit session `c77ba8f8`,
+69 subagent PermissionRequests, ~40 Bash/12min from `review-479`, 11
+WebFetch/4min, all parked renders evaluated but routinely losing the
+prompt-lifetime race). `packages/daemon/src/auto-approve/auto-approve-service.ts`
+— `evaluateDeterministic`. `packages/daemon/src/auto-approve/auto-approve-gate.ts`
+— `resolvePermission`'s subagent branch. ADR 0015 (config as a non-text
+authorization channel), ADR 0016 (groups as checkable policy), ADR 0020
+(the `markHandled` omission reasoning above).

--- a/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
+++ b/.context/decisions/0004-pty-as-arbiter-subagent-questions.md
@@ -134,6 +134,17 @@ not deterministically approve.
   already no-ops for a subagent permission (`onAutoApproveHandled` returns
   early on `isSubagent`; the client broadcast is skipped the same way), so
   omitting the call costs nothing.
+- **A bare tool-name `allow` entry (`allow = ["Write"]`, `["Edit"]`) now
+  grants a subagent silent, hook-time, unrendered approval to sensitive
+  destinations a curated group would veto.** `matchAllowPattern` applies no
+  destination check by design (ADR 0010: "a user allow entry may legitimately
+  be a write"), unlike `approve_groups`, whose write groups carry
+  `vetoSensitiveToolPath`. This was already true for main-context requests;
+  #1024 is the first time it applies to subagent traffic with zero chance of
+  a human ever seeing the prompt. Not a defect in this change — it faithfully
+  extends existing allow semantics, and the config validator already warns on
+  tool-name-shaped allow entries — but the blast radius of a loose config is
+  now wider and quieter. Tracked as #1032.
 
 ## Receipts
 

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -19,7 +19,7 @@ add a row below.
 | [0001](0001-transcript-path-source-of-truth.md) | Transcript path is the session source of truth |
 | [0002](0002-model-b-hold-the-hook-notifications.md) | Hold-the-hook notification model |
 | [0003](0003-synchronous-permission-decisions.md) | Synchronous permission decisions |
-| [0004](0004-pty-as-arbiter-subagent-questions.md) | PTY is the arbiter for subagent questions |
+| [0004](0004-pty-as-arbiter-subagent-questions.md) | PTY is the arbiter for subagent questions — amended 2026-08-08: a config-deterministic approve answers at hook time, the LLM still never runs there |
 | [0005](0005-hub-and-attach-only-clients.md) | Hub mode and attach-only clients |
 | [0006](0006-cc-ref-disavowed.md) | `cc-ref` is not ground truth for Claude Code |
 | [0007](0007-release-automation-and-pins.md) | Release automation and toolchain pins |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,20 +167,31 @@ See `.context/notification-and-session-flow.md` for the full flow diagram.
 - `HookEventBridge` — emits questions from `PermissionRequest` hooks; suppresses redundant notifications.
 - `OutputProcessor` — PTY-output parsing (fallback when hooks are unavailable).
 
-**Subagent permissions: the PTY is the arbiter** (#756 policy, #807 + #814):
+**Subagent permissions: the PTY is the arbiter** (#756 policy, #807 + #814;
+amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-subagent-questions.md)):
 
-- An `agent_id`-tagged `PermissionRequest` is NEVER evaluated at hook time. `AutoApproveGate`
-  parks it (`parkForPTY` → `QuestionPresenceTracker.parkAwaitingPTY`) and answers the hook
-  `passthrough` immediately. Claude blocks on that response, so at hook time nothing can know
-  whether the prompt will ever render — and most never do (16 hooks → 2 renders in a live
-  0.6.22 session).
-- If the prompt DOES render, `arbitrateParkedRender` evaluates it then: `approve`/`deny`/`pick`
-  are typed into the prompt on screen (never a persisting "always" option), and only an
-  `escalate` verdict pushes a card. Every failure direction escalates; nothing is ever
+- An `agent_id`-tagged `PermissionRequest` NEVER reaches the LLM at hook time — that part of
+  the original policy is unchanged. `AutoApproveGate` first asks ONLY the deterministic
+  pre-LLM layers (`AutoApproveService.evaluateDeterministic`: deny — list + groups — checked
+  first, then user `allow`, then the level's `approve_groups`; the exact matcher calls
+  `evaluate()` itself runs, shared so the two can never drift). A deterministic **approve**
+  (no deny match) answers the hook `{behavior:'allow'}` immediately — no park, no render, no
+  LLM, no GPU queue. Everything else — no deterministic verdict, or a **deny** match — parks
+  it (`parkForPTY` → `QuestionPresenceTracker.parkAwaitingPTY`) and answers the hook
+  `passthrough`, exactly as before #1024. A subagent's config-level deny is never turned into
+  a hook-time deny: it has no human-visible channel until a render happens, so it stays on the
+  render-time path below. Claude blocks on the hook response, so for anything that parks,
+  nothing can know whether the prompt will ever render — and most never do (16 hooks → 2
+  renders in a live 0.6.22 session).
+- If the prompt DOES render, `arbitrateParkedRender` evaluates it then (LLM included): `approve`/
+  `deny`/`pick` are typed into the prompt on screen (never a persisting "always" option), and
+  only an `escalate` verdict pushes a card. Every failure direction escalates; nothing is ever
   auto-answered by guess.
-- An allowlist-covered subagent command never renders and so is never evaluated; the
-  `subagent_alert` informational push (`auto-approve/subagent-alert.ts`) is the visibility
-  path for those, deliberately alerting rather than blocking.
+- An allowlist-covered subagent command — whether answered at hook time (#1024) or absorbed
+  silently after parking — never surfaces to a human by itself; the `subagent_alert`
+  informational push (`auto-approve/subagent-alert.ts`) is the visibility path for both cases,
+  fired via the same `onSubagentPassthrough` cue regardless of which path answered the hook,
+  deliberately alerting rather than blocking.
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,11 @@ amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-
   informational push (`auto-approve/subagent-alert.ts`) is the visibility path for both cases,
   fired via the same `onSubagentPassthrough` cue regardless of which path answered the hook,
   deliberately alerting rather than blocking.
+- A bare tool-name `allow` entry (`allow = ["Write"]`, `["Edit"]`) carries no destination veto
+  by design (ADR 0010) and, since #1024, now grants a subagent silent hook-time write access to
+  sensitive destinations a curated `approve_groups` write group would block. Already true for
+  main-context requests; #1024 is the first time it applies with zero chance of a human ever
+  seeing the prompt. Tracked as #1032 (not yet decided).
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,61 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-10
+
+Closes two P0 holes in the deterministic allow-list, both the same shape: a
+crafted quote desynced the shell splitter so a live command separator was read
+as quoted text, collapsing an injected command into a segment that prefix-
+matched a covered read — and the 0ms allow path approved the whole thing,
+tail included. One rode an escaped quote (`\"`), the other bash ANSI-C `$'...'`
+quoting; the second was found while adversarially reviewing the fix for the
+first. Same class as #536. Alongside them: subagent permissions with a
+deterministic verdict are now answered at hook time instead of parking, quoted
+prose no longer trips the shell-control veto, and two smaller UX fixes.
+
+### Fixed
+- **P0: an escaped quote could smuggle a command past the allow-list** (#1031,
+  #1033). `splitCompoundParts` tracked quotes but not backslash escapes, so an
+  escaped quote outside quotes (`\"`) opened a spurious quote span and a live
+  separator after it (`;`/`&&`/`||`/`|`/newline) was swallowed into one segment
+  — hidden from the per-segment veto in `matchCoveredCommand`. A covered read
+  prefix then approved the injected tail. Now backslash escapes are consumed so
+  an escaped quote never toggles quote state.
+- **P0: bash ANSI-C `$'...'` quoting could smuggle a command past the
+  allow-list** (#1034, #1035). The same desync via `$'\''` (the idiom for a
+  literal single quote), mishandled by both `splitCompoundParts` and
+  `maskQuotedSpans`, which treated `$'...'` as a plain single-quoted span. Both
+  now recognize `$'...'` and apply C-style escapes inside it. Found during
+  adversarial review of #1033.
+- **Quoted prose no longer escalates** (#1023, #1028). `hasShellControl` was
+  quote-blind, so a `gh issue create --body "…"` that mentioned a backtick, a
+  `>` comparison, or an `&` tripped the veto and escalated even though `gh
+  issue` was allow-listed. It now runs against a quote-masked view that removes
+  only characters it can prove are literal, so real `$(…)`/backtick/redirect
+  still veto.
+- **Statusline reports the session's repo and branch, not the hub's** (#1025,
+  #1029). A hub-spawned session daemon inherited the hub's working directory; a
+  directory-less remote create-session request now lands the child in home
+  rather than wherever the hub was started, and the statusline reflects the
+  session's own directory.
+- **Terminal status cue no longer collides with the spinner** (#1026, #1027).
+
+### Changed
+- **Deterministic subagent permissions are answered at hook time** (#1024,
+  #1030; amends [ADR 0004]). An `agent_id`-tagged `PermissionRequest` whose
+  deterministic layers return a plain approve (no deny match) is answered
+  `{behavior:"allow"}` immediately — no park, no render, no LLM, no GPU queue.
+  Everything else (no deterministic verdict, or a deny match) still parks for
+  the PTY to arbitrate on render, exactly as before.
+
+### Known open
+- A bare tool-name `allow` entry (e.g. `["Write"]`) carries no destination veto,
+  so since #1024 it grants a subagent silent hook-time write access to
+  sensitive destinations a curated `approve_groups` write group would block
+  (#1032, not yet decided).
+
+[ADR 0004]: .context/decisions/0004-pty-as-arbiter-subagent-questions.md
+
 ## [0.7.4] - 2026-08-03
 
 Closes four security holes and rebuilds auto-approve around deterministic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.2",
+  "version": "0.7.5-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.3",
+  "version": "0.7.5-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.6",
+  "version": "0.7.5-dev.7",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.4",
+  "version": "0.7.5-dev.5",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.5",
+  "version": "0.7.5-dev.6",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.5-dev.1",
+  "version": "0.7.5-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.4",
+  "version": "0.7.5-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -297,6 +297,25 @@ export interface AutoApproveEvaluator {
    *  legitimate wait. Returns the number drained. Optional: a minimal
    *  evaluator under test may omit it. */
   drainScope?(scope: string, opts?: { mainOnly?: boolean }): number;
+  /**
+   * #1024: the deterministic, pre-LLM portion of `evaluate()` ONLY -- deny
+   * (list + groups) checked first, then `allow`, then `approve_groups`. No
+   * network, no model, no queue. Lets `resolvePermission`'s subagent branch
+   * answer a config-authorized request at hook time without ever reaching
+   * the LLM (ADR 0004 still forbids that unconditionally).
+   *
+   * Optional: a minimal test double that never exercises the hook-time
+   * subagent shortcut may omit it, in which case the gate treats every
+   * subagent-tagged event as having no deterministic verdict -- i.e. the
+   * pre-#1024 park-unconditionally behavior.
+   */
+  evaluateDeterministic?(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ):
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null;
 }
 
 export interface AutoApproveGateDeps {
@@ -1341,22 +1360,31 @@ export class AutoApproveGate {
    *   - approve -> 'allow', deny -> 'deny' (Claude proceeds; NO PTY inject).
    *   - escalate (main) -> escalateToUser + 'passthrough' (Claude renders the
    *     prompt; the user answers).
-   *   - ANY SUBAGENT-TAGGED event (`agent_id` present) -> park the rich
-   *     question in the presence tracker + 'passthrough' (#751 PTY-arbiter)
-   *     WITHOUT evaluating it (#807), and REGARDLESS of
-   *     `isInSubagentContext()` (the tracker only brackets synchronous
-   *     Task/Agent spawns, so team members and async/background subagents
-   *     always observe it false — the tag on the event itself is the truth).
-   *     Claude then runs its NORMAL permission flow: the session allowlist
-   *     may absorb the request silently, or the native prompt renders on the
-   *     main PTY — where `arbitrateParkedRender` (#814) evaluates it and
-   *     either answers it on screen or pushes the merged card (answers
-   *     inject; nothing is held). Replaces three prior behaviors:
-   *     silent default-deny (sync-Task shape, broke teammates with no trace),
-   *     hold+push-as-main (async/team shape, pushed cards for prompts the
-   *     user never saw asked), and evaluate-then-route (#751's shape, which
-   *     spent a GPU-backed LLM call per background tool call and silently
-   *     applied its allow/deny verdict to a prompt no human ever saw).
+   *   - a SUBAGENT-TAGGED event (`agent_id` present) the config's own
+   *     deterministic layers already APPROVE (deny checked first, then
+   *     `allow`, then `approve_groups` -- `service.evaluateDeterministic`,
+   *     #1024) -> answer the hook 'allow' directly. No park, no PTY render,
+   *     no LLM: ADR 0004 still holds, this is a 0ms config match, not a
+   *     model evaluation.
+   *   - every OTHER subagent-tagged event (config does not deterministically
+   *     approve it -- including one its `deny`/`deny_groups` covers, which
+   *     is NOT turned into a hook-time deny; see `evaluateDeterministic`'s
+   *     doc for why) -> park the rich question in the presence tracker +
+   *     'passthrough' (#751 PTY-arbiter) WITHOUT ever running the LLM at
+   *     hook time (#807), and REGARDLESS of `isInSubagentContext()` (the
+   *     tracker only brackets synchronous Task/Agent spawns, so team members
+   *     and async/background subagents always observe it false — the tag on
+   *     the event itself is the truth). Claude then runs its NORMAL
+   *     permission flow: the session allowlist may absorb the request
+   *     silently, or the native prompt renders on the main PTY — where
+   *     `arbitrateParkedRender` (#814) evaluates it and either answers it on
+   *     screen or pushes the merged card (answers inject; nothing is held).
+   *     Replaces three prior behaviors: silent default-deny (sync-Task
+   *     shape, broke teammates with no trace), hold+push-as-main (async/team
+   *     shape, pushed cards for prompts the user never saw asked), and
+   *     evaluate-then-route (#751's shape, which spent a GPU-backed LLM call
+   *     per background tool call and silently applied its allow/deny verdict
+   *     to a prompt no human ever saw).
    *   - a MAIN-tagged event (no `agent_id`) with `isInSubagentContext()` true
    *     -> this is the #710 tracker-leak signature (a PostToolUse(Task/Agent)
    *     completion tagged with the spawned agent's own agent_id was dropped
@@ -1375,28 +1403,61 @@ export class AutoApproveGate {
     // subagent/team-member (`agent_id` present) or the main agent.
     const isSubagent = this.isSubagentEvent(input);
 
-    // #807: a subagent-tagged permission NEVER reaches the evaluator, with or
-    // without auto-approve configured.
+    // #807: a subagent-tagged permission NEVER reaches the LLM at hook time,
+    // with or without auto-approve configured.
     //
     // Claude blocks on this hook response, so at decision time we cannot know
     // whether the prompt will ever render on the main PTY — and empirically
     // most never do (a live 0.6.22 session logged 16 subagent
-    // PermissionRequests against 2 renders). Evaluating them all meant one
-    // GPU-backed LLM call per background tool call, and every approve/deny
-    // verdict was applied to a prompt no human ever saw and no card ever
-    // recorded.
+    // PermissionRequests against 2 renders). Evaluating them ALL with the LLM
+    // meant one GPU-backed call per background tool call, and every
+    // approve/deny verdict was applied to a prompt no human ever saw and no
+    // card ever recorded.
     //
-    // So park + passthrough unconditionally: Claude runs its own permission
-    // flow, and either its allowlist absorbs the request silently or the
-    // native prompt renders on the main PTY, where the parked record merges
-    // onto it and pushes a card. The PTY — not the hook — decides whether a
-    // human is asked, which is the arbiter policy #756 asked for.
+    // #1024 amendment: that reasoning applies to the LLM specifically (GPU
+    // cost + unknowable render state), not to a 0ms config-authorized match.
+    // So before parking, ask ONLY the deterministic layers -- deny, then
+    // allow, then approve_groups, the exact matcher calls `evaluate()` itself
+    // runs first (`evaluateDeterministic`, shared so the two can never drift).
+    // A deterministic APPROVE answers the hook directly, no park, no render,
+    // no LLM. Anything else -- no deterministic verdict, OR the config's own
+    // deny layer covers it -- parks + passthroughs exactly as before #1024:
+    // a hook-time deny still has no human-visible channel for a subagent (no
+    // render has happened yet to carry `buildDenyMessage`), so ADR 0004's
+    // PTY-arbiter policy still owns that case.
     //
-    // The evaluation itself is not skipped, only DEFERRED: if this prompt does
-    // render, `arbitrateParkedRender` (#814) evaluates it at that point and
-    // answers it by PTY inject, or pushes a card the phone can answer. That is
-    // the async route this hook response could never take.
+    // Either way, the evaluation itself is not skipped, only DEFERRED for
+    // anything not deterministically approved: if the prompt renders,
+    // `arbitrateParkedRender` (#814) evaluates it at that point (LLM
+    // included) and answers it by PTY inject, or pushes a card the phone can
+    // answer. That is the async route this hook response could never take.
     if (isSubagent) {
+      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      if (deterministic?.decision === 'approve') {
+        log(
+          `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
+        );
+        // Observation only, the SAME cue the park path fires below:
+        // subagent_alert visibility must not depend on whether this call was
+        // ALSO deterministically approved -- e.g. a `curl` command an
+        // approve group covers still deserves the same audit trail a parked
+        // one gets (subagent-alert.ts matches on the raw input, not on how
+        // the hook was answered).
+        //
+        // Deliberately NOT `markHandled()`: every existing `markHandled(true)`
+        // call site (see `arbitrateParkedRender`) is preceded by its own
+        // `onEvalStart({isSubagent:true})`, which is what keeps the shared
+        // per-session `inFlight` eval count (#560/#576, `status-writer.ts`)
+        // balanced. This path never opens that counter -- firing only the
+        // "end" half here could decrement a genuinely in-flight MAIN eval's
+        // count if one happens to be running concurrently, which is exactly
+        // the kind of miscounted cue ADR 0020 exists to catch. Nothing else
+        // `markHandled` does applies here either: the tracker's
+        // `onAutoApproveHandled(isSubagent=true)` and the client status
+        // broadcast are both already no-ops for a subagent permission.
+        this.safeCueWithArg('onSubagentPassthrough', this.deps.onSubagentPassthrough, input);
+        return 'allow';
+      }
       log(
         `[Hooks] Subagent PermissionRequest passed through UNEVALUATED (PTY arbitrates): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name}`,
       );

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -35,7 +35,7 @@ import { type PrecedentReader, precedentMayAuthorize, signatureForOperation } fr
 import { buildPrompt } from './prompt-builder.ts';
 import { classifyRisk, formatMatrixContext } from './risk-bands.ts';
 import { enforceRiskCeiling } from './risk-ceiling.ts';
-import type { AutoApproveConfig, AutoApproveResult, MultiChoiceMode } from './types.ts';
+import type { AutoApproveConfig, AutoApproveResult, DenySource, MultiChoiceMode } from './types.ts';
 
 type BinaryDecision = 'approve' | 'deny' | 'escalate';
 const VALID_DECISIONS = new Set<BinaryDecision>(['approve', 'deny', 'escalate']);
@@ -627,6 +627,80 @@ export class AutoApproveService {
   }
 
   /**
+   * The deterministic, pre-LLM portion of `evaluate()` ONLY: the user's own
+   * `deny`/`deny_groups` (checked first, always win), then `allow`
+   * (`matchAllowPattern`), then the level's `approve_groups` (`matchGroups`)
+   * -- the exact matcher calls, in the exact order, `evaluate()` runs before
+   * it ever considers precedent or the LLM. A pure function of (toolName,
+   * toolInput) and this service's own config: no network, no model, no
+   * queue, no precedent, no design-question routing.
+   *
+   * #1024: extracted so a caller that must decide BEFORE the LLM may ever
+   * run (the gate's subagent-tagged hook-time path, which ADR 0004 forbids
+   * from reaching the LLM at all) can reuse these checks instead of
+   * re-implementing them -- the exact drift ADR 0015/0017 warn about for
+   * the shared catastrophic-pattern list, here avoided by construction:
+   * `evaluate()` below calls this and must never duplicate its checks
+   * inline.
+   *
+   * Returns:
+   *   - `{decision: 'approve', reasoning}` -- the user's own `allow` list or
+   *     `approve_groups` covers this call. Safe to act on directly; this is
+   *     the same 0ms verdict `evaluate()` returns for the identical match.
+   *   - `{decision: 'deny-covered', reasoning, denySource}` -- the user's own
+   *     `deny` list or `deny_groups` covers this call. NOT a verdict a
+   *     hook-time caller may act on by itself: `evaluate()` turns this into
+   *     a full `deny` `AutoApproveResult` because a MAIN-context deny has a
+   *     human-visible channel (`buildDenyMessage` tells Claude why). A
+   *     subagent-tagged hook-time caller has no such channel before the
+   *     prompt renders, so ADR 0004's PTY-arbiter policy requires this case
+   *     to fall through to the render-time path exactly like `null` below --
+   *     it exists as its own variant (rather than folding into `null`) only
+   *     so a caller that DOES want the reasoning (`evaluate()`) does not have
+   *     to re-run the deny matchers to get it.
+   *   - `null` -- nothing here decides it; the caller falls back to whatever
+   *     handles the undecided case (the LLM, for `evaluate()`; parking for
+   *     PTY arbitration, for the gate's subagent branch).
+   */
+  evaluateDeterministic(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+  ):
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null {
+    const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
+    if (denyMatch !== null) {
+      return {
+        decision: 'deny-covered',
+        reasoning: `deny-matched pattern: "${denyMatch}"`,
+        denySource: { kind: 'config', pattern: denyMatch },
+      };
+    }
+    // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
+    // command to be covered and is right for the allow question below; asking
+    // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
+    // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
+    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
+    if (denyGroupMatch !== null) {
+      return {
+        decision: 'deny-covered',
+        reasoning: `deny-matched group: "${denyGroupMatch}"`,
+        denySource: { kind: 'config', pattern: denyGroupMatch },
+      };
+    }
+    const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
+    if (allowMatch !== null) {
+      return { decision: 'approve', reasoning: `allow-matched pattern: "${allowMatch}"` };
+    }
+    const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
+    if (approveGroupMatch !== null) {
+      return { decision: 'approve', reasoning: `approve-matched group: "${approveGroupMatch}"` };
+    }
+    return null;
+  }
+
+  /**
    * Evaluate a permission request. Never throws.
    * On any error, returns escalate so the user gets the question as normal.
    *
@@ -712,52 +786,25 @@ export class AutoApproveService {
     // Entire body wrapped in try/catch so the "never throws" contract holds
     // even if the matchers or other sync code fail (e.g. malformed config).
     try {
-      // Deny list + deny groups: checked first, always win. No LLM call.
-      const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
-      if (denyMatch !== null) {
-        const reasoning = `deny-matched pattern: "${denyMatch}"`;
-        this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return {
-          decision: 'deny',
-          reasoning,
-          durationMs: 0,
-          model,
-          denySource: { kind: 'config', pattern: denyMatch },
-        };
-      }
-      // BROAD, not precise (#1001, ADR 0010). `matchGroups` requires the WHOLE
-      // command to be covered and is right for the allow question below; asking
-      // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
-      // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
-      const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
-      if (denyGroupMatch !== null) {
-        const reasoning = `deny-matched group: "${denyGroupMatch}"`;
-        this.logFn(`${prefix} DENIED ${toolName}: ${reasoning} (0ms)`);
-        return {
-          decision: 'deny',
-          reasoning,
-          durationMs: 0,
-          model,
-          denySource: { kind: 'config', pattern: denyGroupMatch },
-        };
-      }
-
-      // Allow list + approve groups: bypass the LLM for known-safe operations.
-      const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
-      if (allowMatch !== null) {
-        const reasoning = `allow-matched pattern: "${allowMatch}"`;
-        if (this.logDecisions) {
-          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
+      // Deny/allow/group: checked first, always win, no LLM call. Shared with
+      // the gate's subagent hook-time path (#1024) via `evaluateDeterministic`
+      // so the two can never drift apart -- see that method's doc.
+      const deterministic = this.evaluateDeterministic(toolName, toolInput);
+      if (deterministic !== null) {
+        if (deterministic.decision === 'deny-covered') {
+          this.logFn(`${prefix} DENIED ${toolName}: ${deterministic.reasoning} (0ms)`);
+          return {
+            decision: 'deny',
+            reasoning: deterministic.reasoning,
+            durationMs: 0,
+            model,
+            denySource: deterministic.denySource,
+          };
         }
-        return { decision: 'approve', reasoning, durationMs: 0, model };
-      }
-      const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
-      if (approveGroupMatch !== null) {
-        const reasoning = `approve-matched group: "${approveGroupMatch}"`;
         if (this.logDecisions) {
-          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${reasoning}`);
+          this.logFn(`${prefix} ${toolName}: approve (0ms) - ${deterministic.reasoning}`);
         }
-        return { decision: 'approve', reasoning, durationMs: 0, model };
+        return { decision: 'approve', reasoning: deterministic.reasoning, durationMs: 0, model };
       }
 
       // #976 PRECEDENT, approve direction: the user already answered YES to

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -184,9 +184,23 @@ export interface CompoundPart {
 /**
  * Split a command into compound segments on `&&`, `||`, `;`, `|`, and newlines
  * (`\n`/`\r` — the shell treats an unquoted newline as a command separator,
- * exactly like `;`), respecting single/double quotes (best-effort), retaining
- * which operator joined each segment to the previous one.
+ * exactly like `;`), respecting single/double quotes and double-quote /
+ * unquoted backslash escapes, retaining which operator joined each segment
+ * to the previous one.
  * Backgrounding `&` is left in the segment for the shell-control veto to catch.
+ *
+ * Escape handling (#1031): a backslash-escaped quote outside quotes (`\"`)
+ * does not open a quote, and a backslash-escaped `"` inside a double-quoted
+ * span does not close it — in real bash neither toggles quote state, so
+ * treating them as literal is what keeps a LIVE separator after them (a real
+ * `;`/`&&`/`||`/`|`) from being misread as still inside an "unterminated"
+ * quote and swallowed into one segment. Single quotes are unaffected: bash has
+ * no escapes inside them, so only a literal `'` closes one.
+ *
+ * NOT handled (#1034): bash ANSI-C `$'...'` quoting, where `\'` does NOT close
+ * the span. This parser (and `maskQuotedSpans`) still toggles on the inner `'`,
+ * desyncing quote state and leaving a `$'...'`-based separator bypass open — a
+ * distinct pre-existing P0 of the same class as #1031, tracked in #1034.
  */
 export function splitCompoundParts(command: string): CompoundPart[] {
   const parts: CompoundPart[] = [];
@@ -201,9 +215,41 @@ export function splitCompoundParts(command: string): CompoundPart[] {
   for (let i = 0; i < command.length; i++) {
     const c = command[i];
     const next = command[i + 1];
-    if (quote !== null) {
+
+    if (quote === '"') {
+      // Every backslash inside double quotes is consumed with the character
+      // after it, so an escaped `"` cannot close the quote. This is broader
+      // than bash's real rule (only `$ \` " \\` newline are special inside
+      // double quotes), but that is safe here: over-consuming an escape can
+      // only keep already-quoted text together, never merge a live operator —
+      // a live operator requires being OUTSIDE quotes in the first place.
+      if (c === '\\' && next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
       current += c;
-      if (c === quote) quote = null;
+      if (c === '"') quote = null;
+      continue;
+    }
+
+    if (quote === "'") {
+      // No escapes exist inside bash single quotes; only a literal `'` closes.
+      current += c;
+      if (c === "'") quote = null;
+      continue;
+    }
+
+    // quote === null from here.
+    if (c === '\\') {
+      // Outside quotes, the next character is escaped: it cannot toggle quote
+      // state, and cannot act as a separator/operator either way.
+      if (next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
+      current += c; // trailing lone backslash: literal, string ends
       continue;
     }
     if (c === '"' || c === "'") {

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -324,22 +324,146 @@ export function rewriteRedirectClauses(
   );
 }
 
-/** True if the segment carries shell control that could escape the matched prefix. */
+/**
+ * Render a same-length view of a segment in which every character that is
+ * PROVABLY literal text — inside a quoted span, or the second half of a
+ * backslash escape — is replaced by `_`. Everything the function cannot
+ * prove is literal is left VISIBLE, unchanged, at its original position.
+ *
+ * Exists because `hasShellControl` used to run its checks against raw
+ * segment text, so `--body "prose with \`code\` and a > sign"` vetoed a `gh
+ * issue create` the user had explicitly allowed: the backtick and `>` inside
+ * the quoted, escaped prose are not shell metacharacters at all, but a
+ * substring search cannot tell the difference (#1023). Masking only ever
+ * REMOVES characters that are provably inert; anything it cannot classify
+ * stays visible, so it can only shrink the set of segments that veto, never
+ * grow it — same philosophy as `shellWords`, applied to the veto instead of
+ * the flag/positional checks.
+ *
+ * Quote handling, matched to real shell semantics:
+ *
+ *   - single-quoted spans are fully literal: every character inside, and the
+ *     quotes themselves, is masked. No escapes exist inside single quotes,
+ *     not even for the quote character itself.
+ *   - double-quoted spans mask everything EXCEPT an unescaped `$` or
+ *     backtick, because those two still substitute inside double quotes
+ *     (`"$(rm -rf ~)"` and `` "`x`" `` must keep vetoing). `\$`, `` \` ``,
+ *     `\\` and `\"` are escape pairs and are masked whole; a `$` left
+ *     visible directly before `(` keeps the `(` visible too, because the
+ *     substitution check below matches the two-character substring `$(`,
+ *     not a lone `$`.
+ *   - outside quotes, a backslash-escaped character is literal and the pair
+ *     is masked; everything else stays visible, since that is exactly the
+ *     text a real shell would treat as live.
+ *
+ * A quote that never closes is reported honestly: masking a partial span
+ * would be a guess about where it ends, so the function fails closed and
+ * returns the segment UNCHANGED — exactly today's quote-blind behavior for
+ * that input.
+ *
+ * The placeholder is `_` on purpose: it is already a member of
+ * `PLAIN_PATH_TARGET_RE`, so a masked redirect target (`> "file"` becomes
+ * `> ______`) still classifies as a `path` and still vetoes, rather than
+ * silently reclassifying to something this module has never seen before.
+ */
+export function maskQuotedSpans(segment: string): string {
+  const n = segment.length;
+  const out: string[] = new Array(n);
+  let i = 0;
+
+  while (i < n) {
+    const c = segment[i];
+    if (c === undefined) break;
+
+    if (c === '\\') {
+      const next = segment[i + 1];
+      if (next === undefined) {
+        out[i] = '_';
+        i++;
+        continue;
+      }
+      out[i] = '_';
+      out[i + 1] = '_';
+      i += 2;
+      continue;
+    }
+
+    if (c === "'") {
+      const start = i;
+      let j = i + 1;
+      while (j < n && segment[j] !== "'") j++;
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = '_';
+      i = j + 1;
+      continue;
+    }
+
+    if (c === '"') {
+      const start = i;
+      let j = i + 1;
+      const visible = new Set<number>();
+      while (j < n && segment[j] !== '"') {
+        const cur = segment[j];
+        if (cur === '\\') {
+          const next = segment[j + 1];
+          if (next !== undefined && ['"', '\\', '$', '`', '\n'].includes(next)) {
+            j += 2;
+            continue;
+          }
+          j += 1; // lone backslash: literal, masked; next char judged on its own
+          continue;
+        }
+        if (cur === '$' || cur === '`') visible.add(j);
+        j++;
+      }
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = visible.has(k) ? (segment[k] ?? '_') : '_';
+      i = j + 1;
+      continue;
+    }
+
+    out[i] = c;
+    i++;
+  }
+
+  // A `$` left visible directly before `(` keeps the `(` visible too: the
+  // substitution check matches the substring `$(`, and a lone `$` with its
+  // paren masked would silently defeat it.
+  for (let k = 0; k < n - 1; k++) {
+    if (out[k] === '$' && segment[k + 1] === '(') out[k + 1] = '(';
+  }
+
+  return out.join('');
+}
+
+/**
+ * True if the segment carries shell control that could escape the matched
+ * prefix.
+ *
+ * Runs against a `maskQuotedSpans` view rather than the raw segment (#1023):
+ * quoted, escaped prose (a `--body` that mentions a backtick, a `>`
+ * comparison, an `&` ampersand) is not shell control, and checking the raw
+ * text could not tell the difference from the real thing. Masking only
+ * removes characters proven literal, so an actual `$(...)`, backtick,
+ * `<(...)`, backgrounding `&`, or non-`/dev/null` redirect is exactly as
+ * visible after masking as before, and still vetoes.
+ */
 export function hasShellControl(segment: string): boolean {
+  const masked = maskQuotedSpans(segment);
   // Command / process substitution.
-  if (segment.includes('$(') || segment.includes('`') || segment.includes('<(')) {
+  if (masked.includes('$(') || masked.includes('`') || masked.includes('<(')) {
     return true;
   }
   // Backgrounding / control operator: a lone `&` anywhere that is not part of
   // `&&` (already split out), an fd-dup (`2>&1`, `>&2`), nor an `&>` redirect
   // (caught as redirection below). Catches `cmd &`, `cmd & other`, `a&b`.
-  if (/(^|[^&>])&(?![&>0-9])/.test(segment)) {
+  if (/(^|[^&>])&(?![&>0-9])/.test(masked)) {
     return true;
   }
   // Output redirection to anything other than /dev/null or an fd dup (2>&1).
   // `path` and `opaque` both veto, so this is unchanged by the classifier: it
   // recognizes exactly the two safe shapes and refuses everything else.
-  for (const clause of findRedirectClauses(segment)) {
+  for (const clause of findRedirectClauses(masked)) {
     if (clause.target.kind !== 'discard' && clause.target.kind !== 'fd-dup') {
       return true;
     }
@@ -452,7 +576,10 @@ export function matchCoveredCommand(
     const seg = raw.trim();
     if (seg === '') continue;
     // On the ORIGINAL segment, before any grammar is removed: whatever a
-    // keyword introduces, it cannot make a redirect or a `&` safe.
+    // keyword introduces, it cannot make a redirect or a `&` safe. `seg` is
+    // NOT the raw segment by the time `hasShellControl` sees it — it masks
+    // quoted/escaped spans first (#1023) — but no grammar keyword has been
+    // peeled off, which is the property this comment is guarding.
     if (hasShellControl(seg)) return null;
     // Shell grammar is peeled off so the command inside is judged on its own
     // merits (#999). `body` is what actually runs; a segment that is pure

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -197,16 +197,18 @@ export interface CompoundPart {
  * quote and swallowed into one segment. Single quotes are unaffected: bash has
  * no escapes inside them, so only a literal `'` closes one.
  *
- * NOT handled (#1034): bash ANSI-C `$'...'` quoting, where `\'` does NOT close
- * the span. This parser (and `maskQuotedSpans`) still toggles on the inner `'`,
- * desyncing quote state and leaving a `$'...'`-based separator bypass open — a
- * distinct pre-existing P0 of the same class as #1031, tracked in #1034.
+ * ANSI-C handling (#1034): bash `$'...'` applies C-style escapes inside, so
+ * `\'` does NOT close the span — only an unescaped `'` does. This parser (and
+ * `maskQuotedSpans`) recognizes `$'...'` and consumes those escapes, so an
+ * escaped `'` cannot close early and desync quote state, which would otherwise
+ * leave a live separator after the real closing quote swallowed into one
+ * segment (the bypass #1033 left open, same class as #1031).
  */
 export function splitCompoundParts(command: string): CompoundPart[] {
   const parts: CompoundPart[] = [];
   let current = '';
   let joiner: CompoundJoiner = null;
-  let quote: '"' | "'" | null = null;
+  let quote: '"' | "'" | "$'" | null = null;
   const push = (nextJoiner: CompoundJoiner) => {
     parts.push({ text: current, joiner });
     current = '';
@@ -240,6 +242,22 @@ export function splitCompoundParts(command: string): CompoundPart[] {
       continue;
     }
 
+    if (quote === "$'") {
+      // ANSI-C quoting (`$'...'`): bash applies C-style escapes inside, so a
+      // backslash-escaped `'` does NOT close the span — only an UNescaped `'`
+      // does (#1034). Consuming the backslash with its next char is what keeps
+      // an escaped `'` from ending the span early and leaving a LIVE separator
+      // after the real closing quote misread as still inside it.
+      if (c === '\\' && next !== undefined) {
+        current += c + next;
+        i++;
+        continue;
+      }
+      current += c;
+      if (c === "'") quote = null;
+      continue;
+    }
+
     // quote === null from here.
     if (c === '\\') {
       // Outside quotes, the next character is escaped: it cannot toggle quote
@@ -250,6 +268,17 @@ export function splitCompoundParts(command: string): CompoundPart[] {
         continue;
       }
       current += c; // trailing lone backslash: literal, string ends
+      continue;
+    }
+    if (c === '$' && next === "'") {
+      // ANSI-C `$'...'` opens here, recognized explicitly: unlike a plain
+      // single quote it honours backslash escapes inside, so parsing it as a
+      // plain `'...'` span desyncs from bash and can swallow a live separator
+      // that actually sits OUTSIDE the quotes (#1034). `$"..."` needs no such
+      // case — its `"` opens a real double-quote span either way.
+      quote = "$'";
+      current += c + next;
+      i++;
       continue;
     }
     if (c === '"' || c === "'") {
@@ -431,6 +460,28 @@ export function maskQuotedSpans(segment: string): string {
       out[i] = '_';
       out[i + 1] = '_';
       i += 2;
+      continue;
+    }
+
+    if (c === '$' && segment[i + 1] === "'") {
+      // ANSI-C `$'...'`: bash honours C-style escapes inside, so `\'` does NOT
+      // close — only an UNescaped `'` does (#1034). A plain-single-quote scan
+      // ends at the escaped `'` and desyncs, corrupting the mask here and (in
+      // `splitCompoundParts`) hiding a live separator. The whole span is a
+      // string literal, so mask it all — masking only removes proven-literal
+      // text, never a live operator.
+      const start = i;
+      let j = i + 2;
+      while (j < n && segment[j] !== "'") {
+        if (segment[j] === '\\' && segment[j + 1] !== undefined) {
+          j += 2;
+          continue;
+        }
+        j++;
+      }
+      if (j >= n) return segment; // unterminated: fail closed
+      for (let k = start; k <= j; k++) out[k] = '_';
+      i = j + 1;
       continue;
     }
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.6'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.7'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.6'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.7'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.4'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.5'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.4'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.5'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.3'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.3'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -777,6 +777,14 @@ if ((cliSubcommand === 'new' || cliSubcommand === undefined) && cliDir && !cliHo
   process.chdir(dirResult.resolved);
 }
 
+// #1025: `gitInfo` above was computed from process.cwd() at module load,
+// before args were parsed — a hub-spawned child inherits the hub's cwd, so
+// that snapshot named the hub's repo/branch. The --resume/--recent/--dir
+// chdirs above (if any) have now settled process.cwd() on the real session
+// directory; refresh the status snapshot from it. `remi serve` never chdirs
+// here, so this is a no-op and the hub keeps reporting its own cwd.
+updateRemiStatus(detectGitInfo());
+
 // Every read-only / remote-client subcommand (ls, recent, kill, detach, attach,
 // code, start/stop/status/logs, keys, autostart, --host remote-new) has already
 // exited above. Everything past this point boots a daemon or a local wrapper

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.4'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.4'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.1'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.1'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.5'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.6'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.5'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.6'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.5-dev.2'; // REMI_COMPILED_VERSION
+      return '0.7.5-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.5-dev.2'; // REMI_COMPILED_VERSION
+    return '0.7.5-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli/attach-client.ts
+++ b/packages/daemon/src/cli/attach-client.ts
@@ -44,6 +44,26 @@ export interface AttachClientResult {
   reason: 'detached' | 'session_ended' | 'error' | 'timeout' | 'connection_closed';
 }
 
+/**
+ * #1026: pure formatter for the held-question terminal cue, pinned by a byte-
+ * sequence test. Leads with `\r\x1b[2K` (return to column 0, erase the whole
+ * line) instead of a bare `\r\n`: a held permission blocks Claude inside the
+ * hook call, but the TUI spinner keeps animating on its own timer regardless
+ * (elapsed-time display), so the row this cue lands on can already hold a
+ * half-drawn spinner frame. `\r\n` alone moved past that row without erasing
+ * it, so the next spinner repaint and this cue's text could occupy the same
+ * row. Clearing first means the cue always takes the row cleanly; every
+ * following line (and the last) still ends `\r\n`, so the spinner resumes on
+ * its own fresh row below the cue block, same as before.
+ */
+export function formatQuestionBanner(question: Question): string {
+  const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
+  const lines = [`\r\x1b[2K\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
+  if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
+  lines.push(`\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`);
+  return lines.join('');
+}
+
 export async function runAttachClient(opts: AttachClientOptions): Promise<AttachClientResult> {
   const { host, port, sessionId, timeout = 5000, outputFd = 1 } = opts;
   const url = `ws://${host}:${port}/ws`;
@@ -273,22 +293,18 @@ export async function runAttachClient(opts: AttachClientOptions): Promise<Attach
    * `question` messages per visible prompt cycle (hook bridge + PTY parser,
    * different ids), so bannering those would double- or triple-print around
    * the native prompt — the exact noise the old blanket suppression avoided.
-   * Held questions also guarantee an idle PTY, so the banner can never
-   * interleave mid-ANSI-sequence with streaming output. Plain text through
-   * writeOutput (raw mode: \r\n), cyan so it stands apart from Claude's own
-   * output.
+   * #1026 correction: a held permission blocking Claude's hook call does NOT
+   * guarantee an idle PTY — the TUI spinner keeps animating on its own timer
+   * while the hook is pending, and a live session showed the cue's old bare
+   * `\r\n` lead interleaving with that spinner's redraw on the same row.
+   * `formatQuestionBanner` now clears the row first (see its own docstring).
+   * Cyan so it stands apart from Claude's own output.
    */
   function renderQuestionBanner(question: Question): void {
     if (question.held !== true) return;
     if (banneredQuestionIds.has(question.id)) return;
     banneredQuestionIds.add(question.id);
-    const options = question.options.map((o, i) => `${i + 1}) ${o.label}`).join('  ');
-    const lines = [`\r\n\x1b[36m[remi] pending question: ${question.text}\x1b[0m\r\n`];
-    if (options) lines.push(`\x1b[36m[remi] options: ${options}\x1b[0m\r\n`);
-    lines.push(
-      `\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n`,
-    );
-    writeOutput(lines.join(''));
+    writeOutput(formatQuestionBanner(question));
   }
 
   /**

--- a/packages/daemon/src/cli/daemon-manager.ts
+++ b/packages/daemon/src/cli/daemon-manager.ts
@@ -14,6 +14,7 @@ import * as path from 'node:path';
 import { errorToString } from '@remi/shared';
 import { SessionRegistryFile } from '../session/session-registry-file.ts';
 import { rotateIfNeeded } from './log-rotation.ts';
+import { resolveExistingDirectory } from './path-resolver.ts';
 import { formatVersionDrift } from './version-drift.ts';
 
 // Re-exported for existing importers/tests; the definition moved to
@@ -560,12 +561,19 @@ export async function spawnRemiDaemon(
   // own ~/.remi/daemon-status.json.
   childEnv['REMI_SPAWNED_CHILD'] = '1';
 
+  // #1025: without this, the child inherits OUR cwd (the hub's, for a
+  // hub-spawned child), so anything the child reads from process.cwd()
+  // before its own --dir chdir logic runs — e.g. gitInfo at module load —
+  // names the wrong project.
+  const childCwd = resolveExistingDirectory(directory);
+
   let child: ReturnType<typeof spawn>;
   try {
     child = spawn(command, spawnArgs, {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       env: childEnv,
+      ...(childCwd !== undefined && { cwd: childCwd }),
     });
   } catch (err) {
     fs.closeSync(logFd);

--- a/packages/daemon/src/cli/handlers/create-session-events.ts
+++ b/packages/daemon/src/cli/handlers/create-session-events.ts
@@ -17,6 +17,7 @@ import type { SessionRegistryFile } from '../../session/index.ts';
 import { findAvailableTcpPort as defaultFindAvailableTcpPort } from '../../session/port-utils.ts';
 import { spawnRemiDaemon as defaultSpawnRemiDaemon } from '../daemon-manager.ts';
 import { log, logError } from '../logger.ts';
+import { resolveRequestedSessionDirectory } from '../path-resolver.ts';
 import type { SendToConnection } from './trivial-events.ts';
 
 export interface SpawnResult {
@@ -93,10 +94,14 @@ export function createCreateSessionHandlers(deps: CreateSessionHandlerDeps) {
           return;
         }
 
-        log(`Spawning new daemon on port ${freePort} for directory ${directory || '(cwd)'}`);
+        // #1025: no/empty/whitespace directory means "home", never the
+        // hub's own cwd (an accident of where `remi serve` was started) —
+        // see resolveRequestedSessionDirectory for the full rationale.
+        const resolvedDirectory = resolveRequestedSessionDirectory(directory);
+        log(`Spawning new daemon on port ${freePort} for directory ${resolvedDirectory}`);
         spawningPorts.add(freePort);
         try {
-          const result = await spawnDaemon(freePort, directory, [...inheritedArgs()]);
+          const result = await spawnDaemon(freePort, resolvedDirectory, [...inheritedArgs()]);
           send(
             connectionId,
             createCreateSessionResponse(

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -55,12 +55,31 @@ export function resolveDirectory(inputPath: string | null | undefined): ResolveD
  * process's `cwd` option, or `undefined` if it isn't a real, existing
  * directory. Unlike `resolveDirectory`, silent on failure by design: the
  * caller (`spawnRemiDaemon`) uses this only as a best-effort belt-and-braces
- * fix (#1025) and leaves invalid input for the child's OWN `--dir` handling
- * — which calls `resolveDirectory` and reports the error — to catch.
+ * fix (#1025). A non-empty but invalid directory is left for the child's OWN
+ * `--dir` handling — which calls `resolveDirectory` and reports the error —
+ * to catch; falsy input (no directory requested) is handled upstream by
+ * `resolveRequestedSessionDirectory` for a remote request, so by the time a
+ * LOCAL spawn reaches here with no directory, "inherit the parent's cwd" is
+ * the intended behavior, not an error to catch.
  */
 export function resolveExistingDirectory(inputPath: string | null | undefined): string | undefined {
   if (!inputPath) return undefined;
   const resolved = normalizeProjectPath(inputPath);
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return undefined;
   return resolved;
+}
+
+/**
+ * Resolve the directory for a REMOTE create-session request (#1025): no
+ * directory, or an empty/whitespace-only string, means "home" — the
+ * contract `NewSessionModal.tsx` documents ("empty string = home/cwd") and
+ * what `RecentProjects`'s default entry sends. The hub's own cwd is an
+ * accident of wherever `remi serve` happened to be started and is never a
+ * meaningful default for a request that arrived over the wire, unlike a
+ * LOCAL `remi new` from a shell, which correctly inherits the invoking
+ * shell's cwd — this helper is for the remote path only, never the local one.
+ */
+export function resolveRequestedSessionDirectory(directory: string | undefined): string {
+  const trimmed = directory?.trim();
+  return trimmed || os.homedir();
 }

--- a/packages/daemon/src/cli/path-resolver.ts
+++ b/packages/daemon/src/cli/path-resolver.ts
@@ -49,3 +49,18 @@ export function resolveDirectory(inputPath: string | null | undefined): ResolveD
   }
   return { resolved };
 }
+
+/**
+ * Resolve a directory to an absolute path suitable for a spawned child
+ * process's `cwd` option, or `undefined` if it isn't a real, existing
+ * directory. Unlike `resolveDirectory`, silent on failure by design: the
+ * caller (`spawnRemiDaemon`) uses this only as a best-effort belt-and-braces
+ * fix (#1025) and leaves invalid input for the child's OWN `--dir` handling
+ * — which calls `resolveDirectory` and reports the error — to catch.
+ */
+export function resolveExistingDirectory(inputPath: string | null | undefined): string | undefined {
+  if (!inputPath) return undefined;
+  const resolved = normalizeProjectPath(inputPath);
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) return undefined;
+  return resolved;
+}

--- a/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-gate.test.ts
@@ -625,6 +625,195 @@ describe('AutoApproveGate', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1024: a subagent-tagged PermissionRequest that the config's own
+// deterministic layers (deny, then allow, then approve_groups --
+// `evaluateDeterministic`) already approve is answered 'allow' at hook time
+// instead of parked. The LLM must still never run for a subagent at hook
+// time (ADR 0004); anything not deterministically approved -- including a
+// deny match -- parks + passthroughs exactly as before this issue.
+// ---------------------------------------------------------------------------
+describe('AutoApproveGate subagent hook-time deterministic answer (#1024)', () => {
+  const SID = generateId() as UUID;
+  let registry: SessionRegistry;
+  let submits: string[];
+  let escalations: PermissionRequestHookInput[];
+  let parks: PermissionRequestHookInput[];
+  let observed: PermissionRequestHookInput[];
+  let evaluateCalls: number;
+  let tracker: QuestionPresenceTracker;
+
+  type Deterministic =
+    | { decision: 'approve'; reasoning: string }
+    | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
+    | null;
+
+  function gateWithDeterministic(det: Deterministic): AutoApproveGate {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const service: AutoApproveEvaluator = {
+      evaluate: async () => {
+        evaluateCalls++;
+        return approve;
+      },
+      cancel: () => true,
+      evaluateDeterministic: () => det,
+    };
+    return new AutoApproveGate(
+      {
+        service,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: (i) => {
+          parks.push(i);
+          return undefined;
+        },
+        onSubagentPassthrough: (i) => observed.push(i),
+      },
+      SID,
+    );
+  }
+
+  function pr(over: Partial<PermissionRequestHookInput> = {}): PermissionRequestHookInput {
+    return {
+      session_id: 'claude-test',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/d',
+      permission_mode: 'default',
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'grep foo src/' },
+      agent_id: 'agent-1',
+      ...over,
+    };
+  }
+
+  beforeEach(() => {
+    registry = new SessionRegistry({ orphanTimeoutMs: 60000 });
+    submits = [];
+    escalations = [];
+    parks = [];
+    observed = [];
+    evaluateCalls = 0;
+    tracker = new QuestionPresenceTracker(() => undefined);
+    configureLogger({ writeLog: () => {} });
+  });
+
+  afterEach(async () => {
+    __resetLoggerForTests();
+    await registry.shutdown();
+  });
+
+  test('approve_groups-covered command answers "allow", does not park, LLM never runs', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'approve-matched group: "read-only:Bash"',
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(pr());
+    expect(d).toBe('allow');
+    expect(parks).toHaveLength(0);
+    expect(submits).toHaveLength(0);
+    expect(escalations).toHaveLength(0);
+    expect(evaluateCalls).toBe(0);
+  });
+
+  test('user allow-covered tool name (WebFetch) answers "allow"', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'allow-matched pattern: "WebFetch"',
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(
+      pr({ tool_name: 'WebFetch', tool_input: { url: 'https://example.com' } }),
+    );
+    expect(d).toBe('allow');
+    expect(parks).toHaveLength(0);
+    expect(evaluateCalls).toBe(0);
+  });
+
+  test('deterministic approve still fires the subagent_alert observation cue', async () => {
+    const det: Deterministic = {
+      decision: 'approve',
+      reasoning: 'approve-matched group: "read-only:Bash"',
+    };
+    const input = pr({ tool_input: { command: 'curl https://example.com' } });
+    const d = await gateWithDeterministic(det).resolvePermission(input);
+    expect(d).toBe('allow');
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.tool_input).toEqual({ command: 'curl https://example.com' });
+  });
+
+  test('deny-covered match parks (deny wins; no hook-time allow)', async () => {
+    const det: Deterministic = {
+      decision: 'deny-covered',
+      reasoning: 'deny-matched pattern: "rm -rf /"',
+      denySource: { kind: 'config', pattern: 'rm -rf /' },
+    };
+    const d = await gateWithDeterministic(det).resolvePermission(
+      pr({ tool_input: { command: 'rm -rf /tmp/x' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+    // Still observed via the same park-path cue, exactly as before #1024.
+    expect(observed).toHaveLength(1);
+  });
+
+  test('no deterministic verdict parks + passthrough exactly as before #1024', async () => {
+    const d = await gateWithDeterministic(null).resolvePermission(
+      pr({ tool_input: { command: 'npm install' } }),
+    );
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+    expect(observed).toHaveLength(1);
+  });
+
+  test('a test double omitting evaluateDeterministic parks exactly as before #1024', async () => {
+    registry.registerSession(SID, '/d', fakePTY(submits), {
+      handleMessage: () => {},
+      handleQuestion: () => {},
+      handleStatusChange: () => {},
+    } as never);
+    const minimal: AutoApproveEvaluator = {
+      evaluate: async () => {
+        evaluateCalls++;
+        return approve;
+      },
+      cancel: () => true,
+    };
+    const g = new AutoApproveGate(
+      {
+        service: minimal,
+        sessionRegistry: registry,
+        tracker,
+        isInSubagentContext: () => false,
+        escalate: (i) => {
+          escalations.push(i);
+          return generateId();
+        },
+        parkForPTY: (i) => {
+          parks.push(i);
+          return undefined;
+        },
+        onSubagentPassthrough: (i) => observed.push(i),
+      },
+      SID,
+    );
+    const d = await g.resolvePermission(pr());
+    expect(d).toBe('passthrough');
+    expect(parks).toHaveLength(1);
+    expect(evaluateCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Lifecycle callbacks that drive the terminal cue (#513). They must fire on the
 // matching verdict and never cross-fire (a leaked spinner / missed notification
 // would be the symptom).

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -655,6 +655,92 @@ describe('AutoApproveService - permission groups (#494)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// evaluateDeterministic (#1024) — the shared pre-LLM layer `evaluate()` and
+// the gate's subagent hook-time shortcut both call. No network involved, so
+// these do not need the unreachable-base_url trick the tests above use.
+// ---------------------------------------------------------------------------
+
+describe('AutoApproveService - evaluateDeterministic (#1024)', () => {
+  function detService(over: Partial<AutoApproveConfig>): AutoApproveService {
+    return new AutoApproveService(makeConfig({ base_url: 'http://10.255.255.1', ...over }), logFn);
+  }
+
+  test('allow pattern match returns approve', () => {
+    const service = detService({ allow: ['git push'] });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'cd /foo && git push origin main',
+    });
+    expect(result?.decision).toBe('approve');
+    expect(result && 'reasoning' in result ? result.reasoning : '').toContain('allow-matched');
+  });
+
+  test('approve_groups match returns approve', () => {
+    const service = detService({ approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('Grep', { pattern: 'foo' });
+    expect(result?.decision).toBe('approve');
+    expect(result && 'reasoning' in result ? result.reasoning : '').toContain(
+      'approve-matched group',
+    );
+  });
+
+  test('deny pattern match returns deny-covered, never approve', () => {
+    const service = detService({ deny: ['rm -rf /'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'rm -rf /tmp/foo' });
+    expect(result?.decision).toBe('deny-covered');
+    if (result?.decision === 'deny-covered') {
+      expect(result.reasoning).toContain('deny-matched pattern');
+      expect(result.denySource).toEqual({ kind: 'config', pattern: 'rm -rf /' });
+    }
+  });
+
+  test('deny_groups match returns deny-covered with a group denySource', () => {
+    const service = detService({ deny_groups: ['build-test'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'bun test' });
+    expect(result?.decision).toBe('deny-covered');
+    if (result?.decision === 'deny-covered') {
+      expect(result.reasoning).toContain('deny-matched group');
+      expect(result.denySource.kind).toBe('config');
+    }
+  });
+
+  test('deny wins over allow: a command matching both returns deny-covered', () => {
+    const service = detService({ allow: ['git'], deny: ['git push --force'] });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'git push --force origin main',
+    });
+    expect(result?.decision).toBe('deny-covered');
+  });
+
+  test('no match returns null', () => {
+    const service = detService({ allow: [], deny: [], approve_groups: [], deny_groups: [] });
+    const result = service.evaluateDeterministic('Bash', { command: 'npm install' });
+    expect(result).toBeNull();
+  });
+
+  test('agrees with evaluate() on the same allow-matched input (no drift)', async () => {
+    const service = detService({ allow: ['git push'] });
+    const direct = service.evaluateDeterministic('Bash', { command: 'git push origin main' });
+    const viaEvaluate = await service.evaluate('Bash', { command: 'git push origin main' });
+    expect(direct?.decision).toBe('approve');
+    expect(viaEvaluate.decision).toBe('approve');
+    expect(viaEvaluate.reasoning).toBe(direct && 'reasoning' in direct ? direct.reasoning : '');
+    expect(viaEvaluate.durationMs).toBe(0);
+  });
+
+  test('agrees with evaluate() on the same deny-matched input (no drift)', async () => {
+    const service = detService({ deny: ['rm -rf /'] });
+    const direct = service.evaluateDeterministic('Bash', { command: 'rm -rf /tmp/foo' });
+    const viaEvaluate = await service.evaluate('Bash', { command: 'rm -rf /tmp/foo' });
+    expect(direct?.decision).toBe('deny-covered');
+    expect(viaEvaluate.decision).toBe('deny');
+    expect(viaEvaluate.reasoning).toBe(direct && 'reasoning' in direct ? direct.reasoning : '');
+    expect(viaEvaluate.decision === 'deny' ? viaEvaluate.denySource : undefined).toEqual(
+      direct?.decision === 'deny-covered' ? direct.denySource : undefined,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Instructions injected into LLM prompt (behavioral - uses the real engine)
 // ---------------------------------------------------------------------------
 describeEngine('AutoApproveService - instructions affect LLM decision', () => {

--- a/packages/daemon/tests/auto-approve/shell-safety-ansic-quoting.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-ansic-quoting.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #1034 (P0): bash ANSI-C `$'...'` quoting desynced `splitCompoundParts` and
+ * `maskQuotedSpans`. Both treated `$'...'` as a plain single-quoted span, but
+ * bash applies C-style escapes INSIDE `$'...'`, so `\'` does NOT close it —
+ * only an unescaped `'` does. `$'\''` is the standard idiom for a literal
+ * single quote; after it bash is OUTSIDE quotes.
+ *
+ * The old parsers toggled quote state on the escaped `'`, ending up INSIDE a
+ * wrongly-opened span. A live separator after the real closing quote
+ * (`git status $'\'' ; <cmd>`) was then swallowed into one segment, and the 0ms
+ * allow fast-path (`matchCoveredCommand`) approved the covered read with the
+ * injected tail riding along — the same class as #536 / #1031.
+ *
+ * Follow-up to #1033, which closed the `\"` variant but explicitly did not
+ * handle `$'...'`. These tests pin the splitter, the mask, and the end-to-end
+ * closure.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { MUTATION_TOKEN } from '../../src/auto-approve/permission-groups.ts';
+import {
+  hasShellControl,
+  maskQuotedSpans,
+  matchCoveredCommand,
+  splitCompoundParts,
+} from '../../src/auto-approve/shell-safety.ts';
+
+const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
+const READS = ['git status', 'cat', 'grep', 'ls'];
+
+describe("splitCompoundParts handles ANSI-C $'...' quoting (#1034)", () => {
+  test("an escaped `'` inside $'...' no longer swallows a live `;`", () => {
+    // `$'\''` is a literal single quote; after it we are OUTSIDE quotes, so the
+    // `;` is a real separator. Old code closed the span early on the escaped
+    // `'` and read `; touch ...` as still quoted: one segment.
+    const parts = splitCompoundParts("git status $'\\'' ; touch /tmp/x");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[1]?.text.trim()).toBe('touch /tmp/x');
+  });
+
+  test("an escaped `'` inside $'...' no longer swallows a live `|`", () => {
+    const parts = splitCompoundParts("cat file $'\\'' | sh");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '|']);
+    expect(parts[1]?.text.trim()).toBe('sh');
+  });
+
+  test("a benign $'...' with no escaped quote still splits normally after it", () => {
+    const parts = splitCompoundParts("echo $'foo' ; bar");
+    expect(parts.length).toBe(2);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[0]?.text).toContain("$'foo'");
+  });
+
+  test("an escaped backslash inside $'...' is consumed; balanced span is one segment", () => {
+    // `$'a\\b'` — the `\\` is an escaped backslash, the closing `'` still
+    // closes, and there is no separator, so it stays a single segment.
+    const parts = splitCompoundParts("echo $'a\\\\b'");
+    expect(parts.length).toBe(1);
+  });
+});
+
+describe("maskQuotedSpans + hasShellControl handle $'...' (#1034)", () => {
+  test("$'...' prose with >, & inside does not veto (contents are literal)", () => {
+    expect(maskQuotedSpans("echo $'a > b & c'")).toBe('echo ____________');
+    expect(hasShellControl("echo $'a > b & c'")).toBe(false);
+  });
+
+  test("MUST STILL VETO: real command substitution after a $'...' span", () => {
+    // The `$'x'` is inert, but the trailing `$(...)` is real control and must
+    // still veto the whole segment.
+    expect(hasShellControl("echo $'x' $(touch y)")).toBe(true);
+  });
+});
+
+describe('the #1034 exploit is closed end-to-end via matchCoveredCommand', () => {
+  test("THE P0: $'\\'' can no longer smuggle an uncovered tail past the veto", () => {
+    expect(matchCoveredCommand("git status $'\\'' ; touch /tmp/x", READS, readVeto)).toBeNull();
+  });
+
+  test('a piped injection behind the ANSI-C escape is refused too', () => {
+    expect(matchCoveredCommand("cat file $'\\'' | sh", READS, readVeto)).toBeNull();
+  });
+
+  test("control: a covered read with a benign $'...' arg still matches", () => {
+    expect(matchCoveredCommand("grep $'foo' file", READS, readVeto)).toBe('grep');
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -1,0 +1,145 @@
+/**
+ * #1023: `hasShellControl` was quote-blind, so quoted/escaped PROSE tripped
+ * it exactly like the real thing.
+ *
+ * Verified in the 2026-08-08 transit session (c77ba8f8): a `gh issue create`
+ * whose `--body` mentioned code (escaped backticks, a `>` comparison, an `&`
+ * ampersand, all inside double quotes) escalated to the phone even though
+ * `gh issue` was in the config `allow` list. `splitCompoundParts` was already
+ * quote-aware (the `;` in the title did not split the segment); the veto was
+ * the only quote-blind layer left on this path.
+ *
+ * `maskQuotedSpans` fixes this by removing ONLY characters it can prove are
+ * literal text, so it can only shrink the set of segments that veto, never
+ * grow it. The "must still veto" half of this file is the important half.
+ */
+import { describe, expect, test } from 'bun:test';
+import { matchAllowPattern } from '../../src/auto-approve/pattern-matcher.ts';
+import { hasShellControl, maskQuotedSpans } from '../../src/auto-approve/shell-safety.ts';
+
+describe('maskQuotedSpans', () => {
+  test('single-quoted spans are fully literal, quotes included', () => {
+    expect(maskQuotedSpans("echo 'a $(x) > b & c `d`'")).toBe('echo ____________________');
+  });
+
+  test('double-quoted spans mask everything except unescaped $ and backtick', () => {
+    expect(maskQuotedSpans('echo "a > b"')).toBe('echo _______');
+    expect(maskQuotedSpans('echo "$(x)"')).toBe('echo _$(___');
+    expect(maskQuotedSpans('echo "`x`"')).toBe('echo _`_`_');
+  });
+
+  test('an escaped $ or backtick inside double quotes is masked, not left visible', () => {
+    expect(maskQuotedSpans('echo "a \\`b\\` c"')).toBe('echo ___________');
+    expect(maskQuotedSpans('echo "\\$(x)"')).toBe('echo _______');
+  });
+
+  test('escaped " and \\\\ pairs inside double quotes are masked whole', () => {
+    expect(maskQuotedSpans('echo "a \\"b\\" c"')).toBe('echo ___________');
+    expect(maskQuotedSpans('echo "a \\\\ c"')).toBe('echo ________');
+  });
+
+  test('outside quotes, a backslash-escaped character is literal and masked', () => {
+    expect(maskQuotedSpans('echo a\\>b')).toBe('echo a__b');
+    expect(maskQuotedSpans('echo \\$(x)')).toBe('echo __(x)');
+    expect(maskQuotedSpans('echo \\`x\\`')).toBe('echo __x__');
+  });
+
+  test('outside quotes, everything unescaped stays visible unchanged', () => {
+    expect(maskQuotedSpans('echo $(x) > b & c `d`')).toBe('echo $(x) > b & c `d`');
+  });
+
+  test('an unterminated double quote fails closed: original segment, unchanged', () => {
+    const raw = 'echo "a > b';
+    expect(maskQuotedSpans(raw)).toBe(raw);
+  });
+
+  test('an unterminated single quote fails closed: original segment, unchanged', () => {
+    const raw = "echo 'a > b";
+    expect(maskQuotedSpans(raw)).toBe(raw);
+  });
+
+  test('a trailing lone backslash does not crash and is masked', () => {
+    expect(maskQuotedSpans('echo a\\')).toBe('echo a_');
+  });
+});
+
+describe('hasShellControl - #1023 quote-aware veto', () => {
+  test('the real gh issue create case: escaped backticks, >, and & inside quotes', () => {
+    const command =
+      'gh issue create --title "Host teardown never stops the GPU poll thread; renderer calls race reset" ' +
+      '--body "prose with \\`VirtIOGPU\\` and \\`stopPolling()\\` and a > comparison and a & ampersand"';
+    expect(hasShellControl(command)).toBe(false);
+    expect(matchAllowPattern('Bash', { command }, ['gh issue'])).toBe('gh issue');
+  });
+
+  test('quoted prose no longer vetoes: > inside double quotes', () => {
+    expect(hasShellControl('echo "a > b"')).toBe(false);
+  });
+
+  test('quoted prose no longer vetoes: $(...) and > and & inside single quotes', () => {
+    expect(hasShellControl("echo 'a $(x) > b &'")).toBe(false);
+  });
+
+  test('quoted prose no longer vetoes: an escaped backtick inside double quotes', () => {
+    expect(hasShellControl('echo "a \\`b\\` c"')).toBe(false);
+  });
+
+  test('gh pr create with the same body shape is covered by an allow entry', () => {
+    const command = 'gh pr create --title "fix" --body "see \\`foo()\\` for details"';
+    expect(matchAllowPattern('Bash', { command }, ['gh pr'])).toBe('gh pr');
+  });
+
+  test('git commit -m with quoted, escaped code mention is covered by an allow entry', () => {
+    const command = 'git commit -m "use \\`rm -rf\\` carefully"';
+    expect(hasShellControl(command)).toBe(false);
+    expect(matchAllowPattern('Bash', { command }, ['git commit'])).toBe('git commit');
+  });
+
+  test('a masked redirect target still classifies as a path and still vetoes', () => {
+    expect(hasShellControl('echo hi > "file"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: command substitution inside double quotes', () => {
+    expect(hasShellControl('echo "$(rm -rf ~)"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: backtick substitution inside double quotes', () => {
+    expect(hasShellControl('echo "`x`"')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted command substitution', () => {
+    expect(hasShellControl('echo $(x)')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted backtick substitution', () => {
+    expect(hasShellControl('echo `x`')).toBe(true);
+  });
+
+  test('MUST STILL VETO: process substitution', () => {
+    expect(hasShellControl('echo <(x)')).toBe(true);
+  });
+
+  test('MUST STILL VETO: unquoted redirection', () => {
+    expect(hasShellControl('echo a > b')).toBe(true);
+    expect(hasShellControl('echo a >> b')).toBe(true);
+  });
+
+  test('MUST STILL VETO: backgrounding', () => {
+    expect(hasShellControl('cmd &')).toBe(true);
+    expect(hasShellControl('a&b')).toBe(true);
+  });
+
+  test('MUST STILL VETO: an unterminated quote behaves exactly as before', () => {
+    expect(hasShellControl('echo "a > b')).toBe(true);
+    expect(hasShellControl("echo 'a > b")).toBe(true);
+  });
+
+  test('MUST STILL VETO: real shell control survives alongside masked prose', () => {
+    // The `--body` prose is inert, but the trailing `$(...)` outside any
+    // quote is a real command substitution and must still veto the whole
+    // segment.
+    expect(hasShellControl('gh issue create --body "a > b and a \\` mention" $(curl evil)')).toBe(
+      true,
+    );
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -2,7 +2,7 @@
  * #1023: `hasShellControl` was quote-blind, so quoted/escaped PROSE tripped
  * it exactly like the real thing.
  *
- * Verified in the 2026-08-08 transit session (c77ba8f8): a `gh issue create`
+ * Verified in the 2026-08-08 transit session (see #1023): a `gh issue create`
  * whose `--body` mentioned code (escaped backticks, a `>` comparison, an `&`
  * ampersand, all inside double quotes) escalated to the phone even though
  * `gh issue` was in the config `allow` list. `splitCompoundParts` was already

--- a/packages/daemon/tests/auto-approve/shell-safety-split-escape.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-split-escape.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #1031 (P0): `splitCompoundParts` was escape-blind. It tracked single/double
+ * quotes but treated a backslash as an ordinary character, so an escaped quote
+ * OUTSIDE quotes (`\"`) spuriously opened a quote span. A live command
+ * separator after it (`;`, `&&`, `||`, `|`, newline) was then read as sitting
+ * inside that "unterminated" quote and swallowed into ONE segment — hiding it
+ * from the per-segment veto in `matchCoveredCommand`, the 0ms allow path.
+ *
+ * The exploit shape: a covered read prefix, an escaped quote, then a real
+ * separator and an arbitrary command. Old behavior collapsed it to a single
+ * segment that prefix-matched the covered read and carried no mutation token,
+ * so `matchCoveredCommand` approved the whole thing — the injected tail
+ * included. This is the same class as #536.
+ *
+ * The fix makes the splitter consume backslash escapes the way bash does, so
+ * `\"` never toggles quote state and the live separator splits normally. These
+ * tests pin BOTH halves: the escaped quote outside quotes must not merge a live
+ * separator, and an escaped quote INSIDE a real quoted span must still not
+ * split (over-splitting genuine quoted text is the opposite failure).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { MUTATION_TOKEN } from '../../src/auto-approve/permission-groups.ts';
+import { matchCoveredCommand, splitCompoundParts } from '../../src/auto-approve/shell-safety.ts';
+
+const readVeto = (segment: string): boolean => MUTATION_TOKEN.test(segment);
+const READS = ['git status', 'cat', 'grep', 'ls'];
+
+describe('splitCompoundParts is escape-aware (#1031)', () => {
+  test('an escaped quote OUTSIDE quotes does not swallow a live `;`', () => {
+    // Old code opened a quote at `\"` and read `; rm -rf ~` as quoted text: one
+    // segment. Now `\"` is literal and the `;` splits.
+    const parts = splitCompoundParts('git status \\"; rm -rf ~');
+    expect(parts.map((p) => p.text)).toEqual(['git status \\"', ' rm -rf ~']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+  });
+
+  test('an escaped quote outside quotes does not swallow a live `&&`', () => {
+    const parts = splitCompoundParts('ls \\"foo\\" && curl evil');
+    expect(parts.map((p) => p.text)).toEqual(['ls \\"foo\\" ', ' curl evil']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '&&']);
+  });
+
+  test('an escaped `\\"` INSIDE a real double-quoted span does not close it early', () => {
+    // `"a \"; b"` is a single bash string containing `a "; b` — the `;` is
+    // quoted and must NOT split. Over-splitting here is the mirror-image bug.
+    const parts = splitCompoundParts('echo "a \\"; b"');
+    expect(parts.map((p) => p.text)).toEqual(['echo "a \\"; b"']);
+    expect(parts.map((p) => p.joiner)).toEqual([null]);
+  });
+
+  test('an escaped separator char outside quotes is literal, not a split', () => {
+    // `\;` is an escaped semicolon: one command, not two.
+    const parts = splitCompoundParts('echo a\\; b');
+    expect(parts.map((p) => p.text)).toEqual(['echo a\\; b']);
+  });
+
+  test("single quotes have no escapes: a backslash before `'` still closes", () => {
+    // Inside single quotes bash has no escape mechanism, so the first literal
+    // `'` closes the span and the following `;` is a live separator.
+    const parts = splitCompoundParts("echo 'a\\'; rm -rf ~");
+    expect(parts.map((p) => p.joiner)).toEqual([null, ';']);
+    expect(parts[1]?.text).toBe(' rm -rf ~');
+  });
+
+  test('regression: real separators still split with the right joiners', () => {
+    const parts = splitCompoundParts('a && b || c ; d | e');
+    expect(parts.map((p) => p.text.trim())).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(parts.map((p) => p.joiner)).toEqual([null, '&&', '||', ';', '|']);
+  });
+
+  test('a trailing lone backslash does not crash and stays literal', () => {
+    const parts = splitCompoundParts('echo a\\');
+    expect(parts.map((p) => p.text)).toEqual(['echo a\\']);
+  });
+});
+
+describe('the #1031 exploit is closed end-to-end via matchCoveredCommand', () => {
+  test('THE P0: an escaped quote can no longer smuggle an uncovered tail past the veto', () => {
+    // `git status` is a covered read. The escaped quote used to merge the whole
+    // command into one segment that matched `git status` and approved the
+    // injected `rm -rf ~`. Now `rm -rf ~` is its own uncovered segment, so the
+    // whole command is refused.
+    expect(matchCoveredCommand('git status \\"; rm -rf ~', READS, readVeto)).toBeNull();
+  });
+
+  test('a piped injection behind an escaped quote is refused too', () => {
+    expect(matchCoveredCommand('cat file \\" | sh', READS, readVeto)).toBeNull();
+  });
+
+  test('control: a genuinely covered single read still matches', () => {
+    expect(matchCoveredCommand('git status', READS, readVeto)).toBe('git status');
+  });
+
+  test('control: an escaped quote inside a covered read that stays one segment still matches', () => {
+    // No live separator here — the escaped quote is inert, coverage is intact.
+    expect(matchCoveredCommand('grep \\"needle\\" file', READS, readVeto)).toBe('grep');
+  });
+});

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -28,7 +28,7 @@ import type {
   RemiStatus,
   UUID,
 } from '@remi/shared';
-import { runAttachClient } from '../../src/cli/attach-client.ts';
+import { formatQuestionBanner, runAttachClient } from '../../src/cli/attach-client.ts';
 
 const TEST_PORT = 9873;
 
@@ -308,6 +308,31 @@ describe('runAttachClient', () => {
       ...(held ? { held: true } : {}),
     };
   }
+
+  // #1026: pin the exact byte sequence so the clear-line lead (`\r\x1b[2K`)
+  // and the trailing `\r\n` on every line — the shape that keeps the TUI
+  // spinner off the cue's row and lets it resume on a fresh row below —
+  // can't regress back to a bare `\r\n` lead without this test failing.
+  test('formatQuestionBanner clears the current row before the cue text', () => {
+    const question = makeQuestion('Allow file edit?');
+    const banner = formatQuestionBanner(question);
+
+    expect(banner).toBe(
+      '\r\x1b[2K\x1b[36m[remi] pending question: Allow file edit?\x1b[0m\r\n' +
+        '\x1b[36m[remi] options: 1) Yes  2) No\x1b[0m\r\n' +
+        "\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n",
+    );
+  });
+
+  test('formatQuestionBanner omits the options line when there are none', () => {
+    const question: Question = { ...makeQuestion('Allow file edit?'), options: [] };
+    const banner = formatQuestionBanner(question);
+
+    expect(banner).toBe(
+      '\r\x1b[2K\x1b[36m[remi] pending question: Allow file edit?\x1b[0m\r\n' +
+        "\x1b[2m[remi] answer on your phone, or run 'remi unstick' to answer here\x1b[0m\r\n",
+    );
+  });
 
   // #753: a HELD permission (Model B) blocks Claude inside the hook, so no
   // raw PTY bytes for the prompt ever exist — the LIVE question message is

--- a/packages/daemon/tests/cli/handlers/create-session-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/create-session-events.test.ts
@@ -109,6 +109,29 @@ describe('createCreateSessionHandlers', () => {
     expect(spawningPorts.has(20005)).toBe(false);
   });
 
+  test('maps a missing directory to the home directory, not the hub cwd (#1025)', async () => {
+    const spawnHistory: Array<string | undefined> = [];
+    const handlers = createCreateSessionHandlers({
+      liveSessionsRegistry,
+      spawningPorts,
+      basePort: 20000,
+      portRange: 10,
+      inheritedArgs: () => [],
+      send,
+      findAvailableTcpPort: async () => 20008,
+      spawnDaemon: async (port, directory) => {
+        spawnHistory.push(directory);
+        return { sessionId: 's', port, pid: 1 };
+      },
+    });
+
+    await handlers.onCreateSessionRequest(CID, undefined, REQ);
+    await handlers.onCreateSessionRequest(CID, '', REQ);
+    await handlers.onCreateSessionRequest(CID, '   ', REQ);
+
+    expect(spawnHistory).toEqual([os.homedir(), os.homedir(), os.homedir()]);
+  });
+
   test('reserves the port during spawn then releases it', async () => {
     let sawReservedDuringSpawn = false;
     const handlers = createCreateSessionHandlers({

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeProjectPath,
   resolveDirectory,
   resolveExistingDirectory,
+  resolveRequestedSessionDirectory,
 } from '../../src/cli/path-resolver.ts';
 
 describe('resolveDirectory', () => {
@@ -111,6 +112,30 @@ describe('resolveExistingDirectory (#1025)', () => {
     const file = path.join(sandbox, 'file.txt');
     fs.writeFileSync(file, 'hello');
     expect(resolveExistingDirectory(file)).toBeUndefined();
+  });
+});
+
+describe('resolveRequestedSessionDirectory (#1025)', () => {
+  test('maps undefined to the home directory', () => {
+    expect(resolveRequestedSessionDirectory(undefined)).toBe(os.homedir());
+  });
+
+  test('maps an empty string to the home directory', () => {
+    expect(resolveRequestedSessionDirectory('')).toBe(os.homedir());
+  });
+
+  test('maps a whitespace-only string to the home directory', () => {
+    expect(resolveRequestedSessionDirectory('   ')).toBe(os.homedir());
+  });
+
+  test('passes a real path through, trimmed', () => {
+    expect(resolveRequestedSessionDirectory('  /tmp/some-project  ')).toBe('/tmp/some-project');
+  });
+
+  test("does not expand `~` — that is the child daemon's own --dir job", () => {
+    expect(resolveRequestedSessionDirectory('~/Documents/git/project')).toBe(
+      '~/Documents/git/project',
+    );
   });
 });
 

--- a/packages/daemon/tests/cli/path-resolver.test.ts
+++ b/packages/daemon/tests/cli/path-resolver.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { normalizeProjectPath, resolveDirectory } from '../../src/cli/path-resolver.ts';
+import {
+  normalizeProjectPath,
+  resolveDirectory,
+  resolveExistingDirectory,
+} from '../../src/cli/path-resolver.ts';
 
 describe('resolveDirectory', () => {
   let sandbox: string;
@@ -71,6 +75,42 @@ describe('resolveDirectory', () => {
     if ('error' in result) {
       expect(result.error).toStartWith('Not a directory: ');
     }
+  });
+});
+
+describe('resolveExistingDirectory (#1025)', () => {
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-existing-dir-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  test('returns undefined for null / undefined / empty string', () => {
+    expect(resolveExistingDirectory(null)).toBeUndefined();
+    expect(resolveExistingDirectory(undefined)).toBeUndefined();
+    expect(resolveExistingDirectory('')).toBeUndefined();
+  });
+
+  test('returns the resolved path for an existing directory', () => {
+    expect(resolveExistingDirectory(sandbox)).toBe(sandbox);
+  });
+
+  test('expands `~` before checking existence', () => {
+    expect(resolveExistingDirectory('~')).toBe(os.homedir());
+  });
+
+  test('returns undefined for a non-existent path', () => {
+    expect(resolveExistingDirectory(path.join(sandbox, 'nope'))).toBeUndefined();
+  });
+
+  test('returns undefined when the path is a file, not a directory', () => {
+    const file = path.join(sandbox, 'file.txt');
+    fs.writeFileSync(file, 'hello');
+    expect(resolveExistingDirectory(file)).toBeUndefined();
   });
 });
 

--- a/packages/daemon/tests/cli/startup-env.test.ts
+++ b/packages/daemon/tests/cli/startup-env.test.ts
@@ -45,6 +45,22 @@ describe('detectGitInfo', () => {
     expect(info.repo).toBe(path.basename(sandbox));
     expect(info.branch).toBe('?');
   });
+
+  // #1025: a session daemon spawned by the hub inherits the hub's cwd, so
+  // calling detectGitInfo() with no argument (defaulting to process.cwd())
+  // before the session directory is resolved reports the HUB's repo/branch.
+  // Pins that an explicit dir argument always wins over the ambient cwd.
+  test('an explicit dir overrides process.cwd(), even when both are git repos', () => {
+    fs.mkdirSync(path.join(sandbox, '.git'));
+    fs.writeFileSync(path.join(sandbox, '.git', 'HEAD'), 'ref: refs/heads/session-branch\n');
+
+    const info = detectGitInfo(sandbox);
+    expect(info.repo).toBe(path.basename(sandbox));
+    expect(info.branch).toBe('session-branch');
+    // The sandbox is a fresh mkdtemp dir, never process.cwd() during a test
+    // run — this would fail if the argument were ever silently ignored.
+    expect(info.repo).not.toBe(path.basename(process.cwd()));
+  });
 });
 
 describe('parseEnvLine', () => {

--- a/packages/daemon/tests/integration/hub-lifecycle.test.ts
+++ b/packages/daemon/tests/integration/hub-lifecycle.test.ts
@@ -1,15 +1,20 @@
 /**
  * Integration tests for the hub lifecycle races and CLI round-trip (#542,
  * #731 review): the PID-file split-brain branches, `remi start`/`remi stop`
- * through the real CLI, and REMI_SPAWNED_CHILD per-port status routing.
+ * through the real CLI, REMI_SPAWNED_CHILD per-port status routing, and
+ * (#1025) the hub's own status.repo/branch staying cwd-based.
  *
  * Same harness as hub-serve.test.ts: REAL cli.ts subprocesses under an
  * isolated $HOME, no mocks.
  *
  * NOT covered here (covered by on-machine verification instead): a hub
- * spawning a real `--daemon` session child and `remi stop` sparing it — the
- * child wraps a real `claude` process, which CI does not have, and a stub
- * claude binary would violate the no-mocks rule.
+ * spawning a real `--daemon` session child and `remi stop` sparing it, or
+ * that child reporting its OWN directory's repo/branch (#1025) rather than
+ * the hub's — the child wraps a real `claude` process, which CI does not
+ * have, and a stub claude binary would violate the no-mocks rule. Verified
+ * manually (isolated $HOME, real `claude`): hub cwd A ("hub-repo-A"/"main"),
+ * child requested for cwd B ("session-repo-B"/a feature branch) — the
+ * child's status-<port>.json reported B's repo/branch, not A's.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -225,6 +230,32 @@ describe('cleanupFiles ownership guard (#740 review)', () => {
     await runCleanupFiles(home, 4242);
     expect(fs.readFileSync(pidFile, 'utf-8')).toBe('5555');
     expect(JSON.parse(fs.readFileSync(statusFile, 'utf-8')).pid).toBe(5555);
+  }, 30000);
+});
+
+describe('hub status reports its own cwd git info, unaffected (#1025)', () => {
+  // The #1025 fix refreshes the status snapshot's repo/branch from the
+  // resolved SESSION directory after --dir/--recent/--resume chdirs. Hub
+  // (serve) mode never chdirs, so it must keep reporting its own cwd exactly
+  // as before. A hub-spawned child correctly reporting ITS OWN directory
+  // instead of the hub's is covered by on-machine verification only (see
+  // file header): the child wraps a real `claude` process CI does not have,
+  // and it exits (PTY spawn ENOENT) before the debounced status write can
+  // ever reach disk without one.
+  test('serve mode reports the repo/branch of its own working directory', async () => {
+    const { home, work } = makeIsolatedDirs();
+    extraDirs.push(home, work);
+    fs.mkdirSync(path.join(work, '.git'));
+    fs.writeFileSync(path.join(work, '.git', 'HEAD'), 'ref: refs/heads/hub-own-branch\n');
+
+    const hub = await spawnHub({ home, work });
+    hubs.push(hub);
+
+    const status = JSON.parse(
+      fs.readFileSync(path.join(home, '.remi', 'daemon-status.json'), 'utf-8'),
+    );
+    expect(status.repo).toBe(path.basename(work));
+    expect(status.branch).toBe('hub-own-branch');
   }, 30000);
 });
 


### PR DESCRIPTION
## Release 0.7.5

Promotes `develop` to `main`. Merging this triggers `auto-release`: strips the
`-dev.N` suffix, tags `v0.7.5`, and publishes (npm `@yooz-labs/remi`, GitHub
release, Homebrew tap), then syncs `main` back into `develop`.

### Headline — two P0 allow-list bypasses closed
Both the same shape: a crafted quote desynced the shell splitter so a live
command separator was read as quoted text, collapsing an injected command into
a segment that prefix-matched a covered read — and the 0ms allow path approved
the whole thing, tail included (same class as #536).
- **#1033** (closes #1031): escaped quote `\"`.
- **#1035** (closes #1034): bash ANSI-C `$'...'` quoting. Found while
  adversarially reviewing #1033.

Both fixes shipped with tests proven to fail against the pre-fix code and
independent adversarial review.

### Also in 0.7.5
- **#1030** (#1024): deterministic subagent permissions answered at hook time
  (no park/render/LLM/GPU queue), amending ADR 0004.
- **#1028** (#1023): quote-aware shell-control veto — quoted prose no longer
  escalates.
- **#1029** (#1025): statusline reports the session's repo/branch, not the hub's.
- **#1027** (#1026): terminal status cue no longer collides with the spinner.

### Known open (documented, not shipped as fixed)
- **#1032**: a bare tool-name `allow` entry grants a subagent silent hook-time
  write access a curated write group would block. Not yet decided.

Full notes: CHANGELOG.md `## [0.7.5]`.
