### PR TITLE
Stop the status bar freezing on a live question

### DIFF
--- a/.context/decisions/0022-status-bar-never-freezes.md
+++ b/.context/decisions/0022-status-bar-never-freezes.md
@@ -1,0 +1,110 @@
+# ADR 0022: The status bar waits for a quiet PTY; it never stops painting
+
+**Status:** accepted
+**Date:** 2026-08-10
+**Owner:** Yahya
+
+## Context
+
+The reserved-row status bar (#565) and Claude's own PTY output are two
+unsynchronized writers on one fd. #932 named the real hazard precisely: not
+byte-level interleaving (both writes are synchronous `fs.writeSync` on the same
+thread) but a paint landing BETWEEN two forwarded chunks, at a boundary that
+splits one of Claude's own escape sequences — the bar's DECSC/DECRC pair shares
+Claude's cursor-save slot, 166 of 421 occurrences in the installed binary.
+
+Two fixes were written for it, two hours apart on 2026-07-30:
+
+- **PR #933 (19:35), a blanket freeze.** `render()` returned early for as long
+  as `hasLiveQuestions()` was true, painting once on the transition in and once
+  on the way out.
+- **PR #942 (21:28), the durable fix.** `PtyQuiescenceGate`: `isBoundaryClean()`
+  as a hard gate (a write can never land mid-sequence) plus `isQuiescent()` as a
+  soft one (500 ms since the last chunk).
+
+The durable fix subsumed the freeze, but the freeze was never removed. It
+shipped in v0.7.4 and v0.7.5, and the freeze has **no upper bound**: a prompt a
+human sits on for ten minutes freezes row N for ten minutes. Worse, the frame it
+freezes on is not arbitrary. The escalate that raises the prompt is also what
+sets the state to `needs you` — a cue whose entire contract is that it decays
+after `ESCALATE_FRESH_S` (60 s). So the common case was a decaying cue pinned on
+screen indefinitely, reported from the field as:
+
+```
+remi:18766 website:main | no clients | needs you
+```
+
+reproduced verbatim, unchanged across 20 simulated minutes and a phone
+attaching. This is the [ADR 0020](0020-client-status-cue-totality.md) failure
+mode — a status cue with no path back off itself — arriving through the
+renderer instead of through the gate's end paths.
+
+## Decision
+
+While a question is live, `isQuiescent()` is promoted to a **hard** gate on every
+paint — no heartbeat exemption, no onset/resumed exemption — and the bar keeps
+its normal cadence. It does not freeze.
+
+## Consequences
+
+Strictly stronger per-write than the freeze it replaces: the freeze still
+permitted its onset paint while Claude was mid-render of the prompt; this
+permits nothing mid-render. It is also strictly better for the DECSTBM
+re-assertion `buildBarSequence` carries — the freeze suppressed that for the
+entire life of a question, where the heartbeat now still fires every
+`HEARTBEAT_MS` whenever the PTY is quiet.
+
+What is given up: the onset paint is no longer instantaneous. It waits for the
+next tick that finds the PTY quiescent, so up to ~750 ms (250 ms cadence +
+500 ms `QUIESCENCE_MS`) can pass between a question going live and the row
+reflecting it. That was an explicit exemption before, justified by Claude's
+native statusLine disappearing while a dialog is open. It is affordable now
+precisely because the bar no longer stops: the value arrives one tick later
+instead of being the only value for the whole window.
+
+"Mode 2" exposure (a paint inside a save/restore pair spanning a quiet gap)
+remains an accepted residual, unchanged — it was already accepted for every
+paint outside a live question, and closing it needs a full VT emulator.
+
+**Obligation this creates:** anything that suppresses paints must be bounded by
+something other than a human's attention span. A future gate keyed on "is a
+prompt showing" is this bug again.
+
+## Alternatives considered
+
+- **Keep the freeze, make the frozen content time-independent.** Would stop
+  `needs you` sticking, but leaves `attached`/`no clients` and the session
+  status stale for the whole window — and the bar is the *only* cue on screen
+  while a dialog hides Claude's native statusLine. Treats the symptom.
+- **Bound the freeze with a timeout.** Picks an arbitrary number, and every
+  value is either too short to protect or too long to be useful. The quiescence
+  gate already answers the underlying question ("is it safe to paint right
+  now?") with a measurement instead of a guess.
+- **Remove the live-question gating entirely, relying on #942's gates as-is.**
+  Rejected as too loose: the soft gate has documented exemptions (heartbeat,
+  edges) that would then let a paint land mid-render of a prompt. Promoting it
+  to hard *only* while a question is live keeps those exemptions where they were
+  justified and removes them where they are not.
+
+## Receipts
+
+- #1038 (issue) — the field report, both defects, and the reproduction
+- `ad8ec6e4` (PR #933, 2026-07-30 19:35) — the freeze, `if (questionLive &&
+  !onset) return;`
+- `635d1403` (PR #942, 2026-07-30 21:28) — the quiescence + boundary gate that
+  subsumed it two hours later
+- `git tag --contains ad8ec6e4` → `v0.7.4`; v0.7.5 shipped after, matching the
+  field report's "at least two releases ago"
+- `packages/daemon/src/cli/status-bar.ts` — module doc protection 1, and
+  `render()`'s `(questionLive || !forced) && !this.isQuiescent()`
+- `packages/daemon/src/cli/pty-quiescence-gate.ts` — `QUIESCENCE_MS = 500`,
+  measured from a real capture
+- `packages/daemon/tests/cli/status-bar.test.ts` — `a live question makes
+  quiescence a HARD gate`, `a live question suspends the heartbeat exemption`,
+  `a "needs you" cue still decays while the question that raised it is open`
+- `packages/daemon/tests/cli/attach-client.test.ts` — `the bar keeps tracking
+  status while a question (question_snapshot) stays live`, which reads the row
+  MID-question so it cannot pass by catching up after the prompt closes
+- [ADR 0020](0020-client-status-cue-totality.md) — the same "cue with no path
+  back off itself" failure, found via the gate's end paths rather than the
+  renderer

--- a/.context/decisions/0022-status-bar-never-freezes.md
+++ b/.context/decisions/0022-status-bar-never-freezes.md
@@ -1,4 +1,4 @@
-# ADR 0022: The status bar waits for a quiet PTY; it never stops painting
+# ADR 0022: Status-bar liveness is bounded by HEARTBEAT_MS, never by a human
 
 **Status:** accepted
 **Date:** 2026-08-10
@@ -7,104 +7,119 @@
 ## Context
 
 The reserved-row status bar (#565) and Claude's own PTY output are two
-unsynchronized writers on one fd. #932 named the real hazard precisely: not
-byte-level interleaving (both writes are synchronous `fs.writeSync` on the same
-thread) but a paint landing BETWEEN two forwarded chunks, at a boundary that
-splits one of Claude's own escape sequences — the bar's DECSC/DECRC pair shares
-Claude's cursor-save slot, 166 of 421 occurrences in the installed binary.
+unsynchronized writers on one fd. #932 named the hazard precisely: not
+byte-level interleaving (both are synchronous `fs.writeSync` on one thread) but
+a paint landing BETWEEN two forwarded chunks, at a boundary that splits one of
+Claude's own escape sequences.
 
 Two fixes were written for it, two hours apart on 2026-07-30:
 
 - **PR #933 (19:35), a blanket freeze.** `render()` returned early for as long
-  as `hasLiveQuestions()` was true, painting once on the transition in and once
-  on the way out.
+  as `hasLiveQuestions()` was true, painting once on the transition in.
 - **PR #942 (21:28), the durable fix.** `PtyQuiescenceGate`: `isBoundaryClean()`
   as a hard gate (a write can never land mid-sequence) plus `isQuiescent()` as a
-  soft one (500 ms since the last chunk).
+  soft one (500 ms since the last chunk), the latter with documented exemptions
+  for the heartbeat and the onset/resumed edges.
 
-The durable fix subsumed the freeze, but the freeze was never removed. It
-shipped in v0.7.4 and v0.7.5, and the freeze has **no upper bound**: a prompt a
-human sits on for ten minutes freezes row N for ten minutes. Worse, the frame it
-freezes on is not arbitrary. The escalate that raises the prompt is also what
-sets the state to `needs you` — a cue whose entire contract is that it decays
-after `ESCALATE_FRESH_S` (60 s). So the common case was a decaying cue pinned on
-screen indefinitely, reported from the field as:
+The freeze was never removed and shipped in v0.7.4 and v0.7.5. It has **no upper
+bound**: a prompt a human sits on for ten minutes freezes row N for ten minutes.
+The frame it freezes on is not arbitrary — the escalate that raises the prompt
+is also what sets the state to `needs you`, a cue whose contract is that it
+decays after `ESCALATE_FRESH_S` (60 s). Field report, reproduced verbatim and
+held across 20 simulated minutes and a phone attaching:
 
 ```
 remi:18766 website:main | no clients | needs you
 ```
 
-reproduced verbatim, unchanged across 20 simulated minutes and a phone
-attaching. This is the [ADR 0020](0020-client-status-cue-totality.md) failure
-mode — a status cue with no path back off itself — arriving through the
-renderer instead of through the gate's end paths.
+This is the [ADR 0020](0020-client-status-cue-totality.md) failure mode — a cue
+with no path back off itself — arriving through the renderer rather than through
+the gate's end paths.
+
+**#1038's first attempt got this wrong in an instructive way.** Rather than just
+deleting the freeze, it replaced it: `isQuiescent()` was promoted to a hard gate
+while a question was live, removing the heartbeat and edge exemptions there. The
+stated reasoning was that this is "strictly stronger per-write" (true) and that
+a deliberating human leaves the PTY quiet (**false**). This repo had already
+recorded the counter-evidence, from a live session: a held permission does not
+idle the PTY, because Claude's TUI spinner keeps animating on its own timer
+(#1026, see `attach-client.ts`'s `renderQuestionBanner`). Driven against the real
+`PtyQuiescenceGate` with 150 ms spinner frames, `isQuiescent()` never once became
+true and the bar painted **zero times in ten minutes** — worse than the freeze,
+which at least guaranteed its onset paint. It passed its own test suite because
+every test injected `isQuiescent` as a hand-flipped boolean.
 
 ## Decision
 
-While a question is live, `isQuiescent()` is promoted to a **hard** gate on every
-paint — no heartbeat exemption, no onset/resumed exemption — and the bar keeps
-its normal cadence. It does not freeze.
+Delete the freeze and add nothing in its place: a live question suppresses no
+paint. #942's gates are the protection, unchanged and unconditioned on whether a
+question is open.
+
+Consequently, **no suppression in this file may be scoped to a question being
+live.** Liveness is bounded by `HEARTBEAT_MS`; it may never depend on the PTY
+going quiet, because the case that most needs a live bar is exactly the case
+where it never does.
 
 ## Consequences
 
-Strictly stronger per-write than the freeze it replaces: the freeze still
-permitted its onset paint while Claude was mid-render of the prompt; this
-permits nothing mid-render. It is also strictly better for the DECSTBM
-re-assertion `buildBarSequence` carries — the freeze suppressed that for the
-entire life of a question, where the heartbeat now still fires every
-`HEARTBEAT_MS` whenever the PTY is quiet.
+Staleness while Claude streams is bounded by `HEARTBEAT_MS` (2 s), not by the
+250 ms cadence — a status change during a spinning prompt reaches the row on the
+next heartbeat. That is the honest guarantee and is what the docs and tests now
+state; the 250 ms figure applies only when the PTY is quiescent.
 
-What is given up: the onset paint is no longer instantaneous. It waits for the
-next tick that finds the PTY quiescent, so up to ~750 ms (250 ms cadence +
-500 ms `QUIESCENCE_MS`) can pass between a question going live and the row
-reflecting it. That was an explicit exemption before, justified by Claude's
-native statusLine disappearing while a dialog is open. It is affordable now
-precisely because the bar no longer stops: the value arrives one tick later
-instead of being the only value for the whole window.
+The DECSTBM re-assertion `buildBarSequence` carries is restored during a live
+question. The freeze suppressed it for the question's entire life — precisely
+the window where row N is least protected from Claude resetting the region — and
+so did the first attempt, for the same reason.
 
-"Mode 2" exposure (a paint inside a save/restore pair spanning a quiet gap)
-remains an accepted residual, unchanged — it was already accepted for every
-paint outside a live question, and closing it needs a full VT emulator.
+`notifyScrollRegionReset()` works again during a live question. It is called
+synchronously from the chunk observer, so `isQuiescent()` is false by
+construction at that moment; under either the freeze or the first attempt its
+repaint could never land.
 
-**Obligation this creates:** anything that suppresses paints must be bounded by
-something other than a human's attention span. A future gate keyed on "is a
-prompt showing" is this bug again.
+Mode-2 exposure (a paint inside a save/restore pair spanning a quiet gap) is
+unchanged and remains an accepted residual — it already applied to every paint
+outside a live question, and closing it needs a full VT emulator.
+
+**Obligation:** a test that injects `isQuiescent` proves nothing about
+starvation. The suite must also drive the real `PtyQuiescenceGate` with real
+chunk bytes at spinner cadence, which is what
+`StatusBar against the real PtyQuiescenceGate` exists for.
 
 ## Alternatives considered
 
-- **Keep the freeze, make the frozen content time-independent.** Would stop
-  `needs you` sticking, but leaves `attached`/`no clients` and the session
-  status stale for the whole window — and the bar is the *only* cue on screen
-  while a dialog hides Claude's native statusLine. Treats the symptom.
-- **Bound the freeze with a timeout.** Picks an arbitrary number, and every
-  value is either too short to protect or too long to be useful. The quiescence
-  gate already answers the underlying question ("is it safe to paint right
-  now?") with a measurement instead of a guess.
-- **Remove the live-question gating entirely, relying on #942's gates as-is.**
-  Rejected as too loose: the soft gate has documented exemptions (heartbeat,
-  edges) that would then let a paint land mid-render of a prompt. Promoting it
-  to hard *only* while a question is live keeps those exemptions where they were
-  justified and removes them where they are not.
+- **Promote `isQuiescent()` to a hard gate while a question is live.** The first
+  attempt. Measured at zero paints in ten minutes against a spinning PTY. Its
+  premise — that a deliberating human means an idle PTY — is contradicted by
+  #1026.
+- **Keep the freeze, make the frozen content time-independent.** Stops `needs
+  you` sticking, but leaves the attach label and session status stale for the
+  whole window, and the bar is the *only* cue on screen while a dialog hides
+  Claude's native statusLine. Treats the symptom.
+- **Bound the freeze with its own timeout.** A second arbitrary constant beside
+  `HEARTBEAT_MS`, which already means "the row must be rewritten at least this
+  often." Two bounds that must agree is one more than necessary.
 
 ## Receipts
 
 - #1038 (issue) — the field report, both defects, and the reproduction
-- `ad8ec6e4` (PR #933, 2026-07-30 19:35) — the freeze, `if (questionLive &&
-  !onset) return;`
-- `635d1403` (PR #942, 2026-07-30 21:28) — the quiescence + boundary gate that
-  subsumed it two hours later
-- `git tag --contains ad8ec6e4` → `v0.7.4`; v0.7.5 shipped after, matching the
-  field report's "at least two releases ago"
-- `packages/daemon/src/cli/status-bar.ts` — module doc protection 1, and
-  `render()`'s `(questionLive || !forced) && !this.isQuiescent()`
+- `ad8ec6e4` (PR #933, 2026-07-30 19:35) — the freeze
+- `635d1403` (PR #942, 2026-07-30 21:28) — the gates that subsumed it two hours
+  later; `git tag --contains ad8ec6e4` -> `v0.7.4`, and v0.7.5 shipped after
+- `packages/daemon/src/cli/attach-client.ts` — `renderQuestionBanner`'s #1026
+  note: "a held permission blocking Claude's hook call does NOT guarantee an
+  idle PTY — the TUI spinner keeps animating on its own timer while the hook is
+  pending", observed live
 - `packages/daemon/src/cli/pty-quiescence-gate.ts` — `QUIESCENCE_MS = 500`,
   measured from a real capture
-- `packages/daemon/tests/cli/status-bar.test.ts` — `a live question makes
-  quiescence a HARD gate`, `a live question suspends the heartbeat exemption`,
-  `a "needs you" cue still decays while the question that raised it is open`
-- `packages/daemon/tests/cli/attach-client.test.ts` — `the bar keeps tracking
-  status while a question (question_snapshot) stays live`, which reads the row
-  MID-question so it cannot pass by catching up after the prompt closes
+- `packages/daemon/tests/cli/status-bar.test.ts` — `a NEVER-quiescent PTY still
+  paints while a question is live, bounded by HEARTBEAT_MS`; the
+  `against the real PtyQuiescenceGate` block, which drives real chunks at 150 ms
+  and would have caught the first attempt
+- `packages/daemon/tests/cli/attach-client.test.ts` — the end-to-end path with
+  `raw_pty_output` flowing throughout, reading the row mid-question so it cannot
+  pass by catching up after the prompt closes
 - [ADR 0020](0020-client-status-cue-totality.md) — the same "cue with no path
-  back off itself" failure, found via the gate's end paths rather than the
-  renderer
+  back off itself" failure, and the totality requirement that
+  `onAttachStateChanged` (this PR's second half) is emitted from the two
+  mutation sites to satisfy

--- a/.context/decisions/0022-status-bar-never-freezes.md
+++ b/.context/decisions/0022-status-bar-never-freezes.md
@@ -64,8 +64,19 @@ where it never does.
 
 Staleness while Claude streams is bounded by `HEARTBEAT_MS` (2 s), not by the
 250 ms cadence — a status change during a spinning prompt reaches the row on the
-next heartbeat. That is the honest guarantee and is what the docs and tests now
-state; the 250 ms figure applies only when the PTY is quiescent.
+next heartbeat. The 250 ms figure applies only when the PTY is quiescent.
+
+That bound is conditional on the HARD boundary gate, and the condition is not a
+technicality. `isBoundaryClean()` has no exception — not even the heartbeat —
+and `render()` is only attempted on the timer, so a tick landing on a dirty
+boundary is dropped with no retry. Measured residuals, none introduced by this
+decision: an unterminated OSC followed by silence holds the gate dirty
+indefinitely (the `MAX_*_RUN_BYTES` escape hatches are byte-counted, so they
+never trip when no further bytes arrive) — 1 paint in ten minutes; alternating
+mid-CSI chunk boundaries stretch the worst gap to ~2750 ms, over the stated
+bound. The honest guarantee is therefore "`HEARTBEAT_MS` whenever the stream
+reaches a clean boundary", which is every realistic stream. Closing the rest
+means owning a VT parser, which is the same answer mode 2 gets.
 
 The DECSTBM re-assertion `buildBarSequence` carries is restored during a live
 question. The freeze suppressed it for the question's entire life — precisely

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -37,6 +37,7 @@ add a row below.
 | [0019](0019-push-kind-mutability-asymmetry.md) | Push kinds are named on the wire; muting them is asymmetric |
 | [0020](0020-client-status-cue-totality.md) | A client status cue must be total over its gate's end paths |
 | [0021](0021-registration-outcome-not-requery.md) | Question registration outcome flows from the call, not a re-query |
+| [0022](0022-status-bar-never-freezes.md) | The status bar waits for a quiet PTY; it never stops painting |
 
 ## By area
 
@@ -45,7 +46,7 @@ each other — reading one without its siblings is how a "fix" reopens the case
 another one closed.
 
 - **Permission decisions / auto-approve:** 0003, 0010, 0015, 0016, 0017, 0018
-- **Questions + notifications:** 0002, 0004, 0019, 0020, 0021
+- **Questions + notifications:** 0002, 0004, 0019, 0020, 0021, 0022
 - **Protocol + contracts:** 0012, 0013, 0014, 0006
 - **Sessions + transport:** 0001, 0005, 0009
 - **Process:** 0007, 0008, 0011

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -37,7 +37,7 @@ add a row below.
 | [0019](0019-push-kind-mutability-asymmetry.md) | Push kinds are named on the wire; muting them is asymmetric |
 | [0020](0020-client-status-cue-totality.md) | A client status cue must be total over its gate's end paths |
 | [0021](0021-registration-outcome-not-requery.md) | Question registration outcome flows from the call, not a re-query |
-| [0022](0022-status-bar-never-freezes.md) | The status bar waits for a quiet PTY; it never stops painting |
+| [0022](0022-status-bar-never-freezes.md) | Status-bar liveness is bounded by `HEARTBEAT_MS`, never by a human |
 
 ## By area
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1174,6 +1174,14 @@ const sessionRegistry = new SessionRegistry(
     onSessionResumed: (sessionId, connectionId) => {
       log(`Session resumed: ${sessionId} by connection ${connectionId}`);
     },
+    // #1038: `attached`/`queuedCount` are PULLED from this registry at flush
+    // time, and nothing on an attach path calls updateRemiStatus -- so
+    // without this a connected phone read as "no clients" on the reserved-row
+    // bar, in status-<PORT>.json, in the attach client and in the app, until
+    // some unrelated status change happened to flush. Emitted from the two
+    // lines that mutate the set, so it covers every attach path by
+    // construction; `refresh()` schedules only on a real change.
+    onAttachStateChanged: () => statusWriter.refresh(),
     onQuestionsChanged: (sessionId, questions) => {
       // Best-effort: a registry-file hiccup here must never take down the
       // question pipeline itself (the live WS `question`/`question_resolved`
@@ -1934,14 +1942,6 @@ remiAttachState = () => {
     queuedCount: 0,
   };
 };
-// #1038: that pull only ran when something ELSE scheduled a flush, and no
-// attach or detach path calls updateRemiStatus -- so a phone attaching left
-// the reserved-row bar, status-<PORT>.json and every connected client reading
-// "no clients" until an unrelated status change happened along. Poll it (see
-// `StatusWriter.refresh`'s doc for why a poll beats wiring five call sites);
-// a tick with nothing new costs one Set.size read and writes nothing. The
-// interval is unref'd, so this never keeps a short-lived CLI alive.
-statusWriter.startAttachRefresh();
 
 /**
  * Cross-client question dismissal (#585, P7). Fired when a pending question stops

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1934,6 +1934,14 @@ remiAttachState = () => {
     queuedCount: 0,
   };
 };
+// #1038: that pull only ran when something ELSE scheduled a flush, and no
+// attach or detach path calls updateRemiStatus -- so a phone attaching left
+// the reserved-row bar, status-<PORT>.json and every connected client reading
+// "no clients" until an unrelated status change happened along. Poll it (see
+// `StatusWriter.refresh`'s doc for why a poll beats wiring five call sites);
+// a tick with nothing new costs one Set.size read and writes nothing. The
+// interval is unref'd, so this never keeps a short-lived CLI alive.
+statusWriter.startAttachRefresh();
 
 /**
  * Cross-client question dismissal (#585, P7). Fired when a pending question stops
@@ -2917,11 +2925,11 @@ if (cliDaemonMode) {
   );
 
   // Start drawing the reserved-row bar now that the PTY is up. Reads the live
-  // StatusWriter state and repaints on a 1Hz timer (the cadence of the
-  // `evaluating Ns` counter). Inert until started, and a no-op when detached
-  // or while a question is pending (#932 -- see status-bar.ts's module doc:
-  // the bar and Claude's own output share one fd, so painting over a live
-  // prompt risks corrupting or erasing it).
+  // StatusWriter state and repaints on a 250ms timer (the cadence of the
+  // `evaluating Ns` counter). Inert until started, and a no-op when detached.
+  // The bar and Claude's own output share one fd, so a paint must never land
+  // mid-render; while a question is pending that means waiting for PTY
+  // quiescence on every paint (#932, #1038 -- see status-bar.ts's module doc).
   if (statusBarActive) {
     statusBar = new StatusBar({
       getStdoutFd: getPtyStdoutFd,

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -35,26 +35,34 @@
  * own escape sequences (the DECSC/DECRC pair above shares Claude's own
  * cursor-save slot -- 166/421 occurrences in the installed binary). PR #933
  * did not fix that; it only cut how often a paint is attempted:
- *   1. While `hasLiveQuestions()` reports a pending question, EVERY paint
- *      waits for PTY quiescence: `isQuiescent()` is promoted to a hard gate
- *      there, with none of the exemptions the heartbeat and the onset/resumed
- *      edges otherwise get (see `render()`). Originally (#933) this was a
- *      blanket freeze -- one paint on the transition INTO the state, then
- *      nothing until it ended. #1038 replaced that, because the freeze had no
- *      upper bound: a prompt a human sits on for ten minutes froze row N for
- *      ten minutes, and since the escalate that raises the prompt is also
- *      what makes the state read "needs you", the frozen frame was almost
- *      always that one -- a cue contractually bounded by `ESCALATE_FRESH_S`,
- *      pinned on screen indefinitely (reproduced verbatim from a user report:
- *      `remi:18766 website:main | no clients | needs you`, unchanged across
- *      20 simulated minutes and a phone attaching). The quiescence gate is
- *      strictly stronger per-write -- the freeze still permitted its onset
- *      paint mid-render, this permits nothing mid-render -- and it lets the
- *      bar stay current in exactly the window where a human is deliberating
- *      and the PTY is idle. The transition back OUT still forces a paint (see
- *      `resumed`) since the dialog may have redrawn row N while it owned the
- *      screen; the transition IN no longer needs one, because the bar no
- *      longer stops.
+ *   1. **Removed in #1038.** It was a blanket freeze: `render()` no-opped for
+ *      as long as `hasLiveQuestions()` reported a pending question, painting
+ *      once on the transition in. It had no upper bound -- a prompt a human
+ *      sits on for ten minutes froze row N for ten minutes -- and since the
+ *      escalate that raises a prompt is also what sets the state to
+ *      "needs you", the frozen frame was almost always a cue contractually
+ *      bounded by `ESCALATE_FRESH_S`, pinned on screen indefinitely
+ *      (reproduced verbatim from a user report: `remi:18766 website:main |
+ *      no clients | needs you`, unchanged across 20 simulated minutes and a
+ *      phone attaching). It was also redundant: #942's boundary + quiescence
+ *      gates landed two hours after it and are what actually make the hazard
+ *      above structurally impossible.
+ *
+ *      The `onset`/`resumed` edges survive it (see `render()`), because the
+ *      dialog can redraw row N while it owns the screen and Claude's native
+ *      statusLine disappears entirely while one is open.
+ *
+ *      **Do not replace it with a question-scoped quiescence gate.** #1038's
+ *      own first attempt did exactly that -- made `isQuiescent()` hard while
+ *      a question was live -- on the theory that a deliberating human leaves
+ *      the PTY quiet. False, and already recorded here: a held permission
+ *      does not idle the PTY, because the TUI spinner keeps animating on its
+ *      own timer (#1026, observed live). Simulated against the real
+ *      `PtyQuiescenceGate` with 150ms spinner frames, `isQuiescent()` never
+ *      became true and the bar painted ZERO times in ten minutes -- worse
+ *      than the freeze, which at least guaranteed its onset paint. Whatever
+ *      suppresses a paint must be bounded by `HEARTBEAT_MS`, never by how
+ *      long a human takes to answer (ADR 0022).
  *   2. A paint whose built escape sequence is byte-identical to the last one
  *      actually written is skipped -- most ticks rewrite identical bytes, and
  *      every write is an exposure window -- but only up to `HEARTBEAT_MS`: an
@@ -242,23 +250,26 @@ export interface StatusBarDeps {
   readonly isEnabled: () => boolean;
   /** True iff the session currently has at least one pending question
    *  (mirrors `hasLiveQuestions` in `question-presence-tracker.ts`, backed by
-   *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`). #932/#1038:
-   *  while this is true, `render()` still paints on the normal cadence but
-   *  every paint must additionally pass `isQuiescent()` -- no heartbeat or
-   *  edge exemption -- so the bar can never paint while Claude is mid-render
-   *  of a prompt, and never goes stale for the (unbounded) time a human takes
-   *  to answer one. Optional; defaults to always-false (no extra gating) so a
-   *  caller that omits it keeps the pre-#932 behavior instead of silently
-   *  losing the bar.
+   *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`).
    *
-   *  Session-wide, not agent-scoped: it is true whenever ANY agent in the
-   *  session has a pending question, so in a concurrent multi-agent session
-   *  (Agent Teams, Task-tool subagents) the freeze can span output from an
-   *  UNRELATED agent that is still actively writing to this same PTY/fd
-   *  while a different agent's question sits open. The protection this
-   *  buys is deliberately biased toward never painting over a real prompt,
-   *  not toward a precise per-agent freeze window -- see #932's PR
-   *  discussion for the full reasoning on why that tradeoff was kept. */
+   *  Since #1038 this gates only the `onset`/`resumed` edge paints -- it no
+   *  longer suppresses anything. What it says about staleness is therefore
+   *  just what the rest of `render()` says: a changed status paints as soon
+   *  as the PTY is quiescent, and at worst within `HEARTBEAT_MS` regardless.
+   *  Deliberately NOT "the bar is always current": while Claude is streaming,
+   *  row N can lag by up to `HEARTBEAT_MS`. Optional; defaults to
+   *  always-false so a caller that omits it simply never sees an edge paint.
+   *
+   *  Session-wide, not agent-scoped: true whenever ANY agent in the session
+   *  has a pending question. Under the old freeze that was load-bearing and
+   *  costly -- an UNRELATED agent's question froze the bar while this one
+   *  streamed. Now it only means an edge paint can fire for a question the
+   *  user is not looking at, which costs one redundant write. The reason it
+   *  matters more than it looks: a concurrent multi-agent session (Agent
+   *  Teams, Task-tool subagents) keeps the PTY busy for the whole life of
+   *  another agent's question, which is exactly the case that makes any
+   *  quiescence-scoped suppression here starve. See the module doc's
+   *  protection 1. */
   readonly hasLiveQuestions?: () => boolean;
   /** #932 durable fix, HARD gate: true iff a write right now would NOT land
    *  inside an unterminated Claude escape sequence -- backed by
@@ -281,14 +292,12 @@ export interface StatusBarDeps {
    *  it is meant to capture. Only a routine (content-changed,
    *  non-edge/non-heartbeat) paint waits on this.
    *
-   *  #1038: those exceptions are themselves suspended while
-   *  `hasLiveQuestions()` is true. There this gate is hard, because it is
-   *  what took over from the old blanket freeze -- see protection 1 in the
-   *  module doc. Optional; defaults to always-true, same fail-open pattern as
-   *  the other predicates here. Note the fail-open interaction: a caller that
-   *  omits BOTH this and `hasLiveQuestions` gets the pre-#932 bar, which is
-   *  the documented behavior for tests and for a bar not wired to a PTY
-   *  forwarder. */
+   *  Those exceptions are what bound staleness, and #1038 is the receipt for
+   *  why they must never be conditioned on a question being open: a held
+   *  permission keeps the TUI spinner animating (#1026), so scoping them that
+   *  way starves this gate for the entire life of the prompt. Measured: zero
+   *  paints in ten minutes. Optional; defaults to always-true, same fail-open
+   *  pattern as the other predicates here. */
   readonly isQuiescent?: () => boolean;
   /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
   readonly writeToFd?: (fd: number, data: string) => void;
@@ -311,12 +320,12 @@ export interface StatusBarDeps {
  * last one written AND less than `HEARTBEAT_MS` has passed since the last
  * write -- so a byte-identical status (the common case) mostly costs no
  * write, while the DECSTBM re-assertion `buildBarSequence` depends on still
- * happens at least every `HEARTBEAT_MS` regardless. While a question is
- * live, the cadence is unchanged but each paint must also find the PTY
- * quiescent (#1038), so the bar tracks a long-open prompt instead of
- * freezing on the frame that raised it. `stop()` clears the row and halts
- * the loop. All draws are no-ops unless `isEnabled()` and a live fd and
- * enough rows.
+ * happens at least every `HEARTBEAT_MS` regardless. A live question no
+ * longer changes any of that (#1038 removed the freeze), so the bar tracks a
+ * long-open prompt instead of freezing on the frame that raised it, with
+ * staleness bounded by `HEARTBEAT_MS` even while Claude streams. `stop()`
+ * clears the row and halts the loop. All draws are no-ops unless
+ * `isEnabled()` and a live fd and enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -341,10 +350,10 @@ export class StatusBar {
    *  to detect both transitions -- INTO "live" and back OUT (edge, not
    *  level) -- see `render()` for why each edge forces a fresh paint. Reset
    *  by `stop()` so a restart starts from "not live" again. Still edge-
-   *  tracked after #1038 even though the bar no longer freezes between the
-   *  edges: `resumed` remains load-bearing (the dialog can redraw row N
-   *  while it owns the screen, so the physical row cannot be trusted to
-   *  match `lastRendered` once it closes). */
+   *  tracked after #1038 removed the freeze between the edges: `resumed`
+   *  remains load-bearing (the dialog can redraw row N while it owns the
+   *  screen, so the physical row cannot be trusted to match `lastRendered`
+   *  once it closes). */
   private wasQuestionLive = false;
   /** Set by `notifyScrollRegionReset()`; cleared only once a write actually
    *  lands. #932: the ESC[r bonus signal -- if `isBoundaryClean()` refuses
@@ -424,10 +433,10 @@ export class StatusBar {
   }
 
   /** Paint the reserved row now. Safe no-op when disabled / detached / no
-   *  room / a dirty escape-sequence boundary. While a question is live
-   *  (#932, #1038), the normal cadence continues but every paint -- forced
-   *  ones included -- must also find the PTY quiescent; see the
-   *  `onset`/`resumed` comment below and protection 1 in the module doc. */
+   *  room / a dirty escape-sequence boundary. A live question suppresses
+   *  nothing (#1038 removed the freeze); it only produces the `onset` and
+   *  `resumed` edge paints below. See protection 1 in the module doc for why
+   *  it must not gate anything else. */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
     // fd/room/boundary checks come BEFORE hasLiveQuestions() is read and
@@ -467,9 +476,11 @@ export class StatusBar {
     // transition back out; both skip the dedup below so the bar re-paints at
     // each edge. `resumed` is the one that is load-bearing: the dialog may
     // have redrawn or consumed row N while it owned the screen, so the
-    // physical row cannot be trusted to still match `lastRendered`. Neither
-    // edge escapes the quiescence gate while a question is live (#1038) --
-    // the edges say "don't dedup this", never "write regardless."
+    // physical row cannot be trusted to still match `lastRendered`. Both
+    // edges bypass the dedup AND the soft quiescence gate below, exactly as
+    // the heartbeat does -- an edge that waited on quiescence would never
+    // fire during a held permission, whose spinner keeps the PTY busy for
+    // the whole prompt (#1026, and see the module doc's protection 1).
     const onset = questionLive && !wasLive;
     const resumed = !questionLive && wasLive;
     // The whole draw stays inside the try: an exception escaping into the
@@ -493,31 +504,30 @@ export class StatusBar {
       // window": it cannot -- the heartbeat is exempt from the soft gate,
       // so it still fires within HEARTBEAT_MS of the last write regardless
       // of how busy the PTY is, same as before this fix.
-      const forced = onset || resumed || heartbeatDue || this.forceRepaintPending;
+      const bypassesQuiescence = onset || resumed || heartbeatDue || this.forceRepaintPending;
       // #932 protection 2 (unchanged): skip the write when nothing changed
       // since the last successful paint, UNLESS this is one of the forced
       // paths above.
-      if (!forced && sequence === this.lastRendered) return;
+      if (!bypassesQuiescence && sequence === this.lastRendered) return;
       // #932 durable fix, SOFT gate: a routine paint (content changed, none
       // of the forced reasons above) additionally waits for PTY quiescence
       // -- reduces "mode 2" exposure (a paint landing inside a save/restore
       // pair that spans a quiet gap). See `isQuiescent`'s doc for why this
       // check does not apply to the forced paths.
       //
-      // #1038: while a question is live the gate applies to EVERY paint,
-      // forced ones included -- that is what replaced the old blanket freeze
-      // (`if (questionLive && !onset) return;`). The freeze was written
-      // before the quiescence/boundary scanner existed and outlived it: a
-      // prompt a human sits on for ten minutes froze the bar for ten
-      // minutes, and because the escalate that raises the prompt is also
-      // what makes the state read "needs you", the frozen frame was almost
-      // always that one -- a cue whose whole contract is that it decays
-      // after ESCALATE_FRESH_S, pinned on screen indefinitely. Waiting on
-      // quiescence gives the prompt strictly stronger protection than the
-      // freeze did per-write (nothing paints while Claude is mid-render),
-      // while a human deliberating leaves the PTY quiet, which is exactly
-      // when the bar is free to stay current.
-      if ((questionLive || !forced) && !this.isQuiescent()) return;
+      // #1038 deliberately does NOT add a question-scoped exception here.
+      // The first attempt did -- it made this gate hard while a question was
+      // live, on the theory that a human deliberating leaves the PTY quiet.
+      // That theory is false and this repo had already recorded why: a held
+      // permission does not idle the PTY, because Claude's TUI spinner keeps
+      // animating on its own timer (#1026, observed live; see
+      // `attach-client.ts`'s `renderQuestionBanner`). Simulated against the
+      // real `PtyQuiescenceGate` with 150ms spinner frames, `isQuiescent()`
+      // never once became true and the bar painted ZERO times in ten
+      // minutes -- strictly worse than the freeze it replaced, which at
+      // least guaranteed the onset paint. Liveness here must be bounded by
+      // `HEARTBEAT_MS`, never by how long a human takes to answer.
+      if (!bypassesQuiescence && !this.isQuiescent()) return;
       this.writeToFd(fd, sequence);
       this.lastRendered = sequence;
       this.lastWriteAtMs = nowMs;

--- a/packages/daemon/src/cli/status-bar.ts
+++ b/packages/daemon/src/cli/status-bar.ts
@@ -35,14 +35,26 @@
  * own escape sequences (the DECSC/DECRC pair above shares Claude's own
  * cursor-save slot -- 166/421 occurrences in the installed binary). PR #933
  * did not fix that; it only cut how often a paint is attempted:
- *   1. `render()` no-ops while `hasLiveQuestions()` reports a pending
- *      question -- except for one fresh paint on the transition INTO that
- *      state (see `render()`'s `onset`), so the bar is current the moment
- *      Claude's native statusLine (#560) disappears for an AskUserQuestion
- *      dialog, then freezes rather than risk a later paint landing
- *      mid-render. One more forced paint on the transition back OUT (see
- *      `resumed`) recovers row N before normal cadence resumes, since the
- *      dialog may have redrawn it while it owned the screen.
+ *   1. While `hasLiveQuestions()` reports a pending question, EVERY paint
+ *      waits for PTY quiescence: `isQuiescent()` is promoted to a hard gate
+ *      there, with none of the exemptions the heartbeat and the onset/resumed
+ *      edges otherwise get (see `render()`). Originally (#933) this was a
+ *      blanket freeze -- one paint on the transition INTO the state, then
+ *      nothing until it ended. #1038 replaced that, because the freeze had no
+ *      upper bound: a prompt a human sits on for ten minutes froze row N for
+ *      ten minutes, and since the escalate that raises the prompt is also
+ *      what makes the state read "needs you", the frozen frame was almost
+ *      always that one -- a cue contractually bounded by `ESCALATE_FRESH_S`,
+ *      pinned on screen indefinitely (reproduced verbatim from a user report:
+ *      `remi:18766 website:main | no clients | needs you`, unchanged across
+ *      20 simulated minutes and a phone attaching). The quiescence gate is
+ *      strictly stronger per-write -- the freeze still permitted its onset
+ *      paint mid-render, this permits nothing mid-render -- and it lets the
+ *      bar stay current in exactly the window where a human is deliberating
+ *      and the PTY is idle. The transition back OUT still forces a paint (see
+ *      `resumed`) since the dialog may have redrawn row N while it owned the
+ *      screen; the transition IN no longer needs one, because the bar no
+ *      longer stops.
  *   2. A paint whose built escape sequence is byte-identical to the last one
  *      actually written is skipped -- most ticks rewrite identical bytes, and
  *      every write is an exposure window -- but only up to `HEARTBEAT_MS`: an
@@ -230,14 +242,14 @@ export interface StatusBarDeps {
   readonly isEnabled: () => boolean;
   /** True iff the session currently has at least one pending question
    *  (mirrors `hasLiveQuestions` in `question-presence-tracker.ts`, backed by
-   *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`). #932:
-   *  `render()` paints once on the transition into this being true, then
-   *  freezes for as long as it stays true, then paints once more on the
-   *  transition back out before resuming normal cadence -- so the bar can
-   *  never paint over a live prompt but also never freezes on stale content
-   *  (see `render()`'s `onset` / `resumed`). Optional; defaults to
-   *  always-false (no suppression) so a caller that omits it keeps the
-   *  pre-#932 behavior instead of silently losing the bar.
+   *  `sessionRegistry.getSession(id)?.currentQuestions.size > 0`). #932/#1038:
+   *  while this is true, `render()` still paints on the normal cadence but
+   *  every paint must additionally pass `isQuiescent()` -- no heartbeat or
+   *  edge exemption -- so the bar can never paint while Claude is mid-render
+   *  of a prompt, and never goes stale for the (unbounded) time a human takes
+   *  to answer one. Optional; defaults to always-false (no extra gating) so a
+   *  caller that omits it keeps the pre-#932 behavior instead of silently
+   *  losing the bar.
    *
    *  Session-wide, not agent-scoped: it is true whenever ANY agent in the
    *  session has a pending question, so in a concurrent multi-agent session
@@ -267,8 +279,16 @@ export interface StatusBarDeps {
    *  continuously streaming Claude session could starve the heartbeat's
    *  DECSTBM reassertion or delay an onset/resumed capture past the moment
    *  it is meant to capture. Only a routine (content-changed,
-   *  non-edge/non-heartbeat) paint waits on this. Optional; defaults to
-   *  always-true, same fail-open pattern as the other predicates here. */
+   *  non-edge/non-heartbeat) paint waits on this.
+   *
+   *  #1038: those exceptions are themselves suspended while
+   *  `hasLiveQuestions()` is true. There this gate is hard, because it is
+   *  what took over from the old blanket freeze -- see protection 1 in the
+   *  module doc. Optional; defaults to always-true, same fail-open pattern as
+   *  the other predicates here. Note the fail-open interaction: a caller that
+   *  omits BOTH this and `hasLiveQuestions` gets the pre-#932 bar, which is
+   *  the documented behavior for tests and for a bar not wired to a PTY
+   *  forwarder. */
   readonly isQuiescent?: () => boolean;
   /** Write to the terminal fd. Injectable for tests; defaults to fs.writeSync. */
   readonly writeToFd?: (fd: number, data: string) => void;
@@ -292,11 +312,11 @@ export interface StatusBarDeps {
  * write -- so a byte-identical status (the common case) mostly costs no
  * write, while the DECSTBM re-assertion `buildBarSequence` depends on still
  * happens at least every `HEARTBEAT_MS` regardless. While a question is
- * live, every tick is a no-op EXCEPT the first one after the transition
- * into "live" and the first one after the transition back out, both of
- * which always write (edge-triggered onset/resume paints, not the
- * dedup/heartbeat path). `stop()` clears the row and halts the loop. All
- * draws are no-ops unless `isEnabled()` and a live fd and enough rows.
+ * live, the cadence is unchanged but each paint must also find the PTY
+ * quiescent (#1038), so the bar tracks a long-open prompt instead of
+ * freezing on the frame that raised it. `stop()` clears the row and halts
+ * the loop. All draws are no-ops unless `isEnabled()` and a live fd and
+ * enough rows.
  */
 export class StatusBar {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -320,7 +340,11 @@ export class StatusBar {
    *  `render()` compares this against the current `hasLiveQuestions()` read
    *  to detect both transitions -- INTO "live" and back OUT (edge, not
    *  level) -- see `render()` for why each edge forces a fresh paint. Reset
-   *  by `stop()` so a restart starts from "not live" again. */
+   *  by `stop()` so a restart starts from "not live" again. Still edge-
+   *  tracked after #1038 even though the bar no longer freezes between the
+   *  edges: `resumed` remains load-bearing (the dialog can redraw row N
+   *  while it owns the screen, so the physical row cannot be trusted to
+   *  match `lastRendered` once it closes). */
   private wasQuestionLive = false;
   /** Set by `notifyScrollRegionReset()`; cleared only once a write actually
    *  lands. #932: the ESC[r bonus signal -- if `isBoundaryClean()` refuses
@@ -401,10 +425,9 @@ export class StatusBar {
 
   /** Paint the reserved row now. Safe no-op when disabled / detached / no
    *  room / a dirty escape-sequence boundary. While a question is live
-   *  (#932), paints once on the transition into that state and freezes
-   *  after; paints once more on the transition back out, then resumes
-   *  normal cadence -- see the `onset`/`resumed` comment below for why both
-   *  edges force a fresh paint. */
+   *  (#932, #1038), the normal cadence continues but every paint -- forced
+   *  ones included -- must also find the PTY quiescent; see the
+   *  `onset`/`resumed` comment below and protection 1 in the module doc. */
   render(): void {
     if (this.disabled || !this.isEnabled()) return;
     // fd/room/boundary checks come BEFORE hasLiveQuestions() is read and
@@ -436,23 +459,19 @@ export class StatusBar {
     const questionLive = this.hasLiveQuestions();
     const wasLive = this.wasQuestionLive;
     this.wasQuestionLive = questionLive;
-    // #932 protection 1 is edge-triggered, not level-triggered. Freezing row
-    // N while a question is live is right, but freezing it on WHATEVER was
-    // last painted is wrong: Claude's native statusLine (#560) disappears
-    // entirely while an AskUserQuestion dialog is open, so this bar is
-    // exactly the cue that has to be current the moment that happens -- not
-    // up to `HEARTBEAT_MS` stale. `onset` is true only on the first
-    // render() call after the transition into "live"; it forces one fresh
-    // paint below, capturing the status at that instant. Every later call
-    // while still live hits the early return just below. `resumed` is the
-    // mirror on the way back out: the dialog may have redrawn or consumed
-    // row N while it owned the screen, so the physical row cannot be
-    // trusted to still match `lastRendered` either -- the very first
-    // render() after the question clears also forces a fresh paint, then
-    // normal dedup/heartbeat cadence takes back over.
+    // Claude's native statusLine (#560) disappears entirely while an
+    // AskUserQuestion dialog is open, so this bar is the only cue left --
+    // which is why #932's answer to "don't race the dialog" cannot be "stop
+    // updating." `onset` is true only on the first render() call after the
+    // transition into "live", `resumed` only on the first one after the
+    // transition back out; both skip the dedup below so the bar re-paints at
+    // each edge. `resumed` is the one that is load-bearing: the dialog may
+    // have redrawn or consumed row N while it owned the screen, so the
+    // physical row cannot be trusted to still match `lastRendered`. Neither
+    // edge escapes the quiescence gate while a question is live (#1038) --
+    // the edges say "don't dedup this", never "write regardless."
     const onset = questionLive && !wasLive;
     const resumed = !questionLive && wasLive;
-    if (questionLive && !onset) return;
     // The whole draw stays inside the try: an exception escaping into the
     // setInterval callback would surface as an uncaughtException and could take
     // the wrapper down — the one thing a cosmetic bar must never do. The
@@ -474,17 +493,31 @@ export class StatusBar {
       // window": it cannot -- the heartbeat is exempt from the soft gate,
       // so it still fires within HEARTBEAT_MS of the last write regardless
       // of how busy the PTY is, same as before this fix.
-      const bypassesQuiescence = onset || resumed || heartbeatDue || this.forceRepaintPending;
+      const forced = onset || resumed || heartbeatDue || this.forceRepaintPending;
       // #932 protection 2 (unchanged): skip the write when nothing changed
       // since the last successful paint, UNLESS this is one of the forced
       // paths above.
-      if (!bypassesQuiescence && sequence === this.lastRendered) return;
+      if (!forced && sequence === this.lastRendered) return;
       // #932 durable fix, SOFT gate: a routine paint (content changed, none
       // of the forced reasons above) additionally waits for PTY quiescence
       // -- reduces "mode 2" exposure (a paint landing inside a save/restore
       // pair that spans a quiet gap). See `isQuiescent`'s doc for why this
       // check does not apply to the forced paths.
-      if (!bypassesQuiescence && !this.isQuiescent()) return;
+      //
+      // #1038: while a question is live the gate applies to EVERY paint,
+      // forced ones included -- that is what replaced the old blanket freeze
+      // (`if (questionLive && !onset) return;`). The freeze was written
+      // before the quiescence/boundary scanner existed and outlived it: a
+      // prompt a human sits on for ten minutes froze the bar for ten
+      // minutes, and because the escalate that raises the prompt is also
+      // what makes the state read "needs you", the frozen frame was almost
+      // always that one -- a cue whose whole contract is that it decays
+      // after ESCALATE_FRESH_S, pinned on screen indefinitely. Waiting on
+      // quiescence gives the prompt strictly stronger protection than the
+      // freeze did per-write (nothing paints while Claude is mid-render),
+      // while a human deliberating leaves the PTY quiet, which is exactly
+      // when the bar is free to stay current.
+      if ((questionLive || !forced) && !this.isQuiescent()) return;
       this.writeToFd(fd, sequence);
       this.lastRendered = sequence;
       this.lastWriteAtMs = nowMs;

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -64,6 +64,10 @@ export interface StatusWriterDeps {
    * earliest boot phase run without it.
    */
   readonly getAttachState?: () => { attached: boolean; queuedCount: number } | null;
+  /** Interval (ms) for `startAttachRefresh`'s pull loop. Default 250 — matches
+   *  the StatusBar's repaint cadence, so the terminal bar and the clients see
+   *  an attach within one tick of each other. Tests override. */
+  readonly refreshMs?: number;
   /**
    * #754: broadcast the freshly-flushed snapshot to connected clients
    * (`remi_status`), on the same debounce as the disk write. Optional and
@@ -82,6 +86,8 @@ export class StatusWriter {
   private attachStateErrorLogged = false;
   private broadcastErrorLogged = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
+  /** Handle for `startAttachRefresh`'s pull loop, or null when not started. */
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(initial: RemiStatus, deps: StatusWriterDeps) {
     this.status = { ...initial };
@@ -100,6 +106,39 @@ export class StatusWriter {
   update(patch: Partial<RemiStatus>): void {
     Object.assign(this.status, patch);
     this.schedule();
+  }
+
+  /**
+   * Re-read the pull-based fields (`attached` / `queuedCount`) and schedule a
+   * flush only when one of them actually changed.
+   *
+   * `getAttachState` is pulled inside `write()` (#755), which is right about
+   * the VALUE but says nothing about WHEN a write happens — and no attach or
+   * detach path calls `update()`. So before this existed, a phone attaching
+   * changed nothing anybody could see: the reserved-row bar, `status-<PORT>.json`
+   * and the `remi_status` broadcast all kept reading "no clients" until some
+   * unrelated status change happened to trigger a flush.
+   *
+   * Polled (see `startAttachRefresh`) rather than called from each attach site
+   * on purpose: attach/detach happens in `connection-events`,
+   * `resume-session-events`, `session-events` and the orphan timeout, and a cue
+   * that is only correct on the paths someone remembered to wire is exactly the
+   * failure [ADR 0020](../../../.context/decisions/0020-client-status-cue-totality.md)
+   * is about. A pull that is total over every path costs one `Set.size` read.
+   */
+  refresh(): void {
+    if (this.pullAttachState()) this.schedule();
+  }
+
+  /**
+   * Start the pull-refresh loop (idempotent). The timer is `unref`'d so it can
+   * never keep the process alive, and it only reaches disk or the wire when
+   * `refresh()` finds a real change, so an idle session writes nothing.
+   */
+  startAttachRefresh(): void {
+    if (this.refreshTimer) return;
+    this.refreshTimer = setInterval(() => this.refresh(), this.deps.refreshMs ?? 250);
+    this.refreshTimer.unref?.();
   }
 
   /**
@@ -163,6 +202,10 @@ export class StatusWriter {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
     try {
       fs.unlinkSync(this.deps.getTargetFile());
     } catch {
@@ -178,23 +221,40 @@ export class StatusWriter {
     }, this.deps.debounceMs);
   }
 
-  private write(): void {
-    // #755: refresh the attach-state fields from the registry at flush time so
-    // every scheduled write (status changes, evals, connection churn) carries
-    // current values; a pull here beats scattering updates over every attach /
-    // disconnect / auto-promotion site.
+  /**
+   * Pull `attached` / `queuedCount` from the registry into the in-memory
+   * status. Returns true iff either value changed, which is what lets
+   * `refresh()` poll cheaply without writing on every tick.
+   *
+   * A read failure is logged once per streak on its own latch: a stuck
+   * attach-state read must not mute the first report of a broken `remi_status`
+   * broadcast (which the #754 attach status bar depends on), or vice versa.
+   */
+  private pullAttachState(): boolean {
     try {
       const attach = this.deps.getAttachState?.();
-      if (attach) {
-        this.status.attached = attach.attached;
-        this.status.queuedCount = attach.queuedCount;
-      }
+      if (!attach) return false;
+      const changed =
+        this.status.attached !== attach.attached || this.status.queuedCount !== attach.queuedCount;
+      this.status.attached = attach.attached;
+      this.status.queuedCount = attach.queuedCount;
+      return changed;
     } catch (err) {
       if (!this.attachStateErrorLogged) {
         this.deps.writeLog(`[error] Status attach-state read failed: ${err}`);
         this.attachStateErrorLogged = true;
       }
+      return false;
     }
+  }
+
+  private write(): void {
+    // #755: refresh the attach-state fields from the registry at flush time so
+    // every scheduled write (status changes, evals, connection churn) carries
+    // current values; a pull here beats scattering updates over every attach /
+    // disconnect / auto-promotion site. `refresh()` polls the same pull so an
+    // attach that changes nothing else still reaches the bar and the clients.
+    this.pullAttachState();
     // #754: clients get the same debounced snapshot the disk gets, regardless
     // of whether the file write itself is enabled.
     try {

--- a/packages/daemon/src/cli/status-writer.ts
+++ b/packages/daemon/src/cli/status-writer.ts
@@ -64,10 +64,6 @@ export interface StatusWriterDeps {
    * earliest boot phase run without it.
    */
   readonly getAttachState?: () => { attached: boolean; queuedCount: number } | null;
-  /** Interval (ms) for `startAttachRefresh`'s pull loop. Default 250 — matches
-   *  the StatusBar's repaint cadence, so the terminal bar and the clients see
-   *  an attach within one tick of each other. Tests override. */
-  readonly refreshMs?: number;
   /**
    * #754: broadcast the freshly-flushed snapshot to connected clients
    * (`remi_status`), on the same debounce as the disk write. Optional and
@@ -86,8 +82,6 @@ export class StatusWriter {
   private attachStateErrorLogged = false;
   private broadcastErrorLogged = false;
   private timer: ReturnType<typeof setTimeout> | null = null;
-  /** Handle for `startAttachRefresh`'s pull loop, or null when not started. */
-  private refreshTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(initial: RemiStatus, deps: StatusWriterDeps) {
     this.status = { ...initial };
@@ -115,30 +109,22 @@ export class StatusWriter {
    * `getAttachState` is pulled inside `write()` (#755), which is right about
    * the VALUE but says nothing about WHEN a write happens — and no attach or
    * detach path calls `update()`. So before this existed, a phone attaching
-   * changed nothing anybody could see: the reserved-row bar, `status-<PORT>.json`
-   * and the `remi_status` broadcast all kept reading "no clients" until some
-   * unrelated status change happened to trigger a flush.
+   * changed nothing anybody could see: the reserved-row bar,
+   * `status-<PORT>.json`, the attach client and the app all kept reading
+   * "no clients" until some unrelated status change happened to trigger a
+   * flush (#1038).
    *
-   * Polled (see `startAttachRefresh`) rather than called from each attach site
-   * on purpose: attach/detach happens in `connection-events`,
-   * `resume-session-events`, `session-events` and the orphan timeout, and a cue
-   * that is only correct on the paths someone remembered to wire is exactly the
-   * failure [ADR 0020](../../../.context/decisions/0020-client-status-cue-totality.md)
-   * is about. A pull that is total over every path costs one `Set.size` read.
+   * Driven by `SessionRegistry`'s `onAttachStateChanged`, which is emitted
+   * from the only two lines that mutate `attachedConnections` — so it is
+   * total over every attach path by construction rather than by anyone
+   * remembering to wire one, which is the requirement
+   * [ADR 0020](../../../../.context/decisions/0020-client-status-cue-totality.md)
+   * states. Safe to call from anywhere and cheap when nothing moved: it
+   * schedules only on a real change, so a spurious call costs one
+   * `Set.size` read.
    */
   refresh(): void {
     if (this.pullAttachState()) this.schedule();
-  }
-
-  /**
-   * Start the pull-refresh loop (idempotent). The timer is `unref`'d so it can
-   * never keep the process alive, and it only reaches disk or the wire when
-   * `refresh()` finds a real change, so an idle session writes nothing.
-   */
-  startAttachRefresh(): void {
-    if (this.refreshTimer) return;
-    this.refreshTimer = setInterval(() => this.refresh(), this.deps.refreshMs ?? 250);
-    this.refreshTimer.unref?.();
   }
 
   /**
@@ -202,10 +188,6 @@ export class StatusWriter {
       clearTimeout(this.timer);
       this.timer = null;
     }
-    if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
-      this.refreshTimer = null;
-    }
     try {
       fs.unlinkSync(this.deps.getTargetFile());
     } catch {
@@ -238,6 +220,12 @@ export class StatusWriter {
         this.status.attached !== attach.attached || this.status.queuedCount !== attach.queuedCount;
       this.status.attached = attach.attached;
       this.status.queuedCount = attach.queuedCount;
+      // Clear the streak so a LATER failure is reported too. Without this the
+      // latch is once-per-process, not once-per-streak as documented, and an
+      // intermittently-throwing registry read (session teardown) would be
+      // silently swallowed for the life of the daemon after the first one --
+      // the same asymmetry `errorLogged` already avoids for the file write.
+      this.attachStateErrorLogged = false;
       return changed;
     } catch (err) {
       if (!this.attachStateErrorLogged) {

--- a/packages/daemon/src/session/session-registry.ts
+++ b/packages/daemon/src/session/session-registry.ts
@@ -83,6 +83,26 @@ export interface SessionRegistryEvents {
    *  that already has an attached connection, which is not a "resume"). */
   onSessionResumed?: (sessionId: UUID, connectionId: UUID) => void;
   /**
+   * `attachedConnections` changed — a connection attached or detached (#1038).
+   *
+   * Distinct from `onSessionResumed`/`onSessionOrphaned`, which fire only on
+   * the zero<->nonzero EDGES. This fires on every membership change, because
+   * the status snapshot's `attached`/`queuedCount` are derived from the set
+   * itself and a consumer cannot reconstruct them from edges alone.
+   *
+   * Emitted from the two lines that own the mutation (`attachConnection`,
+   * `detachConnection`), not from their callers, which is what makes it total
+   * over every attach path — `connection-events`, `resume-session-events`,
+   * `session-events`, the orphan timeout, and anything added later — without
+   * anyone having to remember to wire it. That totality requirement is
+   * [ADR 0020](../../../../.context/decisions/0020-client-status-cue-totality.md);
+   * before it existed, `StatusWriter` learned about an attach only when some
+   * unrelated status change happened to trigger a flush, so a connected phone
+   * read as "no clients" on the bar, in `status-<PORT>.json`, in the attach
+   * client and in the app.
+   */
+  onAttachStateChanged?: (sessionId: UUID) => void;
+  /**
    * The session's pending-question set changed: one was added, one was
    * resolved (from any surface — terminal, push, web), or all were cleared
    * (#786/#787). Fires with the FULL current set (not a delta) from
@@ -341,6 +361,11 @@ export class SessionRegistry {
     // Mark all as delivered
     this.session.lastDeliveredIndex = this.session.messageHistory.length - 1;
 
+    // #1038: before the edge-only events below, so a consumer that derives
+    // state from the SET (the status snapshot) is current by the time an
+    // edge consumer reacts to it.
+    this.events.onAttachStateChanged?.(sessionId);
+
     if (isResume) {
       this.events.onSessionResumed?.(sessionId, connectionId);
     }
@@ -375,6 +400,12 @@ export class SessionRegistry {
 
     const { sessionId } = this.session;
     this.session.attachedConnections.delete(connectionId);
+
+    // #1038: BEFORE the still-attached early return below. A detach that
+    // leaves others attached is not an orphan, but it did change the set, and
+    // `queuedCount`/`attached` are derived from the set -- returning first
+    // would make this event edge-only, which is the bug it exists to fix.
+    this.events.onAttachStateChanged?.(sessionId);
 
     // Other connections are still attached; the session is not orphaned.
     if (this.session.attachedConnections.size > 0) {

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -646,7 +646,7 @@ describe('runAttachClient', () => {
       host: 'localhost',
       port: TEST_PORT + 12,
       sessionId: targetSessionId,
-      timeout: 3000,
+      timeout: 6000,
       outputFd,
       statusBarEligible: true,
     });
@@ -665,8 +665,9 @@ describe('runAttachClient', () => {
   // "no question" for a session that already has one live. Proves the
   // mechanism end to end on the REAL attach-client code path (not a
   // StatusBar unit test): the deferred first paint doubling as the onset
-  // paint, freeze through a status change made during the freeze, forced
-  // paint reflecting that change on the transition back out.
+  // paint, and — since #1038 removed the freeze — the bar continuing to
+  // track status for as long as the question stays open, with raw_pty_output
+  // flowing the whole time so the PTY is never quiescent.
   test('the bar keeps tracking status while a question (question_snapshot) stays live', async () => {
     setupOutput();
     const targetSessionId = generateId();
@@ -707,9 +708,30 @@ describe('runAttachClient', () => {
             setTimeout(() => {
               ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [questionId])));
             }, 150);
+            // #1038: keep the PTY BUSY for the whole question, the way a
+            // held permission's TUI spinner does (#1026). Without this the
+            // gate's `lastObservedAtMs` stays null, `isQuiescent()` is
+            // trivially true, and this test cannot tell a working bar from
+            // one that only paints when Claude falls silent -- which is
+            // exactly how #1038's own broken first attempt passed its suite.
+            // 150ms is well inside QUIESCENCE_MS (500), so quiescence is
+            // NEVER reached while the question is open. That makes the
+            // heartbeat the only thing that can carry a status change to the
+            // row, which is precisely the bound being asserted below.
+            const spinnerTimer = setInterval(() => {
+              ws.send(
+                serialize(
+                  createRawPtyOutput(
+                    targetSessionId as UUID,
+                    Buffer.from('\r* Running...').toString('base64'),
+                  ),
+                ),
+              );
+            }, 150);
+            setTimeout(() => clearInterval(spinnerTimer), 3400);
             // Status changes to B ("thinking") WHILE the question is still
-            // live -- #1038: this must reach the row now, not when the
-            // question eventually resolves.
+            // live -- #1038: this must reach the row before the question
+            // resolves, not because of it.
             setTimeout(() => {
               ws.send(
                 serialize(
@@ -720,52 +742,58 @@ describe('runAttachClient', () => {
                 ),
               );
             }, 600);
-            // Question resolves, well ahead of the next timer tick.
+            // Question resolves only AFTER the peek below, so anything the
+            // row shows at that point was painted with the prompt still open.
             setTimeout(() => {
               ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [])));
-            }, 1200);
-            setTimeout(() => ws.close(), 1700);
+            }, 3000);
+            setTimeout(() => ws.close(), 3400);
           }
         },
         close() {},
       },
     });
 
-    // Peek at t=900 -- after the status-B send at t=600, well ahead of the
-    // resolve at t=1200 -- via a separate read handle so the write fd stays
-    // open. Reading MID-question is the whole point: a final-count assertion
-    // alone cannot tell "tracked it while the prompt was open" (the fix)
-    // apart from "caught up once the prompt closed" (the bug).
+    // Peek at t=2600: after status B (t=600) and after the first heartbeat
+    // past the bar's first paint (~t=150 + HEARTBEAT_MS = ~2150), but well
+    // before the question resolves (t=3000). Reading MID-question is the
+    // whole point -- a final-count assertion alone cannot tell "tracked it
+    // while the prompt was open" (the fix) from "caught up once the prompt
+    // closed" (the bug).
     let midQuestionOutput = '';
     setTimeout(() => {
       midQuestionOutput = fs.readFileSync(outputPath, 'utf-8');
-    }, 900);
+    }, 2600);
 
     await runAttachClient({
       host: 'localhost',
       port: TEST_PORT + 13,
       sessionId: targetSessionId,
-      timeout: 3000,
+      timeout: 6000,
       outputFd,
       statusBarEligible: true,
     });
 
     const midBars = [...midQuestionOutput.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
     // The bar's first-ever paint is deferred until question_snapshot arrives
-    // and so doubles as the onset paint (status A, stored earlier); the
-    // status-B change at t=600 then repaints on the next ~250ms tick, with
-    // the question still open. Before #1038 this row still read "idle" here
-    // and stayed that way for as long as the prompt did.
+    // and so doubles as the onset paint (status A, stored earlier). With the
+    // PTY never quiescent, the status-B change reaches the row on the
+    // HEARTBEAT (~2s), not the 250ms tick -- staleness while Claude streams
+    // is bounded by HEARTBEAT_MS, which is the honest guarantee. Before
+    // #1038 this row read "idle" here and stayed that way for as long as the
+    // prompt did.
     expect(midBars[0]).toContain('idle');
     expect(midBars.at(-1)).toContain('thinking');
 
     const output = readOutput();
     const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
     expect(bars.at(-1)).toContain('thinking');
-    // The dedup still holds: an unchanged status is not repainted on every
-    // one of the ~250ms ticks across this 1.7s run, only on the two status
-    // values plus bounded HEARTBEAT_MS re-assertions.
-    expect(bars.length).toBeLessThan(7);
+    // The dedup still holds. ~3.25s of bar life at a 250ms cadence is ~13
+    // ticks; expected paints are the onset, one or two heartbeats and the
+    // resumed paint, so a bound of 5 proves ticks were deduped rather than
+    // painted. A bound loose enough to cover every tick could not fail if
+    // the dedup were deleted outright, which is the regression it guards.
+    expect(bars.length).toBeLessThanOrEqual(5);
   });
 
   // #932: an older daemon that never sends question_snapshot must not lose
@@ -809,7 +837,7 @@ describe('runAttachClient', () => {
       host: 'localhost',
       port: TEST_PORT + 14,
       sessionId: targetSessionId,
-      timeout: 3000,
+      timeout: 6000,
       outputFd,
       statusBarEligible: true,
     });
@@ -903,7 +931,7 @@ describe('runAttachClient', () => {
       host: 'localhost',
       port: TEST_PORT + 15,
       sessionId: targetSessionId,
-      timeout: 3000,
+      timeout: 6000,
       outputFd,
       statusBarEligible: true,
     });
@@ -998,7 +1026,7 @@ describe('runAttachClient', () => {
       host: 'localhost',
       port: TEST_PORT + 16,
       sessionId: targetSessionId,
-      timeout: 3000,
+      timeout: 6000,
       outputFd,
       statusBarEligible: true,
     });

--- a/packages/daemon/tests/cli/attach-client.test.ts
+++ b/packages/daemon/tests/cli/attach-client.test.ts
@@ -667,7 +667,7 @@ describe('runAttachClient', () => {
   // StatusBar unit test): the deferred first paint doubling as the onset
   // paint, freeze through a status change made during the freeze, forced
   // paint reflecting that change on the transition back out.
-  test('a live question (question_snapshot) suppresses the bar, then the resumed paint reflects a status change made during the freeze', async () => {
+  test('the bar keeps tracking status while a question (question_snapshot) stays live', async () => {
     setupOutput();
     const targetSessionId = generateId();
     const questionId = generateId() as UUID;
@@ -708,7 +708,8 @@ describe('runAttachClient', () => {
               ws.send(serialize(createQuestionSnapshot(targetSessionId as UUID, [questionId])));
             }, 150);
             // Status changes to B ("thinking") WHILE the question is still
-            // live -- must not paint until the freeze ends.
+            // live -- #1038: this must reach the row now, not when the
+            // question eventually resolves.
             setTimeout(() => {
               ws.send(
                 serialize(
@@ -730,18 +731,14 @@ describe('runAttachClient', () => {
       },
     });
 
-    // Peek the output mid-freeze (t=900: after the status-B send at t=600,
-    // well ahead of the resolve at t=1200), via a separate read handle so
-    // the write fd stays open. This is what actually proves suppression is
-    // holding rather than merely coinciding on a final count: if
-    // hasLiveQuestions() were broken (e.g. wired to a constant), the status
-    // change at t=600 would have produced its own repaint by the very next
-    // ~250ms tick, long before t=900 -- and the final bars.length could
-    // still land on 2 by coincidence (a plain dedup repaint at t=600 plus
-    // nothing else), masking the regression.
-    let midFreezeOutput = '';
+    // Peek at t=900 -- after the status-B send at t=600, well ahead of the
+    // resolve at t=1200 -- via a separate read handle so the write fd stays
+    // open. Reading MID-question is the whole point: a final-count assertion
+    // alone cannot tell "tracked it while the prompt was open" (the fix)
+    // apart from "caught up once the prompt closed" (the bug).
+    let midQuestionOutput = '';
     setTimeout(() => {
-      midFreezeOutput = fs.readFileSync(outputPath, 'utf-8');
+      midQuestionOutput = fs.readFileSync(outputPath, 'utf-8');
     }, 900);
 
     await runAttachClient({
@@ -753,21 +750,22 @@ describe('runAttachClient', () => {
       statusBarEligible: true,
     });
 
-    const midBars = [...midFreezeOutput.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
-    expect(midBars.length).toBe(1); // still frozen: only the onset paint so far
-    expect(midBars[0]).toContain('idle'); // not yet "thinking" -- the freeze held
+    const midBars = [...midQuestionOutput.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
+    // The bar's first-ever paint is deferred until question_snapshot arrives
+    // and so doubles as the onset paint (status A, stored earlier); the
+    // status-B change at t=600 then repaints on the next ~250ms tick, with
+    // the question still open. Before #1038 this row still read "idle" here
+    // and stayed that way for as long as the prompt did.
+    expect(midBars[0]).toContain('idle');
+    expect(midBars.at(-1)).toContain('thinking');
 
     const output = readOutput();
     const bars = [...output.matchAll(/\x1b\[7m([^\x1b]*)\x1b\[0m/g)].map((m) => m[1]);
-    // Exactly two real paints total: the bar's first-ever paint (deferred
-    // until question_snapshot arrives, which doubles as the onset paint
-    // since the question is already live by then -- status A, stored
-    // earlier), and the resumed paint on the transition back out (status B,
-    // reflecting the change made during the freeze). Every tick while
-    // frozen wrote nothing, despite the status having changed mid-freeze.
-    expect(bars.length).toBe(2);
-    expect(bars[0]).toContain('idle');
-    expect(bars[1]).toContain('thinking');
+    expect(bars.at(-1)).toContain('thinking');
+    // The dedup still holds: an unchanged status is not repainted on every
+    // one of the ~250ms ticks across this 1.7s run, only on the two status
+    // values plus bounded HEARTBEAT_MS re-assertions.
+    expect(bars.length).toBeLessThan(7);
   });
 
   // #932: an older daemon that never sends question_snapshot must not lose

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { PtyQuiescenceGate } from '../../src/cli/pty-quiescence-gate.ts';
 import {
   HEARTBEAT_MS,
   MAX_RENDER_ERRORS,
@@ -358,31 +359,41 @@ describe('StatusBar', () => {
     expect(writes[2]).toContain('2 client(s)');
   });
 
-  test('a live question makes quiescence a HARD gate: no paint while the PTY is busy', () => {
-    // This is what replaced the freeze. A routine paint already waits for
-    // quiescence; while a question is live EVERY paint does, including the
-    // forced ones (onset here, plus the heartbeat below) -- so nothing can
-    // land mid-render of the prompt.
-    let quiescent = false;
-    let connections = 0;
+  test('a NEVER-quiescent PTY still paints while a question is live, bounded by HEARTBEAT_MS', () => {
+    // The regression that #1038's own first attempt introduced, and the
+    // single most important test in this file. That attempt made
+    // `isQuiescent()` hard while a question was live, reasoning that a
+    // deliberating human leaves the PTY quiet. A held permission does NOT
+    // idle the PTY -- the TUI spinner keeps animating on its own timer
+    // (#1026, observed live) -- so `isQuiescent()` stayed false for the
+    // whole prompt and the bar painted ZERO times. Worse than the freeze it
+    // replaced, which at least guaranteed its onset paint.
+    //
+    // isQuiescent is pinned false for the entire run: whatever gating exists
+    // here, liveness must come from the heartbeat, never from the PTY going
+    // quiet.
+    let nowMs = NOW_MS;
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
-      isQuiescent: () => quiescent,
-      getStatus: () => mkStatus({ connections: connections++ }),
+      isQuiescent: () => false,
+      isBoundaryClean: () => true,
+      now: () => nowMs,
     });
-    bar.render(); // onset, but PTY busy: refused
-    bar.render();
-    expect(writes).toHaveLength(0);
-    quiescent = true; // the human is deliberating; Claude has gone quiet
-    bar.render();
+    bar.render(); // onset: must paint even mid-spinner
     expect(writes).toHaveLength(1);
+    for (let i = 0; i < 10; i++) {
+      nowMs += HEARTBEAT_MS;
+      bar.render();
+    }
+    expect(writes).toHaveLength(11); // one per heartbeat, never starved
   });
 
-  test('a live question suspends the heartbeat exemption from the quiescence gate', () => {
-    // The heartbeat normally bypasses quiescence so a streaming session
-    // cannot starve the DECSTBM re-assertion. While a question is live that
-    // exemption is off: re-asserting the scroll region is not worth a write
-    // landing inside the dialog's own render.
+  test('a live question does NOT suspend the heartbeat exemption from the quiescence gate', () => {
+    // The heartbeat bypasses quiescence so a streaming session cannot starve
+    // the DECSTBM re-assertion -- and that exemption must NOT be conditioned
+    // on whether a question is open, because a held permission is precisely
+    // when the PTY streams indefinitely. Mirrors the same-named test in the
+    // no-question case, so the two cannot drift apart again.
     let nowMs = NOW_MS;
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
@@ -390,9 +401,25 @@ describe('StatusBar', () => {
       now: () => nowMs,
     });
     bar.render();
+    expect(writes).toHaveLength(1);
     nowMs += HEARTBEAT_MS;
     bar.render();
-    expect(writes).toHaveLength(0);
+    expect(writes).toHaveLength(2);
+  });
+
+  test('a live question does not stop a status change from reaching the row', () => {
+    // The user-visible half: content varies on every getStatus() read, so
+    // this measures repaints rather than a dedup coincidence.
+    let connections = 0;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      getStatus: () => mkStatus({ connections: connections++ }),
+    });
+    bar.render(); // onset
+    bar.render();
+    bar.render();
+    expect(writes).toHaveLength(3);
+    expect(writes[2]).toContain('2 client(s)');
   });
 
   test('a "needs you" cue still decays while the question that raised it is open', () => {
@@ -565,20 +592,21 @@ describe('StatusBar — #932 durable fix (quiescence + clean-boundary gate)', ()
     expect(writes).toHaveLength(1);
   });
 
-  test('the onset paint does NOT bypass the quiescence gate (it implies a live question)', () => {
-    // #1038 flipped this: onset used to fire even mid-burst. Onset only
-    // happens when a question just went live, and that is precisely the
-    // window where quiescence is a hard requirement -- so the capture waits
-    // for the next quiet tick rather than racing the dialog's own render.
-    let quiescent = false;
+  test('the onset paint bypasses the quiescence gate but still honors the boundary gate', () => {
+    // Onset must fire the instant a question goes live, even mid-burst --
+    // see status-bar.ts's HEARTBEAT_MS doc for why the soft gate has
+    // documented exceptions.
+    //
+    // #1038 tried to remove this exemption (onset implies a live question,
+    // and that attempt made quiescence hard there). It must stay: a held
+    // permission keeps the TUI spinner animating (#1026), so an onset that
+    // waited for quiescence would never fire at all -- the bar would keep
+    // whatever it painted BEFORE the escalate, for the whole prompt.
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
-      isQuiescent: () => quiescent,
+      isQuiescent: () => false,
       isBoundaryClean: () => true,
     });
-    bar.render();
-    expect(writes).toHaveLength(0);
-    quiescent = true;
     bar.render();
     expect(writes).toHaveLength(1);
   });
@@ -694,6 +722,113 @@ describe('StatusBar — #932 durable fix (quiescence + clean-boundary gate)', ()
 
   test('omitting isBoundaryClean/isQuiescent keeps pre-durable-fix behavior (always paintable)', () => {
     const { bar, writes } = harness({});
+    bar.render();
+    expect(writes).toHaveLength(1);
+  });
+});
+
+// #1038: the unit tests above inject `isQuiescent` directly, which is how the
+// first attempt at this fix passed its own suite while being broken in
+// production. These drive the REAL PtyQuiescenceGate with real chunk bytes,
+// at the cadence Claude's TUI spinner actually runs, so the starvation case
+// cannot hide behind a hand-flipped boolean.
+describe('StatusBar against the real PtyQuiescenceGate (#1038)', () => {
+  /** Claude's spinner glyphs, redrawn in place on their own timer. */
+  const SPINNER = ['✶', '⠻', '✢', '✳'];
+  /** Well under QUIESCENCE_MS (500), which is the whole point. */
+  const SPINNER_MS = 150;
+  const TICK_MS = 250;
+
+  /**
+   * Run `minutes` of a live question during which the PTY never goes quiet
+   * for QUIESCENCE_MS, and report how often row N was actually painted.
+   */
+  function runWithSpinner(minutes: number): { writes: string[]; status: RemiStatus } {
+    let nowMs = NOW_MS;
+    const gate = new PtyQuiescenceGate(() => nowMs);
+    const status = mkStatus({
+      sessionStatus: 'waiting',
+      attached: false,
+      queuedCount: 0,
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'escalated', lastVerdictAtS: NOW_S },
+    });
+    const writes: string[] = [];
+    const bar = new StatusBar({
+      getStdoutFd: () => 1,
+      getStatus: () => status,
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      hasLiveQuestions: () => true,
+      isBoundaryClean: () => gate.isBoundaryClean(),
+      isQuiescent: () => gate.isQuiescent(),
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => nowMs,
+      log: () => {},
+    });
+
+    let spinnerAt = NOW_MS;
+    let tickAt = NOW_MS;
+    let frame = 0;
+    const end = NOW_MS + minutes * 60_000;
+    while (nowMs < end) {
+      nowMs = Math.min(spinnerAt, tickAt);
+      if (nowMs === spinnerAt) {
+        gate.observe(Buffer.from(`\r${SPINNER[frame++ % SPINNER.length]} Running...`));
+        spinnerAt += SPINNER_MS;
+      }
+      if (nowMs === tickAt) {
+        bar.render();
+        tickAt += TICK_MS;
+        status.attached = true; // a phone attaches while the prompt is open
+      }
+    }
+    return { writes, status };
+  }
+
+  test('a held permission whose spinner never lets the PTY go quiet still paints', () => {
+    // The exact production scenario. `isQuiescent()` is never true for the
+    // whole ten minutes; if liveness depended on it, this is 0.
+    const { writes } = runWithSpinner(10);
+    expect(writes.length).toBeGreaterThan(0);
+    // Bounded by HEARTBEAT_MS, so ~1 paint per 2s over 10 minutes.
+    expect(writes.length).toBeGreaterThanOrEqual((10 * 60_000) / HEARTBEAT_MS - 1);
+  });
+
+  test('the row reflects state that changed during the prompt, not the frame that raised it', () => {
+    // The user-visible bug: "needs you" is contractually bounded by
+    // ESCALATE_FRESH_S and the attach label changed mid-prompt. Both must
+    // reach the row even though Claude never stopped writing.
+    const { writes } = runWithSpinner(10);
+    expect(writes[0]).toContain('needs you');
+    expect(writes.at(-1)).toContain('attached');
+    expect(writes.at(-1)).not.toContain('needs you');
+  });
+
+  test('no paint ever lands at a dirty escape-sequence boundary', () => {
+    // The hard gate is what makes the hazard #932 documents impossible, and
+    // it is the reason painting through a spinner is safe at all. Feed a
+    // deliberately unterminated sequence and confirm the bar refuses.
+    let nowMs = NOW_MS;
+    const gate = new PtyQuiescenceGate(() => nowMs);
+    const writes: string[] = [];
+    const bar = new StatusBar({
+      getStdoutFd: () => 1,
+      getStatus: () => mkStatus(),
+      getSize: () => ({ cols: 80, rows: 24 }),
+      isEnabled: () => true,
+      hasLiveQuestions: () => true,
+      isBoundaryClean: () => gate.isBoundaryClean(),
+      isQuiescent: () => gate.isQuiescent(),
+      writeToFd: (_fd, data) => writes.push(data),
+      now: () => nowMs,
+      log: () => {},
+    });
+    gate.observe(Buffer.from('\x1b[')); // truncated CSI: mid-sequence
+    expect(gate.isBoundaryClean()).toBe(false);
+    nowMs += HEARTBEAT_MS * 3; // heartbeat long overdue
+    bar.render();
+    expect(writes).toHaveLength(0);
+    gate.observe(Buffer.from('0m')); // sequence completes
     bar.render();
     expect(writes).toHaveLength(1);
   });

--- a/packages/daemon/tests/cli/status-bar.test.ts
+++ b/packages/daemon/tests/cli/status-bar.test.ts
@@ -10,7 +10,7 @@ import {
   childRows,
   formatStatusBar,
 } from '../../src/cli/status-bar.ts';
-import type { RemiStatus } from '../../src/cli/status-writer.ts';
+import { ESCALATE_FRESH_S, type RemiStatus } from '../../src/cli/status-writer.ts';
 
 const NOW_MS = 1_000_000_000; // fixed clock; NOW_MS/1000 = 1_000_000 s
 const NOW_S = Math.floor(NOW_MS / 1000);
@@ -328,11 +328,10 @@ describe('StatusBar', () => {
   // question prompt. These prove the mitigations directly against the
   // fd-write count, independent of the timer.
   test('the onset paint happens on the transition into a live question and reflects its state', () => {
-    // Edge-triggered, not level-triggered: freezing row N is right, but
-    // freezing it on whatever was last painted is wrong -- Claude's native
-    // statusLine disappears entirely while a question dialog is open, so the
-    // bar has to be current the MOMENT that happens, not up to HEARTBEAT_MS
-    // stale. The first render() after the transition must still paint.
+    // Claude's native statusLine disappears entirely while a question dialog
+    // is open, so the bar has to be current the MOMENT that happens, not up
+    // to HEARTBEAT_MS stale. The first render() after the transition must
+    // still paint (a quiet PTY -- see the gate test below for the busy case).
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
       getStatus: () => mkStatus({ connections: 3 }),
@@ -342,63 +341,99 @@ describe('StatusBar', () => {
     expect(writes[0]).toContain('3 client(s)');
   });
 
-  test('repaints are suppressed while a question stays live, after the onset paint', () => {
-    // #932 review finding 4: status content must vary DURING the freeze, or
-    // this can't distinguish "the suppression guard held" from "nothing
-    // changed so the dedup check alone produced the same write count" --
-    // neutering `if (questionLive && !onset) return;` previously left this
-    // green because mkStatus() never changed between calls.
+  test('the bar keeps tracking status while a question stays live', () => {
+    // #1038: the old contract was a blanket freeze after the onset paint,
+    // which had no upper bound -- a prompt a human sits on for ten minutes
+    // froze row N for ten minutes. Content varies on every getStatus() read
+    // so this measures repaints, not a dedup coincidence.
     let connections = 0;
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
       getStatus: () => mkStatus({ connections: connections++ }),
     });
-    bar.render(); // onset: paints once
-    expect(writes).toHaveLength(1);
-    bar.render(); // still live: frozen, despite connections having changed
-    bar.render(); // still live: frozen again
-    expect(writes).toHaveLength(1);
+    bar.render(); // onset
+    bar.render();
+    bar.render();
+    expect(writes).toHaveLength(3);
+    expect(writes[2]).toContain('2 client(s)');
   });
 
-  test('repaints resume once the question resolves', () => {
-    // Same fix as above: content changes on every getStatus() read so a
-    // neutered suppression guard would produce an extra write during the
-    // freeze, not just the same count by coincidence.
-    let live = true;
+  test('a live question makes quiescence a HARD gate: no paint while the PTY is busy', () => {
+    // This is what replaced the freeze. A routine paint already waits for
+    // quiescence; while a question is live EVERY paint does, including the
+    // forced ones (onset here, plus the heartbeat below) -- so nothing can
+    // land mid-render of the prompt.
+    let quiescent = false;
     let connections = 0;
     const { bar, writes } = harness({
-      hasLiveQuestions: () => live,
+      hasLiveQuestions: () => true,
+      isQuiescent: () => quiescent,
       getStatus: () => mkStatus({ connections: connections++ }),
     });
-    bar.render(); // onset paint
+    bar.render(); // onset, but PTY busy: refused
+    bar.render();
+    expect(writes).toHaveLength(0);
+    quiescent = true; // the human is deliberating; Claude has gone quiet
+    bar.render();
     expect(writes).toHaveLength(1);
-    bar.render(); // frozen, despite connections having changed
-    expect(writes).toHaveLength(1);
-    live = false;
-    bar.render(); // resumes
-    expect(writes).toHaveLength(2);
   });
 
-  test('the onset paint captures state at the transition, and the resumed repaint reflects a status change made during the freeze', () => {
-    // The regression this guards against: a status change while a question is
-    // live must not be lost -- the bar has to catch up, not stay stale
-    // forever once the question resolves.
+  test('a live question suspends the heartbeat exemption from the quiescence gate', () => {
+    // The heartbeat normally bypasses quiescence so a streaming session
+    // cannot starve the DECSTBM re-assertion. While a question is live that
+    // exemption is off: re-asserting the scroll region is not worth a write
+    // landing inside the dialog's own render.
+    let nowMs = NOW_MS;
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      isQuiescent: () => false,
+      now: () => nowMs,
+    });
+    bar.render();
+    nowMs += HEARTBEAT_MS;
+    bar.render();
+    expect(writes).toHaveLength(0);
+  });
+
+  test('a "needs you" cue still decays while the question that raised it is open', () => {
+    // The reported bug, end to end: an escalate is what raises the prompt, so
+    // the frozen frame was almost always the one reading "needs you" -- a cue
+    // whose whole contract is that it decays after ESCALATE_FRESH_S, pinned
+    // on screen for as long as the prompt stayed open.
+    let nowMs = NOW_MS;
+    const status = mkStatus({
+      sessionStatus: 'waiting',
+      autoApprove: { inFlight: 0, sinceS: 0, lastVerdict: 'escalated', lastVerdictAtS: NOW_S },
+    });
+    const { bar, writes } = harness({
+      hasLiveQuestions: () => true,
+      getStatus: () => status,
+      now: () => nowMs,
+    });
+    bar.render();
+    expect(writes[0]).toContain('needs you');
+    nowMs += ESCALATE_FRESH_S * 1000; // the escalate is no longer fresh
+    bar.render();
+    expect(writes.at(-1)).toContain('waiting');
+    expect(writes.at(-1)).not.toContain('needs you');
+  });
+
+  test('the resumed repaint reflects a status change made while the question was open', () => {
+    // Still load-bearing after #1038: the dialog can redraw or consume row N
+    // while it owns the screen, so the physical row cannot be trusted to
+    // match lastRendered once the question clears.
     let live = true;
     let connections = 0;
     const { bar, writes } = harness({
       hasLiveQuestions: () => live,
       getStatus: () => mkStatus({ connections }),
     });
-    bar.render(); // onset: paints the status AT the transition
-    expect(writes).toHaveLength(1);
+    bar.render();
     expect(writes[0]).toContain('no clients');
-    connections = 5; // status changes while the question is still live
-    bar.render(); // frozen: no write
-    expect(writes).toHaveLength(1);
+    connections = 5;
     live = false;
-    bar.render(); // question resolved: must repaint with the NEW status
-    expect(writes).toHaveLength(2);
-    expect(writes[1]).toContain('5 client(s)');
+    bar.render(); // question resolved: repaints with the NEW status
+    expect(writes.at(-1)).toContain('5 client(s)');
   });
 
   test('an unchanged status does not write a second time', () => {
@@ -530,15 +565,20 @@ describe('StatusBar — #932 durable fix (quiescence + clean-boundary gate)', ()
     expect(writes).toHaveLength(1);
   });
 
-  test('the onset paint bypasses the quiescence gate but still honors the boundary gate', () => {
-    // Onset must fire the instant a question goes live, even mid-burst --
-    // see status-bar.ts's HEARTBEAT_MS doc for why the soft gate has
-    // documented exceptions.
+  test('the onset paint does NOT bypass the quiescence gate (it implies a live question)', () => {
+    // #1038 flipped this: onset used to fire even mid-burst. Onset only
+    // happens when a question just went live, and that is precisely the
+    // window where quiescence is a hard requirement -- so the capture waits
+    // for the next quiet tick rather than racing the dialog's own render.
+    let quiescent = false;
     const { bar, writes } = harness({
       hasLiveQuestions: () => true,
-      isQuiescent: () => false,
+      isQuiescent: () => quiescent,
       isBoundaryClean: () => true,
     });
+    bar.render();
+    expect(writes).toHaveLength(0);
+    quiescent = true;
     bar.render();
     expect(writes).toHaveLength(1);
   });
@@ -558,15 +598,20 @@ describe('StatusBar — #932 durable fix (quiescence + clean-boundary gate)', ()
 
   test('the resumed paint bypasses the quiescence gate but still honors the boundary gate', () => {
     let live = true;
+    let quiescent = true;
     const { bar, writes } = harness({
       hasLiveQuestions: () => live,
-      isQuiescent: () => false,
+      isQuiescent: () => quiescent,
       isBoundaryClean: () => true,
     });
-    bar.render(); // onset
+    bar.render(); // onset, PTY quiet: paints
     expect(writes).toHaveLength(1);
+    // The question clears just as Claude starts writing again. `resumed`
+    // still paints: once no question is live, the soft gate's documented
+    // exemptions are back in force (#1038 suspends them only while one is).
     live = false;
-    bar.render(); // resumed, still not quiescent
+    quiescent = false;
+    bar.render();
     expect(writes).toHaveLength(2);
   });
 

--- a/packages/daemon/tests/cli/status-writer.test.ts
+++ b/packages/daemon/tests/cli/status-writer.test.ts
@@ -332,4 +332,84 @@ describe('StatusWriter', () => {
       expect(broadcastCount).toBe(1);
     });
   });
+
+  // #1038: `getAttachState` was pulled only inside write(), and no attach or
+  // detach path calls update() -- so an attaching phone changed nothing the
+  // bar, the status file or any client could see until an unrelated status
+  // change happened along. refresh() is the pull that closes that.
+  describe('attach-state refresh (#1038)', () => {
+    function attachHarness(debounceMs = 0) {
+      const broadcasts: Array<boolean | undefined> = [];
+      const attach = { attached: false, queuedCount: 0 };
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs,
+        getAttachState: () => ({ ...attach }),
+        broadcast: (s) => broadcasts.push(s.attached),
+      });
+      return { writer, attach, broadcasts };
+    }
+
+    /** refresh() only SCHEDULES; even at debounceMs 0 the flush is a task. */
+    const settle = () => new Promise((r) => setTimeout(r, 5));
+
+    test('refresh flushes when the attach state changed', async () => {
+      const { writer, attach, broadcasts } = attachHarness();
+      writer.refresh(); // first pull: undefined -> false, a real change
+      await settle();
+      expect(broadcasts).toEqual([false]);
+      attach.attached = true; // a phone attaches; nothing else in the status moves
+      writer.refresh();
+      await settle();
+      expect(writer.state.attached).toBe(true);
+      expect(broadcasts).toEqual([false, true]);
+      expect(JSON.parse(fs.readFileSync(target, 'utf-8')).attached).toBe(true);
+    });
+
+    test('refresh writes nothing when the attach state is unchanged', async () => {
+      const { writer, broadcasts } = attachHarness();
+      writer.refresh();
+      await settle();
+      expect(broadcasts).toHaveLength(1);
+      // The poll runs several times a second; an idle session must not turn
+      // that into a disk write and a client broadcast per tick.
+      writer.refresh();
+      writer.refresh();
+      await settle();
+      expect(broadcasts).toHaveLength(1);
+    });
+
+    test('startAttachRefresh polls, is idempotent, and stops on cleanup', async () => {
+      const { writer, attach, broadcasts } = attachHarness();
+      writer.startAttachRefresh();
+      writer.startAttachRefresh();
+      attach.attached = true; // changes with nothing calling update()
+      await new Promise((r) => setTimeout(r, 400)); // > the 250ms default
+      expect(broadcasts).toEqual([true]);
+      // cleanup() clears exactly one handle, so a second timer created by the
+      // second start() would survive it and pick this change up.
+      writer.cleanup();
+      attach.attached = false;
+      await new Promise((r) => setTimeout(r, 400));
+      expect(broadcasts).toEqual([true]);
+    });
+
+    test('a throwing getAttachState is logged once and leaves refresh a no-op', () => {
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        getAttachState: () => {
+          throw new Error('registry down');
+        },
+      });
+      writer.refresh();
+      writer.refresh();
+      expect(fs.existsSync(target)).toBe(false); // nothing scheduled
+      expect(logs.filter((l) => l.includes('attach-state read failed'))).toHaveLength(1);
+    });
+  });
 });

--- a/packages/daemon/tests/cli/status-writer.test.ts
+++ b/packages/daemon/tests/cli/status-writer.test.ts
@@ -381,19 +381,23 @@ describe('StatusWriter', () => {
       expect(broadcasts).toHaveLength(1);
     });
 
-    test('startAttachRefresh polls, is idempotent, and stops on cleanup', async () => {
+    test('a detach that leaves other connections attached still flushes', async () => {
+      // queuedCount/attached are derived from the SET, not from the
+      // zero<->nonzero edges, so a membership change that is not an edge must
+      // still reach the snapshot. Guards the ordering in
+      // `detachConnection`: the emit sits BEFORE the still-attached early
+      // return.
       const { writer, attach, broadcasts } = attachHarness();
-      writer.startAttachRefresh();
-      writer.startAttachRefresh();
-      attach.attached = true; // changes with nothing calling update()
-      await new Promise((r) => setTimeout(r, 400)); // > the 250ms default
+      attach.attached = true;
+      attach.queuedCount = 2;
+      writer.refresh();
+      await settle();
       expect(broadcasts).toEqual([true]);
-      // cleanup() clears exactly one handle, so a second timer created by the
-      // second start() would survive it and pick this change up.
-      writer.cleanup();
-      attach.attached = false;
-      await new Promise((r) => setTimeout(r, 400));
-      expect(broadcasts).toEqual([true]);
+      attach.queuedCount = 1; // one of several detached; still attached
+      writer.refresh();
+      await settle();
+      expect(writer.state.queuedCount).toBe(1);
+      expect(broadcasts).toEqual([true, true]); // flushed again, same attached
     });
 
     test('a throwing getAttachState is logged once and leaves refresh a no-op', () => {
@@ -410,6 +414,31 @@ describe('StatusWriter', () => {
       writer.refresh();
       expect(fs.existsSync(target)).toBe(false); // nothing scheduled
       expect(logs.filter((l) => l.includes('attach-state read failed'))).toHaveLength(1);
+    });
+
+    test('the attach-state error latch is per-streak, not per-process', () => {
+      // The docstring says "once per streak"; without a reset on success it
+      // is once per process, and an intermittently-throwing registry read
+      // (session teardown) would go unreported for the life of the daemon
+      // after the first occurrence.
+      let broken = true;
+      const writer = new StatusWriter(baseStatus(), {
+        getTargetFile: () => target,
+        isEnabled: () => true,
+        writeLog: (m) => logs.push(m),
+        debounceMs: 0,
+        getAttachState: () => {
+          if (broken) throw new Error('registry down');
+          return { attached: false, queuedCount: 0 };
+        },
+      });
+      writer.refresh();
+      expect(logs.filter((l) => l.includes('attach-state read failed'))).toHaveLength(1);
+      broken = false;
+      writer.refresh(); // succeeds: clears the streak
+      broken = true;
+      writer.refresh(); // a NEW streak must report again
+      expect(logs.filter((l) => l.includes('attach-state read failed'))).toHaveLength(2);
     });
   });
 });

--- a/packages/daemon/tests/session-registry.test.ts
+++ b/packages/daemon/tests/session-registry.test.ts
@@ -7,6 +7,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ProtocolMessage } from '@remi/shared';
+import type { UUID } from '@remi/shared';
 import { generateId, now } from '@remi/shared';
 import type { MessageAPI } from '../src/api/message-api.ts';
 import type { PTYSession } from '../src/pty/pty-session.ts';
@@ -36,6 +37,7 @@ describe('SessionRegistry', () => {
     onSessionOrphaned: ReturnType<typeof mock>;
     onSessionResumed: ReturnType<typeof mock>;
     onQuestionsChanged: ReturnType<typeof mock>;
+    onAttachStateChanged: ReturnType<typeof mock>;
   };
 
   beforeEach(() => {
@@ -45,6 +47,7 @@ describe('SessionRegistry', () => {
       onSessionOrphaned: mock(() => {}),
       onSessionResumed: mock(() => {}),
       onQuestionsChanged: mock(() => {}),
+      onAttachStateChanged: mock(() => {}),
     };
 
     registry = new SessionRegistry(
@@ -1037,6 +1040,65 @@ describe('SessionRegistry', () => {
     test('is safe to call with no session', async () => {
       await registry.shutdown();
       expect(registry.sessionCount).toBe(0);
+    });
+  });
+
+  // #1038: the status snapshot's `attached`/`queuedCount` are derived from
+  // `attachedConnections`, and nothing on an attach path calls
+  // updateRemiStatus -- so this event is the ONLY thing that tells the
+  // StatusWriter a phone arrived. It is emitted from the two lines that
+  // mutate the set (rather than from any caller) precisely so it cannot be
+  // missed on a path someone forgets to wire; these prove both of them, and
+  // that it is NOT edge-only like onSessionResumed/onSessionOrphaned.
+  describe('onAttachStateChanged (#1038)', () => {
+    function liveSession(): UUID {
+      const sid = registry.createSessionId();
+      registry.registerSession(sid, '/test/dir', createMockPTY(), createMockMessageAPI());
+      return sid;
+    }
+
+    test('fires on attach', () => {
+      const sid = liveSession();
+      registry.attachConnection(sid, generateId());
+      expect(events.onAttachStateChanged).toHaveBeenCalledTimes(1);
+    });
+
+    test('fires on detach', () => {
+      const sid = liveSession();
+      const conn = generateId();
+      registry.attachConnection(sid, conn);
+      registry.detachConnection(conn);
+      expect(events.onAttachStateChanged).toHaveBeenCalledTimes(2);
+    });
+
+    test('fires for a SECOND attach, which is not a resume', () => {
+      // onSessionResumed only fires on the zero->nonzero edge. The derived
+      // fields change on every membership change, so this must not be
+      // edge-scoped too.
+      const sid = liveSession();
+      registry.attachConnection(sid, generateId());
+      registry.attachConnection(sid, generateId());
+      expect(events.onAttachStateChanged).toHaveBeenCalledTimes(2);
+    });
+
+    test('fires for a detach that leaves others attached, which is not an orphan', () => {
+      // The mirror case, and the one the ordering inside detachConnection
+      // gets wrong if the emit is placed after the still-attached early
+      // return.
+      const sid = liveSession();
+      const first = generateId();
+      registry.attachConnection(sid, first);
+      registry.attachConnection(sid, generateId());
+      registry.detachConnection(first);
+      expect(events.onSessionOrphaned).not.toHaveBeenCalled();
+      expect(events.onAttachStateChanged).toHaveBeenCalledTimes(3);
+    });
+
+    test('does not fire for a detach of a connection that was never attached', () => {
+      const sid = liveSession();
+      registry.attachConnection(sid, generateId());
+      registry.detachConnection(generateId()); // unknown connection: no-op
+      expect(events.onAttachStateChanged).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Closes #1038.

Field report: the status bar sticks on `needs you` and never recovers.

```
remi:18766 website:main | no clients | needs you
```

Not lag — the bar had stopped painting entirely, and separately the attach label had no path to update.

> **Read the second commit first.** The first commit's fix was wrong in an instructive way, caught in review, and the ADR now records it as its main alternative. Detail below.

## 1. The freeze

`status-bar.ts` returned early for as long as any question was pending:

```ts
if (questionLive && !onset) return;   // ad8ec6e4, PR #933
```

No upper bound: a prompt a human sits on for ten minutes freezes row N for ten minutes. The frame it freezes on is rarely arbitrary — the escalate that raises the prompt is also what sets the state to `needs you`, a cue contractually bounded by `ESCALATE_FRESH_S` (60s).

PR #933 (2026-07-30 19:35) was the blunt freeze; PR #942 (21:28, same evening) landed `PtyQuiescenceGate` and subsumed it. The freeze was never removed and shipped in v0.7.4 and v0.7.5 (`git tag --contains ad8ec6e4` -> `v0.7.4`).

**The fix is to delete it and add nothing in its place.**

### The wrong turn, and why it is in the ADR

The first commit did not just delete it — it replaced the freeze with a question-scoped **hard** quiescence gate, on the reasoning that this is "strictly stronger per-write" (true) and that a deliberating human leaves the PTY quiet (**false**).

This repo had already recorded the counter-evidence from a live session: a held permission does not idle the PTY, because Claude's TUI spinner keeps animating on its own timer (#1026, `attach-client.ts`'s `renderQuestionBanner`). Driven against the real `PtyQuiescenceGate` with 150ms spinner frames:

```
spinner every 150ms, QUIESCENCE_MS=500
bar paints over 10 minutes with a live question: 0
row N reads: (NEVER PAINTED)
```

Worse than the freeze it replaced, which at least guaranteed its onset paint. It passed its own test suite because every test injected `isQuiescent` as a hand-flipped boolean — the suite tested the author's mental model, not the system.

It also silently killed two things the freeze had killed for the same reason: the DECSTBM re-assertion, and `notifyScrollRegionReset()`, which is called synchronously from the chunk observer and therefore always sees `isQuiescent() === false`.

The net functional change is one line versus `develop`:

```diff
-    if (questionLive && !onset) return;
```

## 2. `no clients` while attached

`getAttachState` is pulled inside `write()` (#755) — right about the value, silent about *when* a write happens. No attach or detach path calls `update()`, so a phone attaching changed nothing visible until an unrelated status change flushed. That hits all four consumers, which share the snapshot: the reserved-row bar, `status-<PORT>.json` (the Claude Code statusline), the remote attach client, and the app via `remi_status`.

Fixed with `SessionRegistry.onAttachStateChanged`, emitted from the **only two lines that mutate** `attachedConnections` rather than from any caller — total over every attach path by construction, which is [ADR 0020](.context/decisions/0020-client-status-cue-totality.md)'s requirement, with no timer and no lag. (The first commit used a 250ms poll; review correctly pointed out its justification described the *callers* of `attachConnection`, not the mutation sites.)

Deliberately **not** edge-scoped like `onSessionResumed`/`onSessionOrphaned`: `attached`/`queuedCount` derive from the set, so a second attach and a detach-leaving-others must fire too. Both are tested.

## Verification

```
after 20 minutes:                   remi:18766 website:main | attached | waiting
paints over 10 min, spinner at 150ms: 301   (was 0)
```

The suite now drives the **real** `PtyQuiescenceGate` with real chunk bytes at spinner cadence, because injected booleans provably do not catch this class of bug. Mutation-tested: reintroducing the broken gate turns **6 tests red**, including the real-gate ones.

- `a NEVER-quiescent PTY still paints while a question is live, bounded by HEARTBEAT_MS`
- `a held permission whose spinner never lets the PTY go quiet still paints`
- `no paint ever lands at a dirty escape-sequence boundary` — the hard gate that makes painting through a spinner safe
- the end-to-end attach test now streams `raw_pty_output` throughout and reads the row **mid-question**, so it cannot pass by catching up after the prompt closes
- five two-sided `onAttachStateChanged` tests covering both mutation sites and the non-edge cases

Full suite: 5916 pass, 1 skip, 3 fail. All three are `discoverDaemons` mDNS timeouts, **identical on clean `develop` with these changes stashed**, and green on CI.

## The honest bound

Retiming the E2E test with a busy PTY exposed the real contract: while Claude streams, a status change reaches the row on the **heartbeat (~2s)**, not the 250ms tick. The first commit's docs claimed the bar "never goes stale" — false. Docs, ADR and tests now all state `HEARTBEAT_MS`.

## ADR

[ADR 0022](.context/decisions/0022-status-bar-never-freezes.md) — *Status-bar liveness is bounded by `HEARTBEAT_MS`, never by a human.* It records the failed attempt as its main alternative, with the measurement, since that is the part most likely to stop a future reader making the same move:

> no suppression in this file may be scoped to a question being live. Liveness may never depend on the PTY going quiet, because the case that most needs a live bar is exactly the case where it never does.

and the testing obligation that follows:

> a test that injects `isQuiescent` proves nothing about starvation.