### PR TITLE
Approve deletion when the target is provably derived (ADR 0023), and fix #1047

### DIFF
--- a/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
+++ b/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
@@ -1,0 +1,199 @@
+# ADR 0023: Deletion approves only when the target is provably derived — amending #956's blanket rule
+
+**Status:** proposed
+**Date:** 2026-08-10
+**Owner:** Yahya
+
+## Context
+
+#956's standing rule is that deletion escalates at EVERY level, including
+`trusted`: "deletion is where escalation earns its cost." It is pinned in
+three places — the `perLevel` narrowing in `prompt-builder.ts:110-115` (file
+creation/modification move to APPROVE at `balanced`; "deletion never does"),
+the tests `'deletion escalates at every level'` and `'at balanced and
+trusted, deletion is the ONLY file operation left escalating'`
+(`prompt-levels.test.ts:85-115`), and the curated-group comments that keep
+`rm`/`rmdir` out of `fs-write` (`permission-groups.ts:564-567`,
+`levels.ts:60-64`).
+
+Measured on the owner's live daemon (2026-08-10), the blanket rule is now the
+single largest cost center of the whole mechanism:
+
+- 134 escalate vs 129 approve overall (51% escalation); 123 of the 134 were
+  Bash.
+- A cold replay of the real escalation population through the live engine
+  scored 17/21 (81%) approve. Three of the four misses were exactly this
+  rule: `rm -rf dist` (3418ms → escalate), `rm -rf node_modules && bun
+  install` (3493ms), `git worktree remove --force ../remi-1031` (3721ms).
+  Each is ~3.5s of GPU time plus a human interruption spent on a deletion
+  that is regenerable by a command the repo already runs.
+- Target: ≥95% approval on that population with zero unsafe approvals.
+  Covering the three named misses reaches 20/21 (95.2%); the fourth miss is
+  not a deletion and is deliberately not chased.
+
+The blanket rule also already has one shipped exception, which is the
+precedent this ADR generalizes: the `scratch` group
+(`permission-groups.ts:99-140`) deterministically approves `rm`/`rmdir`
+whose every target provably resolves under a scratch root, at `balanced`
+(`levels.ts:75`). So "deletion escalates at every level" has, since #994,
+really meant "deletion escalates unless the destination is PROVED disposable
+by lexical reasoning." This ADR extends that proof from "under `/tmp`" to
+"at or under a directory whose exact name proclaims derived state."
+
+## Decision
+
+**A new curated group (working name `artifact-clean`), gated into `trusted`
+only, deterministically approves deletions whose targets are PROVABLY
+derived state — and nothing else. The prompt-side rule is untouched:
+deletion still escalates on every path that reaches the LLM, at every
+level.** The amendment lives entirely in the deterministic layer, which is
+where ADR 0016 says policy belongs.
+
+The group covers four command shapes, each with its own veto profile
+(ADR 0018: a mutating group supplies its own vetoes or it does not ship):
+
+1. `rm` / `rmdir` where EVERY non-flag token, after `shellWords`
+   tokenization and `resolveDotDot` resolution, is a relative path that
+   does not ascend, contains no expansion the shell would rewrite
+   (`$`, glob, brace, leading `~`), has some exact-case path segment on a
+   fixed ARTIFACT_DIR_NAMES list (`node_modules`, `dist`, `build`, `out`,
+   `target`, `coverage`, `__pycache__`, `.venv`, ...), and does not hit
+   `isSensitiveWritePath`. Flags are allowlisted (`-r -R -f -v` and exact
+   long spellings only).
+2. `git worktree remove` with at most one `--force`/`-f`, no other flags, no
+   `-C`/`--git-dir`, one positional target that is not `.`. Its safety rests
+   on a RUNTIME veto: git itself refuses any path that is not a registered
+   linked worktree of this repository, refuses the main worktree always, and
+   requires a second `--force` for a locked one — which this group never
+   supplies. Committed work survives in the shared object store by
+   construction; only the worktree's uncommitted files are at stake, which
+   is the owner's explicit "disposable worktree" call.
+3. Bare `bun install` (zero positional arguments, flag allowlist of
+   `--frozen-lockfile` only): a lockfile-faithful reinstall of dependencies
+   already vetted, whose lockfile and `package.json` no write group can
+   touch (`BUILD_SURFACE`, `sensitive-paths.ts:141-164`). This is what makes
+   the measured compound `rm -rf node_modules && bun install` fully covered.
+   `bun install <pkg>` is `bun add` and stays an escalation.
+4. `/tmp` / `$TMPDIR` deletion is NOT re-implemented — `scratch` already
+   covers it (`permission-groups.ts:140`, `levels.ts:75`).
+
+A `cd` anywhere in the compound whose target is not a plain relative
+descendant (absolute, `~`, `$`, ascending, bare `cd`, `cd -`, or
+grammar-wrapped) poisons every later segment for this group — computed by a
+scratch-style indexed pre-walk, never un-poisoned. Git-ignored status is
+NOT consulted: it is I/O in a pure layer, TOCTOU-racy, the wrong axis
+(ignored means unversioned, which includes `.env` and irreplaceable data,
+not "disposable") — and above all, `.gitignore` is on no sensitive list, so
+`fs-write` at `balanced`/`trusted` can auto-approve writing `src` into it,
+turning "git-ignored ⇒ deletable" into a two-step self-widening loop, the
+exact privilege-escalation shape `sensitive-paths.ts`'s module doc exists to
+close.
+
+`git clean` is excluded in every form. Its population is UNTRACKED files,
+and untracked ≠ derived: a file the agent created five minutes ago is
+untracked source. The `-X` (ignored-only) form is lexically identifiable but
+is defeated by the same `.gitignore` write above. `git clean -xfd ~` in a
+dotfiles home repo is catastrophic. It stays an escalation, always.
+
+## Consequences
+
+Easier: the three measured misses approve at 0ms with no model and no human;
+the escalation population drops to operations that genuinely need judgment.
+The rule becomes checkable the way every other group is — pure functions
+over `(toolName, toolInput)`, testable without a daemon (ADR 0016).
+
+Harder, and accepted: the artifact-name list buys residual risk on names
+that are conventions, not guarantees. A SOURCE directory legitimately named
+`build/` or `coverage/` is deletable at `trusted`. Bounded honestly: if its
+contents are tracked, `git checkout -- <path>` restores them (shared history
+is untouched by `rm`); if untracked, they are lost — the same residual the
+owner accepted for worktree `--force`. Symlinks stay invisible to every
+lexical check here, exactly as `scratch` documents
+(`permission-groups.ts:130-136`); the one lexically visible trigger
+(trailing `/` on a target, which makes `rm -rf link/` traverse the link
+target on some platforms) is vetoed.
+
+New obligations, and the reason this ADR exists:
+
+- **The name list is an allow surface and will attract additions.** An entry
+  qualifies only if the exact name proclaims derived state AND a command the
+  repo already runs regenerates it. `vendor` (often tracked), `tmp`
+  (proclaims temporariness but regenerates nothing), and any suffix/glob
+  form (`*.egg-info`) do not clear the bar.
+- **Name matching is exact-case while `sensitive-paths.ts` lowercases, and
+  that asymmetry is deliberate** (ADR 0010 applied to names): the deny check
+  lowercases to widen; an allow check that lowercased would treat `Dist` as
+  `dist` on case-sensitive Linux, where they are different directories.
+  "Cleaning up" the inconsistency reopens a hole.
+- **The prompt half of #956's rule stays true and pinned.** The tests at
+  `prompt-levels.test.ts:85-115` keep passing untouched; their comments (and
+  `permission-groups.ts:564-567`, `levels.ts:60-64`, the
+  `prompt-builder.ts:112` "deletion never does" line) must be amended in the
+  same change to cite this ADR, per ADR 0011 rule 3 — `levels.ts:63`'s
+  "`rm` ... not groups at all, at any strictness" becomes false the moment
+  this merges.
+- **#1024 makes this group a silent subagent grant**: a subagent's
+  `rm -rf dist` at `trusted` now answers the hook with no render and no
+  card. The visibility path is `auto_approve.subagent_alert` (an `rm` entry
+  there alerts without blocking), and the ADR records that this was chosen,
+  not overlooked.
+- **The adversarial corpus is part of the deliverable, not documentation.**
+  #959 needed four review rounds and found eleven bypasses, three in code
+  written to fix the previous round (ADR 0018). The corpus ships as a pinned
+  test (`artifact-clean.test.ts`), and at least one independent adversarial
+  pass happens before merge.
+
+## Alternatives considered
+
+- **Widen the prompt instead ("at trusted, approve artifact deletion").**
+  Loses on ADR 0016's own measurement: 35 of 226 escalations cited the
+  user's prose and escalated anyway; and ADR 0017's mirror — 10 of 12
+  escalate-expected operations denied against explicit instructions.
+  Prose is not obeyed at the rate group membership is, and a model verdict
+  costs the ~3.5s this exists to eliminate.
+- **Add `rm` to `fs-write` behind `writeGroupVeto`.** Loses on polarity:
+  `fs-write`'s destination axis is a DENYlist ("not a known-bad path"), which
+  is the right shape for writes and fails open for deletion — `rm -rf src`
+  touches nothing sensitive. Deletion needs positive proof, an ALLOWLIST of
+  destination shapes, which is `scratch`'s shape, not `fs-write`'s.
+- **Consult git-ignored status.** The trap, rejected above: impure, racy,
+  wrong axis, and self-widening via an `fs-write`-approvable `.gitignore`.
+- **Gate into `balanced`.** The measurement is one machine running
+  `trusted`. `balanced` gets no evidence, and ADR 0016's precedent is to
+  ship the mechanism narrow and widen in a deliberate one-line follow-up.
+- **Cover `git clean -fdX` (ignored-only).** Rejected: defeated by the
+  `.gitignore` write; fixing THAT means adding `.gitignore` to the sensitive
+  lists, which breaks a routine edit every project makes. Not worth it for a
+  form absent from the measured population.
+- **A user-extensible artifact-name config key.** Deferred, not rejected: it
+  reopens ADR 0016's "policy as user text" surface and none of the measured
+  misses need it.
+
+## Receipts
+
+- Live daemon measurement 2026-08-10: 134/263 escalate (51%), 123 Bash;
+  cold replay 17/21 approve; misses `rm -rf dist` 3418ms,
+  `rm -rf node_modules && bun install` 3493ms,
+  `git worktree remove --force ../remi-1031` 3721ms. Target ≥95%, zero
+  unsafe approvals.
+- `packages/daemon/src/auto-approve/permission-groups.ts:99-140` (`scratch`:
+  the shipped destination-proof deletion precedent), `:140`
+  (`SCRATCH_COMMANDS` includes `rm`), `:564-567` (`rm` kept out of
+  `fs-write`, #956), `:587-592` (`git worktree remove` excluded from
+  `vcs-write`)
+- `packages/daemon/src/auto-approve/levels.ts:66-79` (`LEVEL_GROUPS`; the
+  gate point), `:60-64` (the comment this ADR falsifies)
+- `packages/daemon/src/auto-approve/prompt-builder.ts:93-125`
+  (`ESCALATE_ENTRIES` `perLevel`; untouched by this ADR)
+- `packages/daemon/tests/auto-approve/prompt-levels.test.ts:85-115` (the
+  pins; untouched, comments amended)
+- `packages/daemon/src/auto-approve/sensitive-paths.ts:196-261, 275-290`
+  (`isSensitiveWritePath`, `resolveDotDot` — reused),
+  `shell-safety.ts:548-569, 659-710, 740-854` (`hasShellControl`,
+  `matchCoveredCommand` + indexed vetoes, `shellWords` — reused),
+  `write-flag-safety.ts:55-153` (`FlagPolicy` pattern — extended)
+- ADR 0010 (allow precise / deny broad), ADR 0016 (levels are groups, not
+  prose), ADR 0017 (10-of-12 deny measurement), ADR 0018 (three vetoes;
+  eleven bypasses), #956 (the amended rule), #959/#960 (write groups),
+  #994 (`scratch`), #1024 (subagent hook-time approves), #1031/#1034
+  (quote/ANSI-C splitter fixes this design inherits)

--- a/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
+++ b/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
@@ -181,13 +181,73 @@ That two independent authors encoded "the weird `cd` forms" as the single
 literal `-` is the finding under the finding: the check wanted to be "is this
 token an OPTION", not "is it one specific option".
 
+**The monotonicity refactor silently weakened `fs-write` — and at `balanced`,
+a level this ADR does not claim to touch.** `matchGroups` was rewritten from
+first-registrant-wins to a union that tries EVERY owning group and approves if
+any one's proof holds. That fixed a real non-monotonicity (a scratch-provable
+`cp` under `/tmp` escalated the moment `fs-write` was requested alongside), but
+the union is disjunctive over vetoes too — so for the five prefixes owned by
+both `fs-write` and `scratch` (`cp`, `mv`, `mkdir`, `touch`, `tee`),
+`scratch`'s laxer proof discarded `fs-write`'s sensitive-destination veto,
+which `scratchTargetVeto` never had. Measured develop → branch at `balanced`:
+
+| command | develop | before the fix |
+|---|---|---|
+| `cp /tmp/a /tmp/.env` | escalate | `scratch:cp` at 0ms |
+| `mv /tmp/a /tmp/id_rsa` | escalate | `scratch:mv` |
+| `cp /tmp/a /tmp/.git/config` | escalate | `scratch:cp` |
+
+It also falsified a shipped claim in `config.ts` ("the write groups refuse
+sensitive destinations regardless of prefix ... credentials (.env, id_rsa)").
+
+Fixed by hoisting `segmentTouchesSensitivePath` out of the per-owner dispatch
+into a global conjunct checked before any owner's proof. Monotonicity survives
+— adding a group cannot introduce a sensitive destination — and ADR 0010's
+shape is restored: a deny-shaped check must not be escapable by finding some
+other owner whose positive proof is laxer.
+
+This is ADR 0018's pattern repeating exactly: **the bypass was in code written
+to make the feature composable, not in the feature.** Three of #959's eleven
+were the same.
+
+**Two corpus entries could not fail on their claim.** `rm -rf dist*` ('glob')
+and `rm -rf {dist,build}` ('brace expansion') stay GREEN with `*` and `{}`
+deleted from `ARTIFACT_EXPANSION_RE`, because neither is an exact artifact name
+and the NAME check refuses them anyway. The guard they are named for was
+unpinned. Three entries added that do pin it (`*/dist`, `dist/*`, `{a,b}/dist`
+— each carries a real artifact segment, so only the expansion guard stands
+between them and approval); mutation-verified, corpus now 48.
+
+**"Bare `bun install` is lockfile-faithful" was false.** Only
+`--frozen-lockfile` guarantees that; bare `bun install` reconciles
+`package.json` against the lockfile and may resolve new versions, rewrite the
+lockfile, and run lifecycle scripts. The bare form stays covered — it is the
+measured miss, and narrowing drops the result back below 95% — but as a
+DECLARED residual, not because it is inert.
+
+**The pinned prompt test's NAME overclaimed.** `'deletion escalates at every
+level'` is false at the system level once this ships; its body was already
+qualified, but a name is a claim too. Renamed to
+`'every deletion that REACHES the prompt escalates, at every level'`.
+
 Verified non-findings worth recording, so a later reader does not re-derive
 them: the deny axis holds on top of the name proof (`dist/.env`, `dist/.git`
 refuse); no lexical ascent escapes (`../dist`, `dist/../src` refuse, because
 `resolveDotDot` pops the artifact ancestor before any `..` can escape past it);
-and `git worktree remove`'s flag handling is tight (`-C`, `--git-dir`,
-`--force=`, a second `--force` all fail closed), though its safety still rests
-entirely on git's runtime refusal, exactly as the Decision states.
+`git worktree remove`'s flag handling is tight (`-C`, `--git-dir`, `--force=`,
+a second `--force` all fail closed), though its safety still rests entirely on
+git's runtime refusal, exactly as the Decision states; ANSI-C `$'...'` decoding
+diverges from bash but fails SAFE; and #1024's stated visibility path was
+confirmed accurate — `onSubagentPassthrough` does fire on the deterministic
+hook-time approve, so `subagent_alert` can surface it, but only if the user
+configured a matching pattern. A default install is silent, as the ADR says.
+
+Two accepted, not fixed: `--` end-of-options hides a dash-leading target from
+the proof, and a QUOTED `>` truncates the target the proof sees. Both were
+executed and both are bounded to deleting a relative junk-named path whose
+spelling is constrained to flag-shaped tokens — neither reaches source, an
+absolute path, or code execution, and any real co-target is still checked.
+Recorded so a future reader knows they were found and weighed, not missed.
 
 ## Alternatives considered
 

--- a/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
+++ b/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
@@ -65,9 +65,13 @@ The group covers four command shapes, each with its own veto profile
    on a RUNTIME veto: git itself refuses any path that is not a registered
    linked worktree of this repository, refuses the main worktree always, and
    requires a second `--force` for a locked one — which this group never
-   supplies. Committed work survives in the shared object store by
-   construction; only the worktree's uncommitted files are at stake, which
-   is the owner's explicit "disposable worktree" call.
+   supplies. Committed work on a NAMED BRANCH survives in the shared object
+   store; only the worktree's uncommitted files are at stake, which is the
+   owner's explicit "disposable worktree" call. **Not "by construction"**, as
+   an earlier draft said: `git worktree remove` deletes the per-worktree `HEAD`
+   and reflog, so a DETACHED-HEAD worktree's commits become unreachable and
+   GC-eligible. Verified in a scratch repo — after remove, `git rev-list --all`
+   names none of them and `git fsck` reports them unreachable.
 3. Bare `bun install` (zero positional arguments, flag allowlist of
    `--frozen-lockfile` only): a lockfile-faithful reinstall of dependencies
    already vetted, whose lockfile and `package.json` no write group can
@@ -237,17 +241,51 @@ refuse); no lexical ascent escapes (`../dist`, `dist/../src` refuse, because
 `git worktree remove`'s flag handling is tight (`-C`, `--git-dir`, `--force=`,
 a second `--force` all fail closed), though its safety still rests entirely on
 git's runtime refusal, exactly as the Decision states; ANSI-C `$'...'` decoding
-diverges from bash but fails SAFE; and #1024's stated visibility path was
-confirmed accurate — `onSubagentPassthrough` does fire on the deterministic
-hook-time approve, so `subagent_alert` can surface it, but only if the user
-configured a matching pattern. A default install is silent, as the ADR says.
+diverges from bash but fails SAFE; and #1024's visibility path fires
+(`onSubagentPassthrough` on the deterministic hook-time approve, so
+`subagent_alert` surfaces it).
 
-Two accepted, not fixed: `--` end-of-options hides a dash-leading target from
-the proof, and a QUOTED `>` truncates the target the proof sees. Both were
-executed and both are bounded to deleting a relative junk-named path whose
-spelling is constrained to flag-shaped tokens — neither reaches source, an
-absolute path, or code execution, and any real co-target is still checked.
-Recorded so a future reader knows they were found and weighed, not missed.
+On that last point an earlier draft of THIS section added "but only if the user
+configured a matching pattern. A default install is silent, as the ADR says."
+Wrong twice over, and caught by the PR review.
+`DEFAULT_CONFIG.auto_approve.subagent_alert` already ships `rm -rf` and
+`rm -f`, and matching is substring, so a subagent's `rm -rf dist` at
+`trusted` DOES alert on a stock install. And the Consequences section never made
+that claim, so "as the ADR says" attributed it to a section that says no such
+thing. Both errors sat inside the list whose whole value is being trustable
+without re-checking.
+
+One accepted, one FIXED — and the correction matters more than either.
+
+The `--` end-of-options residual stands: a dash-leading target after `--` is
+dropped from the proof, bounded to a relative path whose spelling is
+constrained to flag-shaped tokens. Executed; no real co-target escapes.
+
+The quoted-`>` residual was **not** bounded, and an earlier draft of this
+section said it was ("neither reaches source, an absolute path, or code
+execution"). The PR review disproved that:
+
+    rm -rf 'dist>x/../../src'                       -> approved at trusted
+    rm -rf 'node_modules>x/../../../../Documents'    -> approved at trusted
+
+`rewriteRedirectClauses` is quote-BLIND and runs on raw text, so it truncated
+the token at the `>` and `isProvedArtifactTarget` only ever saw `dist` — the
+`..` segments the ascent guard exists to catch were invisible to it. Verified
+against a real filesystem: with a directory named `dist>x` present, the command
+deleted a sibling *above* the cwd. Worse, `mkdir 'dist>x'` is itself approved by
+`fs-write` at `balanced`, so it is a two-step chain in which both steps are
+silent.
+
+Fixed: a redirect character inside a target token now vetoes outright, before
+the rewrite can hide it. A genuine redirect clause is its own token
+(`2>/dev/null`), so requiring the redirect shape to START the token keeps those
+working. Four corpus entries added (now 52).
+
+**This is the lesson, not the bug.** The finding was recorded as an accepted
+residual on the strength of one adversary's bounding, and that bounding was
+wrong. A residual is only as trustworthy as the measurement behind it — and
+"we looked at this and decided it was fine" is exactly the shape ADR 0011 says
+stops people looking again.
 
 ## Alternatives considered
 

--- a/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
+++ b/.context/decisions/0023-artifact-deletion-is-proved-not-judged.md
@@ -143,6 +143,52 @@ New obligations, and the reason this ADR exists:
   test (`artifact-clean.test.ts`), and at least one independent adversarial
   pass happens before merge.
 
+## Adversarial pass, 2026-08-11 (the obligation above, discharged)
+
+Three independent adversaries, given distinct lenses (lexical/tokenization,
+destination/state, integration/composition) and required to EXECUTE every
+candidate through `matchGroups` rather than reason about it.
+
+**One confirmed bypass, and it was the group's worst case.**
+`cdTargetIsPlainDescendant` rejected the exact string `'-'` as a non-descendant
+`cd` target. But `cd` reads ANY leading-dash token as OPTIONS, so `cd -P`,
+`cd -L`, `cd --` and `cd -LP` are an option with **no operand** — and a `cd`
+with no operand goes to `$HOME`. Verified in bash on darwin 25.6: all four land
+in `/Users/<user>`.
+
+So `cd -P && rm -rf .venv` read as plain relative descent, approved at 0ms, and
+deleted the user's `~/.venv`. Worse, a SECOND plain `cd` descends normally from
+there, so `cd -P && cd <anyproject> && rm -rf node_modules` reached any project
+under `$HOME` — no card, and under #1024 a silent subagent grant. The
+one-directional poison model is what converted the blind spot into an approval
+rather than an escalation.
+
+Fixed by rejecting any leading dash, which costs nothing: a directory named
+`-foo` cannot be reached by `cd -foo` in bash either. Five entries added to the
+corpus (now 45), mutation-verified.
+
+**The same defect was live in shipped code, and the adversary got that half
+wrong.** It reported `scratch`'s `advanceScratchCwd` as failing safe here.
+Checking rather than accepting that showed it does not: `-P` fell through to
+`resolveScratchTarget` and was tracked as a SUBDIRECTORY NAME, so the tracked
+cwd became `<scratch>/-P` — still under the root — while bash had left for
+`$HOME`. `cd /tmp/work && cd -P && rm -rf out` approved at 0ms and deleted
+`~/out`, reachable at `balanced` and above. Filed as **#1047** and fixed in the
+same change, since one root cause split across two commits would ship a fix for
+the new code while leaving the shipped one open.
+
+That two independent authors encoded "the weird `cd` forms" as the single
+literal `-` is the finding under the finding: the check wanted to be "is this
+token an OPTION", not "is it one specific option".
+
+Verified non-findings worth recording, so a later reader does not re-derive
+them: the deny axis holds on top of the name proof (`dist/.env`, `dist/.git`
+refuse); no lexical ascent escapes (`../dist`, `dist/../src` refuse, because
+`resolveDotDot` pops the artifact ancestor before any `..` can escape past it);
+and `git worktree remove`'s flag handling is tight (`-C`, `--git-dir`,
+`--force=`, a second `--force` all fail closed), though its safety still rests
+entirely on git's runtime refusal, exactly as the Decision states.
+
 ## Alternatives considered
 
 - **Widen the prompt instead ("at trusted, approve artifact deletion").**

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -38,6 +38,7 @@ add a row below.
 | [0020](0020-client-status-cue-totality.md) | A client status cue must be total over its gate's end paths |
 | [0021](0021-registration-outcome-not-requery.md) | Question registration outcome flows from the call, not a re-query |
 | [0022](0022-status-bar-never-freezes.md) | Status-bar liveness is bounded by `HEARTBEAT_MS`, never by a human |
+| [0023](0023-artifact-deletion-is-proved-not-judged.md) | (proposed) Deletion approves only when the target is provably derived — amends #956's blanket escalate rule |
 
 ## By area
 
@@ -45,7 +46,7 @@ Most work touches one of these clusters, and the ADRs in a cluster constrain
 each other — reading one without its siblings is how a "fix" reopens the case
 another one closed.
 
-- **Permission decisions / auto-approve:** 0003, 0010, 0015, 0016, 0017, 0018
+- **Permission decisions / auto-approve:** 0003, 0010, 0015, 0016, 0017, 0018, 0023
 - **Questions + notifications:** 0002, 0004, 0019, 0020, 0021, 0022
 - **Protocol + contracts:** 0012, 0013, 0014, 0006
 - **Sessions + transport:** 0001, 0005, 0009

--- a/packages/daemon/src/auto-approve/levels.ts
+++ b/packages/daemon/src/auto-approve/levels.ts
@@ -64,7 +64,8 @@ export const DEFAULT_AUTO_APPROVE_LEVEL: AutoApproveLevel = 'strict';
  *   not either; what ADR 0023 gates into `trusted` is narrower:
  *   `artifact-clean` approves a deletion only when EVERY target is provably
  *   derived state (exact-named artifact directories, structural `git
- *   worktree remove`, bare lockfile-faithful `bun install`), extending the
+ *   worktree remove`, bare `bun install` — NOT lockfile-faithful, see that
+ *   group's declared residual), extending the
  *   destination-proof exception `scratch` already shipped at `balanced`.
  *   Deletion that reaches the LLM still escalates at every level.
  */

--- a/packages/daemon/src/auto-approve/levels.ts
+++ b/packages/daemon/src/auto-approve/levels.ts
@@ -59,9 +59,14 @@ export const DEFAULT_AUTO_APPROVE_LEVEL: AutoApproveLevel = 'strict';
  * - `net-read` — cut from #959 after five of eleven bypasses turned out to be
  *   curl's (#961). Re-adding it means a policy derived from `man curl` rather
  *   than remembered.
- * - `rm`, package installs, `git push`, any `--force` — not groups at all, at
- *   any strictness (#956). Deletion, remote mutation and arbitrary install
- *   scripts are where escalation earns its cost.
+ * - `git push`, remote mutation, arbitrary install scripts — not groups at
+ *   all, at any strictness (#956). Blanket `rm` and blanket `--force` are
+ *   not either; what ADR 0023 gates into `trusted` is narrower:
+ *   `artifact-clean` approves a deletion only when EVERY target is provably
+ *   derived state (exact-named artifact directories, structural `git
+ *   worktree remove`, bare lockfile-faithful `bun install`), extending the
+ *   destination-proof exception `scratch` already shipped at `balanced`.
+ *   Deletion that reaches the LLM still escalates at every level.
  */
 const LEVEL_GROUPS: Readonly<Record<AutoApproveLevel, readonly string[]>> = {
   // Exactly today's shipped `approve_groups` default. Asserted against
@@ -75,7 +80,21 @@ const LEVEL_GROUPS: Readonly<Record<AutoApproveLevel, readonly string[]>> = {
   balanced: ['read-only', 'vcs-read', 'build-test', 'fs-write', 'scratch'],
   // Adds local git mutation (add/commit/checkout/switch/merge/stash/worktree).
   // NOT `git push` — that stays an escalation at every level.
-  trusted: ['read-only', 'vcs-read', 'build-test', 'fs-write', 'scratch', 'vcs-write'],
+  // Also adds `artifact-clean` (ADR 0023): proved-derived deletion. The
+  // measured misses it exists for — `rm -rf dist`, `rm -rf node_modules &&
+  // bun install`, `git worktree remove --force ../remi-1031` — each burned
+  // ~3.5s of LLM time reaching an escalation a human then overrode. Trusted
+  // ONLY: the measurement is one machine running `trusted`, and ADR 0016's
+  // precedent is to ship narrow and widen in a deliberate one-line follow-up.
+  trusted: [
+    'read-only',
+    'vcs-read',
+    'build-test',
+    'fs-write',
+    'scratch',
+    'vcs-write',
+    'artifact-clean',
+  ],
 };
 
 /** True if `value` names a level. */

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -96,9 +96,28 @@ function hasWriteGroupPositionalVeto(segment: string): boolean {
  * paths, so `cp /tmp/a /tmp/.env` approved at `balanced` where develop
  * escalated it.
  *
- * A new mutating group MUST be added here. Forgetting is not caught by types;
- * it is caught by `permission-groups.test.ts`'s per-group sensitive-destination
- * cases, which is why those exist per group rather than once.
+ * A new mutating group MUST be added here, and NOTHING CATCHES YOU IF YOU
+ * FORGET. An earlier version of this comment claimed
+ * `permission-groups.test.ts`'s per-group cases did. Measured, and all three
+ * clauses were wrong: those cases live in `artifact-clean.test.ts`, not here;
+ * removing `'artifact-clean'` from this set flips no test; and removing
+ * `'fs-write'` flips none either, because its own `writeGroupVeto` re-checks
+ * the axis independently. Only `'scratch'` is genuinely pinned (10 failures) —
+ * it is the one group with no second copy of the check.
+ *
+ * The two checks masking each other is the real hazard: drop
+ * `isProvedArtifactTarget`'s `isSensitiveWritePath` call alone and nothing
+ * moves; drop `'artifact-clean'` here alone and nothing moves; drop BOTH and
+ * `rm -rf dist/.env` approves at 0ms. Deliberate defence in depth, but it means
+ * neither half is individually load-bearing in the test suite, so read a green
+ * run as evidence about the PAIR and not about either member.
+ *
+ * The stated invariant is also weaker than the load-bearing one. What actually
+ * prevents the escape is: every group sharing a PREFIX with a mutating group
+ * must be in this set. A future non-mutating group that happened to list `cp`
+ * would route around the axis without ever looking like a "mutating group".
+ * No live instance today — the seven current groups' mutating and non-mutating
+ * halves share no prefix — so this is a note on the comment, not on the code.
  */
 const MUTATING_GROUPS: ReadonlySet<string> = new Set([
   'fs-write',

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -667,6 +667,26 @@ function artifactCleanPoisonWalk(command: string): boolean[] {
  */
 function artifactCleanVeto(segment: string, matchedPrefix: string, poisoned: boolean): boolean {
   if (poisoned) return true;
+  // A redirect character INSIDE a target token vetoes outright, before the
+  // rewrite below can hide it. Found by the ADR 0023 PR review, and it was a
+  // real bypass rather than the bounded residual an earlier draft of the ADR
+  // claimed:
+  //
+  //     rm -rf 'dist>x/../../src'   ->  approved, and it deletes ../src
+  //
+  // `rewriteRedirectClauses` is quote-BLIND and runs on raw text, so it
+  // truncated the token at the quoted `>` and `isProvedArtifactTarget` only
+  // ever saw `dist`. The `..` segments the ascent guard exists to catch were
+  // invisible to it. `hasShellControl` reads a quote-MASKED view and correctly
+  // treats that `>` as literal, so nothing else objected. Verified against a
+  // real filesystem: with a directory named `dist>x`, the command deleted a
+  // sibling above the cwd -- and `mkdir 'dist>x'` is itself auto-approved by
+  // `fs-write`, making it a two-step, both-silent chain.
+  //
+  // A genuine redirect clause is its own token (`2>/dev/null`, `>out.txt`), so
+  // requiring the redirect shape to START the token keeps those working while
+  // refusing an embedded one. Allow-side narrowing: the safe direction.
+  if (shellWords(segment).some((w) => /[<>]/.test(w) && !/^\d*(?:>>?|<)/.test(w))) return true;
   const stripped = rewriteRedirectClauses(segment, () => '').trim();
   const words = shellWords(stripped);
 

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -269,9 +269,23 @@ function isStrictlyUnderScratchRoot(token: string, cwd: ScratchCwd): boolean {
  */
 function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd {
   if (trimmedSegment === '') return cwd;
-  const words = shellWords(trimmedSegment);
+  // Strip redirect clauses BEFORE tokenizing. `shellWords('cd ..>/dev/null')`
+  // is `['cd', '..>/dev/null']`, and that glued token is neither `..` nor
+  // `../…`, so the ascent was invisible and the tracked cwd became
+  // `<scratch>/..>/dev/null` -- a name that never pops below the root. Real
+  // bash ascends. Chained, `cd /tmp/x && cd ..>/dev/null && cd ..>/dev/null &&
+  // rm -rf etc` reached `rm -rf /etc` at `balanced`, on SHIPPED releases.
+  const words = shellWords(rewriteRedirectClauses(trimmedSegment, () => '').trim());
   if (words[0] !== 'cd') return cwd;
   const target = words[1];
+  // POSITIVE allowlist on the operand, not another round of subtracting known
+  // -bad spellings. The #1047 fix rejected a leading dash; this found the same
+  // hole one spelling over (`..>/dev/null`, `..>&1`, `..&>/dev/null`), and
+  // `&>` is not even modelled by `rewriteRedirectClauses`. So the rule is now
+  // "does this look like a path at all" -- shell metacharacters, whitespace and
+  // quotes all disqualify. `$TMPDIR`, `${TMPDIR}`, `~` and `/tmp/x` are the
+  // shapes `resolveScratchTarget` genuinely handles, so they stay in.
+  if (target !== undefined && !/^[A-Za-z0-9._+/@~$:{}-]+$/.test(target)) return null;
   // ANY leading dash resets, not just the exact `-` (#1047). `cd` reads a
   // leading-dash token as OPTIONS, so `cd -P` / `cd -L` / `cd --` / `cd -LP`
   // are an option with NO operand -- and a bare `cd` goes to `$HOME`. Testing
@@ -608,6 +622,13 @@ function cdTargetIsPlainDescendant(words: readonly string[]): boolean {
   // reached by `cd -foo` in bash either. It needs `cd ./-foo` (no leading
   // dash, still allowed) or `cd -- -foo` (three words, already poisons).
   if (target.startsWith('-')) return false;
+  // POSITIVE allowlist, added after the leading-dash fix above proved too
+  // narrow: `cd ..>/dev/null` and `cd ..&>/dev/null` carry the ascent inside a
+  // token that is not dash-led, and `&>` is not modelled by
+  // `rewriteRedirectClauses` at all. Enumerating bad spellings loses; asking
+  // "does this look like a path" does not. Shell metacharacters, whitespace
+  // and quotes all disqualify.
+  if (!/^[A-Za-z0-9._+/@-]+$/.test(target)) return false;
   if (ARTIFACT_EXPANSION_RE.test(target)) return false;
   if (target.startsWith('/') || target.startsWith('~')) return false;
   const resolved = resolveDotDot(target);
@@ -647,7 +668,18 @@ function artifactCleanPoisonWalk(command: string): boolean[] {
     // the peeled body is the two-walks-that-must-agree defect shape (#1000).
     const body = stripShellGrammar(trimmed).command;
     if (body === '') continue;
-    const words = shellWords(body);
+    // Redirect clauses stripped BEFORE tokenizing, matching what
+    // `artifactCleanVeto` already does to the same text -- two walks of one
+    // command computed from two different strings is the #1000 defect shape,
+    // and here it was live: `shellWords('cd ..>/dev/null')` glues the operand
+    // to the redirect, so `cdTargetIsPlainDescendant` saw a token that was
+    // neither `..` nor `../…` and set no poison. `cd ..>/dev/null && rm -rf
+    // dist` approved at 0ms, and the segment is idempotent, so N of them climb
+    // N levels -- reaching `~/.venv`, verbatim the outcome #1047 was supposed
+    // to have closed. Stripping first also EARNS coverage:
+    // `cd sub 2>/dev/null && rm -rf dist` now approves correctly.
+    const stripped = rewriteRedirectClauses(body, () => '').trim();
+    const words = shellWords(stripped);
     if (words[0] !== 'cd') continue;
     if (body !== trimmed || !cdTargetIsPlainDescendant(words)) poisoned = true;
   }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -84,6 +84,30 @@ function hasWriteGroupPositionalVeto(segment: string): boolean {
 }
 
 /**
+ * Every group that can MUTATE the filesystem, and therefore every group whose
+ * matches must clear the sensitive-destination axis (`sensitive-paths.ts`).
+ *
+ * Consulted by `matchGroups`'s per-owner dispatch, because that dispatch is a
+ * UNION: a prefix owned by two groups is approved when EITHER proof holds, so
+ * the axis cannot live only inside one owner's veto or the other owner is a
+ * way around it. That is not hypothetical — it is what the ADR 0023
+ * adversarial pass found: `cp`/`mv`/`mkdir`/`touch`/`tee` are owned by both
+ * `fs-write` and `scratch`, and `scratchTargetVeto` never checked sensitive
+ * paths, so `cp /tmp/a /tmp/.env` approved at `balanced` where develop
+ * escalated it.
+ *
+ * A new mutating group MUST be added here. Forgetting is not caught by types;
+ * it is caught by `permission-groups.test.ts`'s per-group sensitive-destination
+ * cases, which is why those exist per group rather than once.
+ */
+const MUTATING_GROUPS: ReadonlySet<string> = new Set([
+  'fs-write',
+  'vcs-write',
+  'scratch',
+  'artifact-clean',
+]);
+
+/**
  * The veto profile every write-side group shares: the flag boundaries above,
  * plus the sensitive-destination axis a read group never needed
  * (`sensitive-paths.ts`).
@@ -446,10 +470,21 @@ function scratchTargetVeto(segment: string, cwd: ScratchCwd): boolean {
 //     and requires a SECOND `--force` for a locked one — which this group
 //     never supplies. Committed work survives in the shared object store by
 //     construction; only the worktree's uncommitted files are at stake.
-//   - bare `bun install` (`--frozen-lockfile` only): a lockfile-faithful
-//     reinstall of dependencies already vetted, whose lockfile and
-//     package.json no write group can touch (BUILD_SURFACE,
-//     sensitive-paths.ts). `bun install <pkg>` is `bun add` and escalates.
+//   - bare `bun install` (flag allowlist: `--frozen-lockfile` only). Its
+//     lockfile and package.json are on BUILD_SURFACE (sensitive-paths.ts), so
+//     no write group can edit them into something else first, and
+//     `bun install <pkg>` is `bun add` in disguise and escalates.
+//
+//     "Lockfile-faithful" is what an EARLIER version of this comment claimed,
+//     and it is only true of the `--frozen-lockfile` form. The ADR 0023
+//     adversarial pass caught it: BARE `bun install` reconciles package.json
+//     against the lockfile, so it may resolve new versions, rewrite the
+//     lockfile, and run lifecycle scripts of whatever it installs. The bare
+//     form is covered anyway because it is the measured miss this group exists
+//     for (`rm -rf node_modules && bun install`) and narrowing to
+//     `--frozen-lockfile` would drop that back below the 95% target — but it
+//     is covered as a DECLARED residual, not because it is inert. Anyone
+//     tightening this should tighten the coverage, not the wording.
 //
 // `/tmp`/`$TMPDIR` deletion is NOT re-implemented here — `scratch` covers it,
 // and `matchGroups` tries every owning group's proof for a shared prefix.
@@ -1042,6 +1077,35 @@ export function matchGroups(
     // walk done in each pre-pass, rather than re-tracked by a closure here —
     // see `ScratchSanitized`.
     const vetoedByOwner = (owner: string, segment: string, prefix: string, index: number) => {
+      // The sensitive-destination axis is a GLOBAL conjunct, checked before any
+      // owner's own proof and never delegated to one. Found by the ADR 0023
+      // adversarial pass: the owner union below is disjunctive, so a prefix
+      // owned by both `fs-write` and `scratch` (`cp`, `mv`, `mkdir`, `touch`,
+      // `tee`) was approved the moment scratch's laxer proof held — and
+      // `scratchTargetVeto` never consulted `isSensitiveWritePath`. Measured
+      // develop -> this branch at BALANCED, a level this ADR does not even
+      // claim to touch:
+      //
+      //   cp /tmp/a /tmp/.env         develop: escalate -> branch: scratch:cp
+      //   mv /tmp/a /tmp/id_rsa       develop: escalate -> branch: scratch:mv
+      //   cp /tmp/a /tmp/.git/config  develop: escalate -> branch: scratch:cp
+      //
+      // It also falsified a shipped claim in `config.ts` ("the write groups
+      // refuse sensitive destinations regardless of prefix ... credentials
+      // (.env, id_rsa)"), which is exactly the ADR 0011 failure mode.
+      //
+      // Hoisting it here keeps the monotonicity the union was written for --
+      // adding a group cannot introduce a sensitive destination, so it still
+      // can only ADD approvals -- while restoring the property ADR 0010 wants:
+      // a deny-shaped check is broad, and must not be escapable by finding
+      // some OTHER owner whose positive proof happens to be laxer.
+      //
+      // Scoped to the MUTATING owners, not applied globally. A first cut
+      // applied it to every owner and broke three read tests
+      // (`jq .version package.json`, and two `/dev/null` redirect cases):
+      // `segmentTouchesSensitivePath` is a WRITE-side axis, and READING a
+      // sensitive path is exactly what `read-only` exists to allow.
+      if (MUTATING_GROUPS.has(owner) && segmentTouchesSensitivePath(segment)) return true;
       if (owner === 'scratch') {
         return scratchTargetVeto(segment, scratch?.cwdBySegment[index] ?? null);
       }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -248,7 +248,17 @@ function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd 
   const words = shellWords(trimmedSegment);
   if (words[0] !== 'cd') return cwd;
   const target = words[1];
-  if (target === undefined || target === '-') return null;
+  // ANY leading dash resets, not just the exact `-` (#1047). `cd` reads a
+  // leading-dash token as OPTIONS, so `cd -P` / `cd -L` / `cd --` / `cd -LP`
+  // are an option with NO operand -- and a bare `cd` goes to `$HOME`. Testing
+  // only `-` let `-P` be treated as a SUBDIRECTORY NAME: the tracked cwd
+  // became `<scratch>/-P`, still under the root, while bash had left for
+  // `$HOME`. So `cd /tmp/work && cd -P && rm -rf out` approved at 0ms and
+  // deleted `~/out`. Verified in bash on darwin: the chain ends in `$HOME`.
+  //
+  // Resetting to null is the safe direction -- an unknowable cwd means no
+  // relative target can be proved to land under a scratch root.
+  if (target === undefined || target.startsWith('-')) return null;
   return resolveScratchTarget(target, cwd);
 }
 
@@ -545,7 +555,24 @@ function isProvedArtifactTarget(token: string): boolean {
 function cdTargetIsPlainDescendant(words: readonly string[]): boolean {
   if (words.length !== 2) return false;
   const target = words[1];
-  if (target === undefined || target === '' || target === '-') return false;
+  if (target === undefined || target === '') return false;
+  // ANY leading dash, not just the exact `-`. Found by the ADR 0023
+  // adversarial pass, and it was the whole group's worst case: `cd` treats a
+  // leading-dash token as OPTIONS, not a directory, so `cd -P` / `cd -L` /
+  // `cd --` / `cd -LP` parse as an option with NO operand -- and a bare `cd`
+  // goes to `$HOME`. Verified in bash on darwin: each of those four lands in
+  // `/Users/<user>`.
+  //
+  // Rejecting only `-` therefore let `cd -P && rm -rf .venv` read as "plain
+  // relative descent", approve at 0ms, and delete the user's `~/.venv`. Worse,
+  // a SECOND plain `cd` still descends normally from there, so
+  // `cd -P && cd <anyproject> && rm -rf node_modules` reached any project
+  // under `$HOME` -- with no card, and under #1024 as a silent subagent grant.
+  //
+  // Costs nothing real: a directory whose name starts with `-` cannot be
+  // reached by `cd -foo` in bash either. It needs `cd ./-foo` (no leading
+  // dash, still allowed) or `cd -- -foo` (three words, already poisons).
+  if (target.startsWith('-')) return false;
   if (ARTIFACT_EXPANSION_RE.test(target)) return false;
   if (target.startsWith('/') || target.startsWith('~')) return false;
   const resolved = resolveDotDot(target);

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -412,6 +412,255 @@ function scratchTargetVeto(segment: string, cwd: ScratchCwd): boolean {
   return false;
 }
 
+// ---------------------------------------------------------------------------
+// `artifact-clean` group (ADR 0023): deletion approves ONLY when every target
+// is PROVABLY derived state. #956's blanket rule — deletion escalates at
+// every level — already had one shipped exception: `scratch` (above) approves
+// rm/rmdir whose every target provably resolves under a scratch root. So the
+// real shipped rule since #994 is "deletion escalates unless the destination
+// is PROVED disposable by lexical reasoning", and this section extends that
+// proof from "under /tmp" to "at or under a directory whose exact name
+// proclaims derived state".
+//
+// Three command families, each with its own veto profile (ADR 0018: a
+// mutating group supplies its own vetoes or it does not ship):
+//
+//   - `rm`/`rmdir`: every non-flag token must be a relative, non-ascending,
+//     expansion-free path with some exact-case segment on ARTIFACT_DIR_NAMES
+//     and no `isSensitiveWritePath` hit. Flags are allowlisted
+//     (write-flag-safety.ts: `-rRfv`/`-pv`, exact long spellings only).
+//   - `git worktree remove`: structural check only (at most one `--force`,
+//     no other flags, exactly one positional that is not `.`). Its safety
+//     rests on a RUNTIME veto: git refuses any path that is not a registered
+//     linked worktree of this repository, always refuses the main worktree,
+//     and requires a SECOND `--force` for a locked one — which this group
+//     never supplies. Committed work survives in the shared object store by
+//     construction; only the worktree's uncommitted files are at stake.
+//   - bare `bun install` (`--frozen-lockfile` only): a lockfile-faithful
+//     reinstall of dependencies already vetted, whose lockfile and
+//     package.json no write group can touch (BUILD_SURFACE,
+//     sensitive-paths.ts). `bun install <pkg>` is `bun add` and escalates.
+//
+// `/tmp`/`$TMPDIR` deletion is NOT re-implemented here — `scratch` covers it,
+// and `matchGroups` tries every owning group's proof for a shared prefix.
+// `git clean` is excluded in every form: its population is UNTRACKED files,
+// and untracked is not derived — a file the agent created five minutes ago is
+// untracked source (ADR 0023).
+//
+// Accepted residuals, DECLARED rather than open bugs (ADR 0023):
+//
+//   - The name list is a convention, not a guarantee: a SOURCE directory
+//     genuinely named `build/` or `coverage/` is deletable at `trusted`.
+//     Bounded honestly: tracked contents come back via `git checkout --
+//     <path>` (shared history is untouched by rm); untracked contents are
+//     lost — the same residual the owner accepted for worktree `--force`.
+//   - Symlinks are invisible to every lexical check here, exactly as
+//     `scratch` documents above: an INTERMEDIATE segment that is a symlink
+//     (`packages/web` pointing elsewhere) makes `rm -rf packages/web/dist`
+//     delete through it. The one lexically VISIBLE trigger — a trailing `/`
+//     on a target, which makes `rm -rf link/` traverse the link target on
+//     some platforms — is vetoed.
+//
+// #1024 makes this group a silent subagent grant: a subagent's `rm -rf dist`
+// at `trusted` answers the hook with no render and no card. The visibility
+// path is `auto_approve.subagent_alert` (an `rm` entry there alerts without
+// blocking) — chosen, not overlooked (ADR 0023).
+// ---------------------------------------------------------------------------
+
+/**
+ * Directory names whose EXACT spelling proclaims derived state.
+ *
+ * This is an allow surface and will attract additions (ADR 0023). An entry
+ * qualifies only if the exact name proclaims derived state AND a command the
+ * repo already runs regenerates it. `vendor` (often tracked), `tmp`
+ * (proclaims temporariness but regenerates nothing), and any suffix/glob
+ * form (`*.egg-info`) do not clear the bar.
+ *
+ * Matching is EXACT-CASE while `sensitive-paths.ts` lowercases, and the
+ * asymmetry is deliberate (ADR 0010 applied to names): the deny check
+ * lowercases to WIDEN; an allow check that lowercased would treat `Dist` as
+ * `dist` on case-sensitive Linux, where they are different directories.
+ * "Cleaning up" the inconsistency reopens a hole.
+ */
+const ARTIFACT_DIR_NAMES: ReadonlySet<string> = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'target',
+  'coverage',
+  '__pycache__',
+  '.venv',
+]);
+
+/**
+ * Characters whose presence means the token rm receives is not the token
+ * written: variable expansion, glob, or brace expansion would rewrite it
+ * first, so no lexical proof about the written text can hold. `shellWords`
+ * has removed quotes by the time this runs, so a QUOTED glob (`'dist*'`,
+ * genuinely literal to the shell) is refused too — over-refusal, the safe
+ * direction, costing an escalation on a filename that really contains one of
+ * these characters.
+ */
+const ARTIFACT_EXPANSION_RE = /[$`*?[{}]/;
+
+/**
+ * True if `token` is PROVABLY at or under an exact-named derived-state
+ * directory: relative, non-ascending, expansion-free, some path segment on
+ * `ARTIFACT_DIR_NAMES`, and no sensitive hit. The proof is name-based, not
+ * cwd-based — which is why a poisoning `cd` (see `artifactCleanPoisonWalk`)
+ * has to be checked separately: the name `dist` proves the same thing in any
+ * directory REACHED BY relative descent, and nothing at all in `/etc`.
+ */
+function isProvedArtifactTarget(token: string): boolean {
+  if (token === '') return false;
+  if (ARTIFACT_EXPANSION_RE.test(token)) return false;
+  // Relative paths only: an absolute or home-rooted target can name any tree
+  // on the machine, and the measured population this group exists for is
+  // in-project relative cleanup (ADR 0023).
+  if (token.startsWith('/') || token.startsWith('~')) return false;
+  // Trailing-slash veto: `rm -rf link/` traverses a symlinked directory's
+  // TARGET on some platforms. The one symlink trigger that is lexically
+  // visible; the residuals note above records the rest. Checked on the RAW
+  // token — `resolveDotDot` would silently drop the slash.
+  if (token.endsWith('/')) return false;
+  // Resolve `.`/`..` BEFORE the name scan, the same ordering
+  // `sensitive-paths.ts` documents for its prefix axis: `dist/../src` names
+  // `src` and must be judged as `src`.
+  const resolved = resolveDotDot(token);
+  if (resolved === '' || resolved === '..' || resolved.startsWith('../')) return false;
+  if (!resolved.split('/').some((s) => ARTIFACT_DIR_NAMES.has(s))) return false;
+  // The deny axis still applies ON TOP of the allow proof (ADR 0018):
+  // `dist/.env` carries a qualifying segment AND a sensitive basename, and
+  // the deny check wins.
+  return !isSensitiveWritePath(token);
+}
+
+/**
+ * True if a `cd`'s argument list is a single plain relative descendant —
+ * the only `cd` shape that does not poison `artifact-clean` (see
+ * `artifactCleanPoisonWalk`). Anything else (bare `cd` → `$HOME`, `cd -` →
+ * unknowable, absolute, `~`, expansion, ascending, extra arguments) fails.
+ */
+function cdTargetIsPlainDescendant(words: readonly string[]): boolean {
+  if (words.length !== 2) return false;
+  const target = words[1];
+  if (target === undefined || target === '' || target === '-') return false;
+  if (ARTIFACT_EXPANSION_RE.test(target)) return false;
+  if (target.startsWith('/') || target.startsWith('~')) return false;
+  const resolved = resolveDotDot(target);
+  return resolved !== '..' && !resolved.startsWith('../');
+}
+
+/**
+ * Pre-walk for `artifact-clean` (ADR 0023), beside
+ * `sanitizeCommandForScratch`: for each compound segment BY INDEX, whether a
+ * poisoning `cd` occurred anywhere earlier. A `cd` poisons unless its single
+ * target is a plain relative descendant; a grammar-wrapped `cd` (`if ...;
+ * then cd sub; fi`) poisons regardless of target, because it runs zero or
+ * more times and the directory afterwards is unknowable from the text.
+ * Poison is NEVER un-poisoned: after `cd /etc`, a later `rm -rf dist` names
+ * `/etc/dist`, and no subsequent `cd` can make the tracked directory
+ * trustworthy again for an ALLOW decision.
+ *
+ * Unlike `scratch`'s cwd tracking, the joining operators (`|`, `||`) need no
+ * special handling here, because poison is one-directional: a GOOD `cd` that
+ * may not have run is harmless either way (the artifact proof is name-based
+ * and holds in the old directory too), and a BAD `cd` that may not have run
+ * still poisons — over-escalation, the safe direction.
+ */
+function artifactCleanPoisonWalk(command: string): boolean[] {
+  const poisonedBySegment: boolean[] = [];
+  let poisoned = false;
+  for (const part of splitCompoundParts(command)) {
+    // Like the scratch walk: the state RECORDED for a segment is the one in
+    // effect when the shell reaches it — a `cd` poisons the segments after
+    // it, not itself (a `cd` segment is neutral and never matches anyway).
+    poisonedBySegment.push(poisoned);
+    const trimmed = part.text.trim();
+    if (trimmed === '') continue;
+    // Detect the `cd` in the PEELED body, not the raw text, for the same
+    // reason the scratch walk does: `then cd /etc` is a `cd` that moves the
+    // shell, and judging raw text here while `matchCoveredCommand` judges
+    // the peeled body is the two-walks-that-must-agree defect shape (#1000).
+    const body = stripShellGrammar(trimmed).command;
+    if (body === '') continue;
+    const words = shellWords(body);
+    if (words[0] !== 'cd') continue;
+    if (body !== trimmed || !cdTargetIsPlainDescendant(words)) poisoned = true;
+  }
+  return poisonedBySegment;
+}
+
+/**
+ * Veto for a segment `artifact-clean`'s own prefix matched, dispatching by
+ * the matched family. Returns true to REFUSE — fall through to the LLM,
+ * where deletion still escalates at every level: the prompt half of #956's
+ * rule is untouched by ADR 0023.
+ *
+ * Any redirect clause still present in `segment` is discard/fd-dup by
+ * construction (`hasShellControl` vetoed everything else before this ran);
+ * it is stripped so a leftover token like `2>/dev/null` is not mistaken for
+ * a positional target — the same reasoning as `scratchTargetVeto`.
+ */
+function artifactCleanVeto(segment: string, matchedPrefix: string, poisoned: boolean): boolean {
+  if (poisoned) return true;
+  const stripped = rewriteRedirectClauses(segment, () => '').trim();
+  const words = shellWords(stripped);
+
+  if (matchedPrefix === 'rm' || matchedPrefix === 'rmdir') {
+    // Flag axis first: the exact allowlist in write-flag-safety.ts.
+    if (hasUnsafeWriteFlag(stripped)) return true;
+    const targets = words.slice(1).filter((w) => w !== '' && !w.startsWith('-'));
+    // No target, no proof: a bare `rm -rf` approves nothing. And EVERY
+    // token is checked rather than guessing which one is "the destination",
+    // mirroring `segmentTouchesSensitivePath`'s reasoning: getting a
+    // command's flag grammar wrong can only fail in the safe direction here
+    // (an extra escalation, never a wrongly-approved delete).
+    if (targets.length === 0) return true;
+    return !targets.every(isProvedArtifactTarget);
+  }
+
+  if (matchedPrefix === 'git worktree remove') {
+    // Defensive re-anchor: a prefix match guarantees the raw text starts
+    // with the entry, and this guarantees the TOKENIZED view agrees.
+    if (words[0] !== 'git' || words[1] !== 'worktree' || words[2] !== 'remove') return true;
+    let force = 0;
+    const positionals: string[] = [];
+    for (const w of words.slice(3)) {
+      if (w === '') continue;
+      if (w === '-f' || w === '--force') {
+        force++;
+        continue;
+      }
+      // ANY other flag fails closed — `-C`, `--git-dir`, a bare `--`, a
+      // value-carrying `--force=...`: the safety argument is git's runtime
+      // refusal profile, and an unmodeled flag could change it.
+      if (w.startsWith('-')) return true;
+      positionals.push(w);
+    }
+    // A LOCKED worktree needs a second --force, which this group never
+    // grants: the lock is a human's explicit "do not clean this up".
+    if (force > 1) return true;
+    if (positionals.length !== 1) return true;
+    return positionals[0] === '.';
+  }
+
+  if (matchedPrefix === 'bun install') {
+    if (words[0] !== 'bun' || words[1] !== 'install') return true;
+    for (const w of words.slice(2)) {
+      if (w === '' || w === '--frozen-lockfile') continue;
+      // A positional makes it `bun add` in disguise; any other flag
+      // (`--force`, `-g`, ...) is outside the lockfile-faithful shape.
+      return true;
+    }
+    return false;
+  }
+
+  // A prefix this dispatch does not model is refused, not guessed.
+  return true;
+}
+
 export interface PermissionGroup {
   /** Bare tool names this group approves (e.g. "Read", "Glob"). */
   readonly tools: readonly string[];
@@ -561,10 +810,16 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'tee',
       'cp',
       'mv',
-      // `rm`, `rmdir`, `truncate`, `dd`, `shred`, `chmod` and `chown` are
-      // deliberately absent at every strictness level (#956). Deletion and
-      // permission changes are where escalation earns its cost; a write group
-      // that quietly covered them would be the #536 mistake in a new place.
+      // `truncate`, `dd`, `shred`, `chmod` and `chown` are deliberately
+      // absent at every strictness level (#956). `rm`/`rmdir` are absent
+      // from THIS group for a polarity reason (ADR 0023): fs-write's
+      // destination axis is a DENYlist ("not a known-bad path"), which is
+      // the right shape for writes and fails OPEN for deletion — `rm -rf
+      // src` touches nothing sensitive. Deletion approves only through a
+      // destination-PROOF group, where the target must be shown disposable:
+      // `scratch` (under a scratch root) and `artifact-clean` (exact-named
+      // derived directories; `trusted` only). Everything else
+      // deletion-shaped still escalates at every level.
     ],
     segmentVeto: writeGroupVeto,
     toolVeto: vetoSensitiveToolPath,
@@ -601,6 +856,16 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
   scratch: {
     tools: [],
     commands: SCRATCH_COMMANDS,
+  },
+  // See the "`artifact-clean` group" section above `PermissionGroup` for the
+  // full design writeup (ADR 0023). Like `scratch`, no `segmentVeto` field:
+  // its veto needs the cd-poison state for the segment's INDEX, which the
+  // stateless `(segment) => boolean` signature has no room for, so
+  // `matchGroups` calls `artifactCleanVeto` directly. Gated into `trusted`
+  // only (levels.ts).
+  'artifact-clean': {
+    tools: [],
+    commands: ['rm', 'rmdir', 'git worktree remove', 'bun install'],
   },
 };
 
@@ -713,38 +978,72 @@ export function matchGroups(
     const scratchActive = known.includes('scratch');
     const scratch = scratchActive ? sanitizeCommandForScratch(rawCommand) : null;
     const command = scratch?.command ?? rawCommand;
-    // Map each prefix back to its owning group for the descriptive return.
-    const prefixToGroup = new Map<string, string>();
+    // The cd-poison pre-walk for `artifact-clean` (ADR 0023). Like the
+    // scratch pre-pass: run only when the group was actually requested, and
+    // walked over the SAME string `matchCoveredCommand` receives, so the two
+    // agree by segment index (the scratch sanitize preserves segment count
+    // and joiners; it only rewrites redirect clauses inside segments).
+    const artifactPoison = known.includes('artifact-clean')
+      ? artifactCleanPoisonWalk(command)
+      : null;
+    // Map each prefix to EVERY owning group that lists it, in request order.
+    // Multiple owners are real, and load-bearing since ADR 0023: at
+    // `trusted`, `rm` belongs to BOTH `scratch` (destination proof: under a
+    // scratch root) and `artifact-clean` (name proof: an exact-named derived
+    // directory), and a segment is approved when EITHER proof holds. The
+    // previous first-registrant-wins map would have let `scratch` eat the
+    // prefix and veto `rm -rf dist` outright. Trying every owner also makes
+    // this matcher monotone in its group list — adding a group can only add
+    // approvals — which first-wins quietly was not (a scratch-provable `cp`
+    // under /tmp escalated the moment `fs-write` was requested alongside).
+    const prefixOwners = new Map<string, string[]>();
     for (const name of known) {
       for (const cmd of BUILTIN_GROUPS[name]?.commands ?? []) {
-        if (!prefixToGroup.has(cmd)) prefixToGroup.set(cmd, name);
+        const owners = prefixOwners.get(cmd);
+        if (owners === undefined) prefixOwners.set(cmd, [name]);
+        else owners.push(name);
       }
     }
     // Per-segment veto (#957/#959): each matched segment is judged by the
     // profile of the group that matched IT, not by one blanket rule for the
     // whole command. A group with no `segmentVeto` gets the historical read
     // profile, so read-only/vcs-read/build-test behave exactly as before.
-    // `scratch` is special-cased directly (its veto needs the tracked scratch
-    // directory, which the stateless `PermissionGroup.segmentVeto` signature
-    // has no room for). That directory is looked up BY SEGMENT INDEX from the
-    // single walk done in the pre-pass, rather than re-tracked by a closure
-    // here — see `ScratchSanitized`.
+    // `scratch` and `artifact-clean` are special-cased directly (their vetoes
+    // need per-INDEX state — the tracked scratch directory, the cd-poison
+    // flag — which the stateless `PermissionGroup.segmentVeto` signature has
+    // no room for). That state is looked up BY SEGMENT INDEX from the single
+    // walk done in each pre-pass, rather than re-tracked by a closure here —
+    // see `ScratchSanitized`.
+    const vetoedByOwner = (owner: string, segment: string, prefix: string, index: number) => {
+      if (owner === 'scratch') {
+        return scratchTargetVeto(segment, scratch?.cwdBySegment[index] ?? null);
+      }
+      if (owner === 'artifact-clean') {
+        return artifactCleanVeto(segment, prefix, artifactPoison?.[index] ?? true);
+      }
+      const veto = BUILTIN_GROUPS[owner]?.segmentVeto ?? readSegmentVeto;
+      return veto(segment);
+    };
+    // The owner whose proof passed for the FIRST matched segment — the
+    // segment whose prefix `matchCoveredCommand` returns — so the label
+    // names the group that actually approved it, not the first registrant.
+    let hitOwner: string | null = null;
     const hit = matchCoveredCommand(
       command,
-      [...prefixToGroup.keys()],
+      [...prefixOwners.keys()],
       readSegmentVeto,
       (segment, matchedPrefix, index) => {
-        const owner = prefixToGroup.get(matchedPrefix);
-        if (owner === 'scratch') {
-          return scratchTargetVeto(segment, scratch?.cwdBySegment[index] ?? null);
+        for (const owner of prefixOwners.get(matchedPrefix) ?? []) {
+          if (!vetoedByOwner(owner, segment, matchedPrefix, index)) {
+            if (hitOwner === null) hitOwner = owner;
+            return false;
+          }
         }
-        const group = owner === undefined ? undefined : BUILTIN_GROUPS[owner];
-        const veto = group?.segmentVeto ?? readSegmentVeto;
-        return veto(segment);
+        return true;
       },
     );
     if (hit === null) return null;
-    return `${prefixToGroup.get(hit) ?? 'group'}:${hit}`;
+    return `${hitOwner ?? prefixOwners.get(hit)?.[0] ?? 'group'}:${hit}`;
   }
 
   for (const name of known) {

--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -109,7 +109,12 @@ const ESCALATE_ENTRIES: ReadonlyArray<{
   {
     text: '- Bash: file creation, modification, or deletion under the project tree',
     perLevel: {
-      // Creation and modification move to APPROVE; deletion never does.
+      // Creation and modification move to APPROVE; deletion never does — on
+      // any path that reaches the LLM. ADR 0023's `artifact-clean` (trusted)
+      // approves proved-derived deletion in the DETERMINISTIC layer, which
+      // never builds a prompt, so this text is deliberately unchanged: a
+      // deletion the model is asked about is one no proof covered, and it
+      // still escalates at every level.
       balanced: '- Bash: file DELETION under the project tree (rm, rmdir, shred, truncate)',
       trusted: '- Bash: file DELETION under the project tree (rm, rmdir, shred, truncate)',
     },

--- a/packages/daemon/src/auto-approve/write-flag-safety.ts
+++ b/packages/daemon/src/auto-approve/write-flag-safety.ts
@@ -47,6 +47,13 @@
  * Long options are handled by two-way prefix matching against a dangerous
  * list, because git accepts unambiguous abbreviations: `--forc` must be
  * caught by the `--force` entry, and `--force-with-lease` must be too.
+ *
+ * The `rm`/`rmdir` families (ADR 0023) invert the long-option rule: an
+ * EXACT-spelling allowlist (`safeLongFlags`) instead of the dangerous
+ * denylist. For a deletion command the dangerous set is open-ended — GNU rm
+ * accepts any unambiguous abbreviation, so `--recur` IS `--recursive` and
+ * `--no-p` IS `--no-preserve-root` — and a denylist under-reaches on every
+ * spelling nobody listed. Only exact membership fails closed.
  */
 
 import { shellWords } from './shell-safety.ts';
@@ -65,8 +72,19 @@ interface FlagPolicy {
    * Long options that veto, matched in BOTH prefix directions so an
    * abbreviation (`--forc`) and an extension (`--force-with-lease`) are each
    * caught by the `--force` entry. Written without the leading dashes.
+   * Ignored when `safeLongFlags` is present.
    */
   readonly dangerousLongFlags: readonly string[];
+  /**
+   * When present, long options are EXACT-membership allowlisted instead: a
+   * `--token` whose body (everything after the dashes, INCLUDING any
+   * `=value`) is not literally in this set vetoes the segment, so an
+   * abbreviation (`--recur`) and a value-carrying spelling (`--force=yes`)
+   * both fall outside it and fail closed. Written without the leading
+   * dashes. The inversion is for families whose dangerous long-option set is
+   * open-ended (ADR 0023) — see the module doc.
+   */
+  readonly safeLongFlags?: readonly string[];
 }
 
 const FLAG_POLICIES: readonly FlagPolicy[] = [
@@ -103,6 +121,25 @@ const FLAG_POLICIES: readonly FlagPolicy[] = [
     family: /^tee\b/,
     safeShortFlags: 'aip',
     dangerousLongFlags: ['output-error'],
+  },
+  {
+    // rm/rmdir (ADR 0023): consumed only by `artifact-clean`'s veto — no
+    // other group lists either prefix through this module (`scratch` covers
+    // rm too, but its safety is destination proof, not flag policy). Long
+    // flags are the EXACT-spelling allowlist, not the dangerous denylist:
+    // GNU rm accepts unambiguous abbreviations, so `--recur`,
+    // `--no-preserve-root`, `--interactive=never` and every spelling nobody
+    // listed all veto by falling OUTSIDE the set.
+    family: /^rm\b/,
+    safeShortFlags: 'rRfv',
+    dangerousLongFlags: [], // unused: safeLongFlags governs
+    safeLongFlags: ['recursive', 'force', 'verbose'],
+  },
+  {
+    family: /^rmdir\b/,
+    safeShortFlags: 'pv',
+    dangerousLongFlags: [], // unused: safeLongFlags governs
+    safeLongFlags: ['parents', 'verbose'],
   },
   {
     // cp/mv: -f forces past a permission error. NOTE the real clobber
@@ -182,6 +219,14 @@ export function hasUnsafeWriteFlag(segment: string): boolean {
     if (!token.startsWith('-') || token === '-' || token === '--') continue;
 
     if (token.startsWith('--')) {
+      if (policy.safeLongFlags !== undefined) {
+        // EXACT spelling or veto (ADR 0023). Compared against the WHOLE
+        // token body — `--force=yes` is `force=yes`, not `force` — so an
+        // abbreviated or value-carrying spelling falls outside the set and
+        // fails closed, the direction the module doc requires.
+        if (!policy.safeLongFlags.includes(token.slice(2))) return true;
+        continue;
+      }
       const name = token.slice(2).split('=')[0] ?? '';
       for (const dangerous of policy.dangerousLongFlags) {
         if (longFlagMatches(name, dangerous)) return true;

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -1250,6 +1250,10 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 #   vcs-write   git add/commit/checkout/switch/merge, stash push, worktree add
 #   scratch     touch/cp/mv/tee/mkdir/rm/rmdir + output redirection, ONLY when
 #               every target resolves under /tmp, /private/tmp, or $TMPDIR
+#   artifact-clean  rm/rmdir ONLY when every target is a relative path at or
+#               under an exact-named derived-state dir (node_modules, dist,
+#               build, out, target, coverage, __pycache__, .venv), plus
+#               structural "git worktree remove" and bare "bun install"
 #
 # The write groups refuse sensitive destinations regardless of prefix: system
 # trees (/etc, /usr, /System, ...), credentials (~/.ssh, ~/.aws, .env, id_rsa),
@@ -1260,19 +1264,26 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 # (package.json, tsconfig.json, lockfiles, Makefile, ...), because build-test
 # is enabled by DEFAULT and executes what those files say. scratch instead
 # gets its safety entirely from the destination being confined to a scratch
-# root, which is why it is the one group allowed to cover deletion and output
-# redirection -- rm/rmdir and >/>> are excluded from every OTHER group.
+# root -- and artifact-clean from the target's exact NAME proving derived
+# state -- which is why those two are the only groups allowed to cover
+# deletion: the target must be PROVED disposable, not merely "not known-bad".
+# rm/rmdir and >/>> are excluded from every OTHER group.
 #
-# Matching is case-insensitive (macOS filesystems are) and resolves dot-dot.
+# Deny matching is case-insensitive (macOS filesystems are) and resolves
+# dot-dot; artifact-clean's name match is deliberately exact-case (an allow
+# check that lowercased would conflate Dist with dist on Linux).
 #
-# rm, package installs, git push, and any --force are in NO group EXCEPT
-# scratch's own deletion coverage, which stays confined to scratch roots.
+# Blanket rm, package installs, git push, and any --force are still in no
+# group: deletion approves only through scratch's and artifact-clean's
+# proofs above, "git worktree remove --force" approves only single-force
+# against git's own runtime refusals, and bare "bun install" is a
+# lockfile-faithful reinstall ("bun install <pkg>" still escalates).
 # Remote mutation and arbitrary install scripts stay escalations everywhere.
 # Strictness preset. Selects which of the groups above are auto-approved:
 #
 #   strict     read-only + vcs-read + build-test   (the default; today's behavior)
 #   balanced   strict   + fs-write + scratch
-#   trusted    balanced + vcs-write
+#   trusted    balanced + vcs-write + artifact-clean
 #
 # An explicit approve_groups below OVERRIDES the preset entirely, and the
 # daemon logs that it did -- so a config written before levels existed keeps

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -1262,10 +1262,18 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 # ~/.remi + ~/.claude -- config that governs this very mechanism, which an
 # auto-approved write must never be able to widen -- and the BUILD SURFACE
 # (package.json, tsconfig.json, lockfiles, Makefile, ...), because build-test
-# is enabled by DEFAULT and executes what those files say. scratch instead
-# gets its safety entirely from the destination being confined to a scratch
-# root -- and artifact-clean from the target's exact NAME proving derived
-# state -- which is why those two are the only groups allowed to cover
+# is enabled by DEFAULT and executes what those files say. This axis applies
+# to EVERY mutating group, scratch and artifact-clean included -- narrowed
+# from "the write groups" by the ADR 0023 adversarial pass. It used to live
+# inside fs-write's veto alone, so once matchGroups began trying every owning
+# group's proof for a shared prefix, scratch's laxer proof became a way around
+# it: cp /tmp/a /tmp/.env approved at balanced where it had escalated. A
+# deny-shaped check must not be escapable by finding an owner whose positive
+# proof is laxer (ADR 0010), so it is now checked before any owner's proof.
+# The cost is real and accepted: a genuinely disposable /tmp/.env now
+# escalates. scratch still gets its POSITIVE proof from the destination being
+# confined to a scratch root -- and artifact-clean from the target's exact NAME
+# proving derived state -- which is why those two are the only groups allowed to cover
 # deletion: the target must be PROVED disposable, not merely "not known-bad".
 # rm/rmdir and >/>> are excluded from every OTHER group.
 #

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -1281,12 +1281,22 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 # dot-dot; artifact-clean's name match is deliberately exact-case (an allow
 # check that lowercased would conflate Dist with dist on Linux).
 #
-# Blanket rm, package installs, git push, and any --force are still in no
-# group: deletion approves only through scratch's and artifact-clean's
-# proofs above, "git worktree remove --force" approves only single-force
-# against git's own runtime refusals, and bare "bun install" is a
-# lockfile-faithful reinstall ("bun install <pkg>" still escalates).
-# Remote mutation and arbitrary install scripts stay escalations everywhere.
+# Blanket rm, package installs, git push, and BLANKET --force are still in
+# no group: deletion approves only through scratch's and artifact-clean's
+# proofs above. Read the narrow exceptions literally -- artifact-clean does
+# accept -f/--force on rm (they are on its exact flag allowlist), and one
+# --force on "git worktree remove", which approves only single-force against
+# git's own runtime refusals.
+#
+# Bare "bun install" is approved and is NOT lockfile-faithful: only
+# --frozen-lockfile guarantees that. Bare install reconciles package.json
+# against the lockfile, so it may resolve new versions, rewrite the lockfile,
+# and run lifecycle scripts of what it installs. It is covered because it is
+# the measured case this exists for, as a DECLARED residual (ADR 0023) --
+# which is also why "arbitrary install scripts stay escalations everywhere"
+# below is scoped to installs this group does not name.
+# ("bun install <pkg>" is "bun add" in disguise and still escalates.)
+# Remote mutation stays an escalation everywhere.
 # Strictness preset. Selects which of the groups above are auto-approved:
 #
 #   strict     read-only + vcs-read + build-test   (the default; today's behavior)

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -115,6 +115,16 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['rm -rf dist/*', 'glob in a CHILD segment: same'],
   ['rm -rf {a,b}/dist', 'brace in a parent segment: same'],
   ['rm -rf dist/.env', 'sensitive basename under an artifact dir: the deny axis wins'],
+  // A quoted `>` inside a target used to TRUNCATE the token the proof saw:
+  // `rewriteRedirectClauses` is quote-blind and runs on raw text, so
+  // `isProvedArtifactTarget` only ever got `dist` and the `..` segments were
+  // invisible. Executed against a real filesystem, it deleted a sibling above
+  // the cwd. An earlier ADR draft called this a bounded junk-name residual;
+  // the PR review showed it reaches source and, with enough `..`, anywhere.
+  ["rm -rf 'dist>x/../../src'", 'quoted > truncated the token: this names ../../src'],
+  ["rm -rf 'coverage>x/../..'", 'same, ascending out of the tree'],
+  ["rm -rf 'node_modules>x/../../../../Documents'", 'same, reaching $HOME/Documents'],
+  ["rm -rf 'dist<x/../../src'", 'input redirect, same truncation shape'],
   ['rm -rf', 'no target, no proof'],
   // --- flag axis: exact allowlist (5)
   ['rm --no-preserve-root -rf dist', 'long flag outside the exact allowlist'],
@@ -162,13 +172,13 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
 ];
 
-describe('the adversarial corpus: 48 refusals (ADR 0023)', () => {
-  test('the corpus is the full 48 entries', () => {
+describe('the adversarial corpus: 52 refusals (ADR 0023)', () => {
+  test('the corpus is the full 52 entries', () => {
     // 40 from the design's own corpus; 8 added by the independent adversarial
     // pass ADR 0023 requires before merge: 5 for the `cd -<option>` family
     // (#1047) and 3 that actually pin the expansion guard the two shipped
     // glob/brace entries only appeared to.
-    expect(ADVERSARIAL.length).toBe(48);
+    expect(ADVERSARIAL.length).toBe(52);
   });
 
   for (const [cmd, why] of ADVERSARIAL) {

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -1,0 +1,223 @@
+/**
+ * ADR 0023: `artifact-clean` — deletion approves only when every target is
+ * PROVABLY derived state.
+ *
+ * The adversarial corpus below is part of the deliverable, not documentation
+ * (ADR 0023): #959 needed four review rounds and found eleven bypasses, three
+ * of them in code written to fix the previous round. Every negative entry
+ * asserts the verdict the design requires — null, i.e. fall through to the
+ * LLM, where deletion still escalates at every level — and every positive
+ * control asserts the 0ms approval the group exists to grant, including the
+ * three measured misses that motivated it (each ~3.5s of LLM time before).
+ *
+ * No mocks (repo rule): `matchGroups` is a pure function over
+ * (toolName, toolInput), so none are needed.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { groupsForLevel } from '../../src/auto-approve/levels.ts';
+import { matchGroups, matchGroupsBroad } from '../../src/auto-approve/permission-groups.ts';
+
+const GROUP = ['artifact-clean'];
+
+/** Match a Bash command; defaults to the group under test, alone. */
+function bash(command: string, groups: readonly string[] = GROUP): string | null {
+  return matchGroups('Bash', { command }, groups);
+}
+
+describe('positive controls: the three measured misses approve', () => {
+  // The cold-replay population (ADR 0023 receipts): covering exactly these
+  // three takes the owner's real escalation replay from 17/21 to 20/21.
+  test('rm -rf dist', () => {
+    expect(bash('rm -rf dist')).toBe('artifact-clean:rm');
+  });
+
+  test('rm -rf node_modules && bun install', () => {
+    expect(bash('rm -rf node_modules && bun install')).toBe('artifact-clean:rm');
+  });
+
+  test('git worktree remove --force ../remi-1031', () => {
+    expect(bash('git worktree remove --force ../remi-1031')).toBe(
+      'artifact-clean:git worktree remove',
+    );
+  });
+});
+
+describe('positive controls: ordinary artifact cleanup', () => {
+  const cases: Array<[string, string]> = [
+    ['rm -rf node_modules', 'artifact-clean:rm'],
+    ['rm -rf packages/web/dist', 'artifact-clean:rm'],
+    ['rm -rf dist coverage', 'artifact-clean:rm'],
+    ['rm -rf ./dist', 'artifact-clean:rm'],
+    ['rm -rf "dist"', 'artifact-clean:rm'],
+    // Deleting UNDER an artifact dir is as proved as deleting the dir.
+    ['rm -rf dist/assets', 'artifact-clean:rm'],
+    ['rm -rf __pycache__', 'artifact-clean:rm'],
+    ['rm -rf .venv', 'artifact-clean:rm'],
+    ['rm -rf target/debug', 'artifact-clean:rm'],
+    // A discard redirect is permitted by hasShellControl and must not be
+    // mistaken for a positional target.
+    ['rm -rf coverage 2>/dev/null', 'artifact-clean:rm'],
+    // Exact long spellings are on the allowlist.
+    ['rm --recursive --force dist', 'artifact-clean:rm'],
+    ['rmdir build', 'artifact-clean:rmdir'],
+    ['rmdir -p out/nested', 'artifact-clean:rmdir'],
+    // A plain relative-descendant cd does not poison.
+    ['cd packages/web && rm -rf dist', 'artifact-clean:rm'],
+    ['bun install', 'artifact-clean:bun install'],
+    ['bun install --frozen-lockfile', 'artifact-clean:bun install'],
+    ['git worktree remove ../engine-epic-v0.6.0', 'artifact-clean:git worktree remove'],
+    ['git worktree remove -f ../wt', 'artifact-clean:git worktree remove'],
+  ];
+  for (const [cmd, expected] of cases) {
+    test(JSON.stringify(cmd), () => expect(bash(cmd)).toBe(expected));
+  }
+
+  test('the declared residual: a SOURCE dir genuinely named build is deletable', () => {
+    // ADR 0023 accepts this: the name list is a convention, not a guarantee.
+    // Bounded honestly — tracked contents come back via `git checkout --
+    // build` (rm does not touch shared history); untracked contents are
+    // lost, the same residual the owner accepted for worktree --force. A
+    // DECLARED residual, not a bug: do not "fix" it here.
+    expect(bash('rm -rf build')).toBe('artifact-clean:rm');
+  });
+});
+
+/**
+ * The 40-entry adversarial corpus (ADR 0023). Expected verdict for every
+ * entry: null — fall through to the LLM, where deletion escalates at every
+ * level. Grouped by the veto that must catch each; the second column names
+ * it, so a future red test says WHICH proof obligation broke.
+ */
+const ADVERSARIAL: ReadonlyArray<[string, string]> = [
+  // --- target grammar: the name proof (14)
+  ['rm -rf src', 'no artifact-named segment'],
+  ['rm -rf Dist', 'exact-case only: Dist is not dist on case-sensitive filesystems'],
+  ['rm -rf dist/../src', 'dot-dot resolves BEFORE the name scan: this names src'],
+  ['rm -rf ../dist', 'ascending target'],
+  ['rm -rf node_modules/../../etc', 'still ascends after resolution'],
+  ['rm -rf /Users/me/project/dist', 'absolute target'],
+  ['rm -rf ~/dist', 'home-rooted target'],
+  ['rm -rf $HOME/dist', 'variable expansion'],
+  ['rm -rf dist/', 'trailing slash traverses a symlinked dir target on some platforms'],
+  ['rm -rf dist src', 'EVERY target must prove, not just one'],
+  ['rm -rf dist*', 'glob'],
+  ['rm -rf {dist,build}', 'brace expansion'],
+  ['rm -rf dist/.env', 'sensitive basename under an artifact dir: the deny axis wins'],
+  ['rm -rf', 'no target, no proof'],
+  // --- flag axis: exact allowlist (5)
+  ['rm --no-preserve-root -rf dist', 'long flag outside the exact allowlist'],
+  ['rm --recur dist', 'GNU abbreviation of --recursive: outside the EXACT-spelling set'],
+  ['rm --force=yes dist', 'a value-carrying spelling is not the exact token'],
+  ['rm -rfd dist', 'unknown short flag inside a cluster'],
+  ['rmdir --ignore-fail-on-non-empty build', 'rmdir long flag outside the allowlist'],
+  // --- shell structure (6)
+  ['rm -rf $(pwd)/dist', 'command substitution'],
+  ['rm -rf dist > deleted.txt', 'redirect to a real file'],
+  ['rm -rf dist; rm -rf /etc/cron.d', 'every compound segment must be covered'],
+  ['rm -rf dist\nrm -rf ~/Documents', 'an unquoted newline is a separator'],
+  ['sudo rm -rf dist', 'wrappers are not covered prefixes'],
+  ['VERBOSE=1 rm -rf dist', 'assignment prefixes are never peeled'],
+  // --- cd poison (7)
+  ['cd /etc && rm -rf dist', 'absolute cd: dist now names /etc/dist'],
+  ['cd .. && rm -rf node_modules', 'ascending cd'],
+  ['cd ~ && rm -rf .venv', 'home cd'],
+  ['cd $TMPDIR && rm -rf build', 'expansion cd (scratch may prove this; THIS group must not)'],
+  ['cd - && rm -rf dist', 'cd -: the previous directory is unknowable statically'],
+  ['cd && rm -rf dist', 'bare cd goes to $HOME'],
+  ['if true; then cd /etc; fi\nrm -rf dist', 'a grammar-wrapped cd runs zero or more times'],
+  // --- git worktree remove structure (5)
+  ['git worktree remove --force --force ../wt', 'a second --force overrides a LOCK'],
+  ['git worktree remove .', 'the current worktree'],
+  ['git worktree remove ../a ../b', 'exactly one positional'],
+  ['git worktree remove --force', 'a force with no target'],
+  ['git worktree remove -C .. wt', 'unmodeled flag'],
+  // --- bun install / git clean (3)
+  ['bun install left-pad', 'a positional makes it bun add in disguise'],
+  ['bun install --force', 'outside the lockfile-faithful shape'],
+  ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
+];
+
+describe('the adversarial corpus: 40 refusals (ADR 0023)', () => {
+  test('the corpus is the full 40 entries', () => {
+    expect(ADVERSARIAL.length).toBe(40);
+  });
+
+  for (const [cmd, why] of ADVERSARIAL) {
+    test(`${JSON.stringify(cmd)} — ${why}`, () => {
+      expect(bash(cmd)).toBeNull();
+    });
+  }
+});
+
+describe('level integration: trusted only', () => {
+  const TRUSTED = groupsForLevel('trusted');
+  const BALANCED = groupsForLevel('balanced');
+
+  test('artifact-clean is gated into trusted only', () => {
+    expect(groupsForLevel('trusted')).toContain('artifact-clean');
+    expect(groupsForLevel('balanced')).not.toContain('artifact-clean');
+    expect(groupsForLevel('strict')).not.toContain('artifact-clean');
+  });
+
+  test('at trusted, rm -rf dist approves although scratch also lists rm', () => {
+    // `rm` has TWO owners at trusted: scratch (destination proof) and
+    // artifact-clean (name proof). First-registrant-only dispatch would let
+    // scratch eat the prefix and veto (dist is not under a scratch root) —
+    // the matcher must try every owner's proof.
+    expect(matchGroups('Bash', { command: 'rm -rf dist' }, TRUSTED)).toBe('artifact-clean:rm');
+  });
+
+  test('at trusted, scratch still proves what it always proved', () => {
+    expect(matchGroups('Bash', { command: 'rm -rf /tmp/junk' }, TRUSTED)).toBe('scratch:rm');
+    expect(matchGroups('Bash', { command: 'cd /private/tmp/work && rm -rf output' }, TRUSTED)).toBe(
+      'scratch:rm',
+    );
+  });
+
+  test('a corpus refusal for THIS group may still be proved by scratch at trusted', () => {
+    // `cd $TMPDIR` poisons artifact-clean (expansion cd), but scratch's own
+    // cwd tracking recognizes $TMPDIR and proves `build` lands under it.
+    // Same command, two independent proofs, one suffices — by design
+    // (ADR 0023 point 4: /tmp deletion is scratch's, not re-implemented).
+    expect(matchGroups('Bash', { command: 'cd $TMPDIR && rm -rf build' }, TRUSTED)).toBe(
+      'scratch:rm',
+    );
+  });
+
+  test('at balanced, artifact deletion still escalates', () => {
+    expect(matchGroups('Bash', { command: 'rm -rf dist' }, BALANCED)).toBeNull();
+    expect(
+      matchGroups('Bash', { command: 'git worktree remove --force ../wt' }, BALANCED),
+    ).toBeNull();
+    expect(matchGroups('Bash', { command: 'bun install' }, BALANCED)).toBeNull();
+  });
+
+  test('at trusted, unproved deletion still escalates', () => {
+    expect(matchGroups('Bash', { command: 'rm -rf src' }, TRUSTED)).toBeNull();
+    expect(matchGroups('Bash', { command: 'rm -rf ~/Documents' }, TRUSTED)).toBeNull();
+    expect(matchGroups('Bash', { command: 'git clean -xfd' }, TRUSTED)).toBeNull();
+  });
+});
+
+describe('owner fallback: a shared prefix is judged by every owner', () => {
+  test('scratch coverage no longer shrinks when fs-write is requested alongside', () => {
+    // With scratch ALONE this always approved. Before the multi-owner map,
+    // requesting fs-write alongside flipped it to an escalation, because
+    // fs-write registered `cp` first and its flag veto (--force) ended the
+    // match — adding a group could REMOVE approvals. Approving is the
+    // designed reading: the destination proof confines the blast radius to
+    // the scratch root, and the matcher is now monotone in its group list.
+    const cmd = 'cd /tmp/s && cp --force a b';
+    expect(matchGroups('Bash', { command: cmd }, ['scratch'])).toBe('scratch:cp');
+    expect(matchGroups('Bash', { command: cmd }, ['fs-write', 'scratch'])).toBe('scratch:cp');
+  });
+});
+
+describe('deny stays broad (ADR 0010)', () => {
+  test('artifact-clean in deny_groups blocks any rm anywhere in a compound', () => {
+    expect(matchGroupsBroad('Bash', { command: 'echo hi && rm -rf dist' }, GROUP)).toBe(
+      'artifact-clean:rm',
+    );
+  });
+});

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -125,6 +125,19 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['cd $TMPDIR && rm -rf build', 'expansion cd (scratch may prove this; THIS group must not)'],
   ['cd - && rm -rf dist', 'cd -: the previous directory is unknowable statically'],
   ['cd && rm -rf dist', 'bare cd goes to $HOME'],
+  // The independent adversarial pass's one confirmed bypass (#1047). `cd`
+  // reads a leading-dash token as OPTIONS, so these are an option with NO
+  // operand -- and a bare `cd` goes to $HOME. Verified in bash on darwin: each
+  // lands in /Users/<user>. Only the exact `-` was rejected, so `cd -P` read as
+  // plain relative descent and `cd -P && rm -rf .venv` deleted ~/.venv at 0ms.
+  ['cd -P && rm -rf dist', 'cd -P is an option with no operand: goes to $HOME'],
+  ['cd -L && rm -rf node_modules', 'cd -L likewise'],
+  ['cd -- && rm -rf .venv', 'cd -- likewise: end-of-options, no operand'],
+  ['cd -LP && rm -rf dist', 'a combined option cluster, still no operand'],
+  [
+    'cd -P && cd projectX && rm -rf node_modules',
+    'the worst case: a second PLAIN cd descends normally from $HOME, reaching any project',
+  ],
   ['if true; then cd /etc; fi\nrm -rf dist', 'a grammar-wrapped cd runs zero or more times'],
   // --- git worktree remove structure (5)
   ['git worktree remove --force --force ../wt', 'a second --force overrides a LOCK'],
@@ -138,9 +151,11 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
 ];
 
-describe('the adversarial corpus: 40 refusals (ADR 0023)', () => {
-  test('the corpus is the full 40 entries', () => {
-    expect(ADVERSARIAL.length).toBe(40);
+describe('the adversarial corpus: 45 refusals (ADR 0023)', () => {
+  test('the corpus is the full 45 entries', () => {
+    // 40 from the design's own corpus; 5 added by the independent adversarial
+    // pass ADR 0023 requires before merge (#1047, the `cd -<option>` family).
+    expect(ADVERSARIAL.length).toBe(45);
   });
 
   for (const [cmd, why] of ADVERSARIAL) {

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -58,6 +58,9 @@ describe('positive controls: ordinary artifact cleanup', () => {
     // A discard redirect is permitted by hasShellControl and must not be
     // mistaken for a positional target.
     ['rm -rf coverage 2>/dev/null', 'artifact-clean:rm'],
+    // Earned by the cd-redirect fix: stripping redirects before tokenizing the
+    // cd means a real descent with a real redirect is now provable.
+    ['cd sub 2>/dev/null && rm -rf dist', 'artifact-clean:rm'],
     // Exact long spellings are on the allowlist.
     ['rm --recursive --force dist', 'artifact-clean:rm'],
     ['rmdir build', 'artifact-clean:rmdir'],
@@ -159,6 +162,22 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
     'cd -P && cd projectX && rm -rf node_modules',
     'the worst case: a second PLAIN cd descends normally from $HOME, reaching any project',
   ],
+  // The SECOND PR-review round: the same worst case, one spelling over. The
+  // #1047 fix rejected a leading dash, but `shellWords('cd ..>/dev/null')`
+  // glues the operand to the redirect, so the token is neither `..` nor
+  // `../…` and no poison was set. Real bash ascends, and the segment is
+  // idempotent — N of them climb N levels, reaching ~/.venv. Every one of
+  // these is a TOKEN-BOUNDARY variation; the entries above are all
+  // TOKEN-SHAPE variations, which is exactly why none of them caught it.
+  ['cd ..>/dev/null && rm -rf dist', 'redirect glued to the operand hides the ascent'],
+  ['cd ..>&1 && rm -rf dist', 'fd-dup spelling of the same'],
+  ['cd ..>>/dev/null && rm -rf dist', 'append spelling'],
+  ['cd ..&>/dev/null && rm -rf dist', '&> is not even modelled by rewriteRedirectClauses'],
+  ['cd "..">/dev/null && rm -rf dist', 'quoted operand, same glue'],
+  [
+    'cd ..>/dev/null && cd ..>/dev/null && cd ..>/dev/null && rm -rf .venv',
+    'idempotent: three of them climb three levels, to ~/.venv',
+  ],
   ['if true; then cd /etc; fi\nrm -rf dist', 'a grammar-wrapped cd runs zero or more times'],
   // --- git worktree remove structure (5)
   ['git worktree remove --force --force ../wt', 'a second --force overrides a LOCK'],
@@ -172,13 +191,13 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
 ];
 
-describe('the adversarial corpus: 52 refusals (ADR 0023)', () => {
-  test('the corpus is the full 52 entries', () => {
+describe('the adversarial corpus: 58 refusals (ADR 0023)', () => {
+  test('the corpus is the full 58 entries', () => {
     // 40 from the design's own corpus; 8 added by the independent adversarial
     // pass ADR 0023 requires before merge: 5 for the `cd -<option>` family
     // (#1047) and 3 that actually pin the expansion guard the two shipped
     // glob/brace entries only appeared to.
-    expect(ADVERSARIAL.length).toBe(52);
+    expect(ADVERSARIAL.length).toBe(58);
   });
 
   for (const [cmd, why] of ADVERSARIAL) {

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -103,6 +103,17 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['rm -rf dist src', 'EVERY target must prove, not just one'],
   ['rm -rf dist*', 'glob'],
   ['rm -rf {dist,build}', 'brace expansion'],
+  // The two entries above do NOT pin the expansion guard, which the ADR 0023
+  // adversarial pass caught by mutation: delete `*` or `{}` from
+  // ARTIFACT_EXPANSION_RE and both stay GREEN, because `dist*` and
+  // `{dist,build}` are refused by the EXACT-NAME check anyway — neither is an
+  // artifact name. A corpus entry named for a guard it does not exercise is
+  // the ADR 0011 row-5 anti-pattern. These three do exercise it: each carries
+  // a real artifact segment, so the name check passes and only the expansion
+  // guard stands between them and an approval.
+  ['rm -rf */dist', 'glob in a PARENT segment: the name check passes on `dist`'],
+  ['rm -rf dist/*', 'glob in a CHILD segment: same'],
+  ['rm -rf {a,b}/dist', 'brace in a parent segment: same'],
   ['rm -rf dist/.env', 'sensitive basename under an artifact dir: the deny axis wins'],
   ['rm -rf', 'no target, no proof'],
   // --- flag axis: exact allowlist (5)
@@ -151,11 +162,13 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
 ];
 
-describe('the adversarial corpus: 45 refusals (ADR 0023)', () => {
-  test('the corpus is the full 45 entries', () => {
-    // 40 from the design's own corpus; 5 added by the independent adversarial
-    // pass ADR 0023 requires before merge (#1047, the `cd -<option>` family).
-    expect(ADVERSARIAL.length).toBe(45);
+describe('the adversarial corpus: 48 refusals (ADR 0023)', () => {
+  test('the corpus is the full 48 entries', () => {
+    // 40 from the design's own corpus; 8 added by the independent adversarial
+    // pass ADR 0023 requires before merge: 5 for the `cd -<option>` family
+    // (#1047) and 3 that actually pin the expansion guard the two shipped
+    // glob/brace entries only appeared to.
+    expect(ADVERSARIAL.length).toBe(48);
   });
 
   for (const [cmd, why] of ADVERSARIAL) {
@@ -226,6 +239,60 @@ describe('owner fallback: a shared prefix is judged by every owner', () => {
     const cmd = 'cd /tmp/s && cp --force a b';
     expect(matchGroups('Bash', { command: cmd }, ['scratch'])).toBe('scratch:cp');
     expect(matchGroups('Bash', { command: cmd }, ['fs-write', 'scratch'])).toBe('scratch:cp');
+  });
+});
+
+/**
+ * Found by the ADR 0023 adversarial pass, and it is this branch's own
+ * regression rather than a pre-existing one. `matchGroups` was rewritten from
+ * first-registrant-wins to a UNION over every owning group, which fixed a real
+ * non-monotonicity — but the union is disjunctive over VETOES too. For the
+ * five prefixes owned by both `fs-write` and `scratch` (cp/mv/mkdir/touch/tee),
+ * `scratch`'s laxer proof discarded `fs-write`'s sensitive-destination veto,
+ * which `scratchTargetVeto` never had. Measured develop -> branch at BALANCED,
+ * a level ADR 0023 does not claim to touch:
+ *
+ *     cp /tmp/a /tmp/.env         develop: escalate -> was: scratch:cp @ 0ms
+ *     mv /tmp/a /tmp/id_rsa       develop: escalate -> was: scratch:mv
+ *     cp /tmp/a /tmp/.git/config  develop: escalate -> was: scratch:cp
+ *
+ * It also falsified a shipped claim in config.ts ("the write groups refuse
+ * sensitive destinations regardless of prefix ... credentials (.env, id_rsa)").
+ *
+ * Per group, not once, so that adding a mutating group and forgetting
+ * `MUTATING_GROUPS` fails here rather than shipping.
+ */
+describe('the sensitive-destination axis survives the owner union', () => {
+  const BALANCED = groupsForLevel('balanced');
+  const TRUSTED_ALL = groupsForLevel('trusted');
+
+  const sensitive: Array<[string, string]> = [
+    ['cp /tmp/a /tmp/.env', 'a credential basename, inside a scratch root'],
+    ['mv /tmp/a /tmp/id_rsa', 'a private key'],
+    ['tee /tmp/bun.lock', 'a build-surface lockfile'],
+    ['cp /tmp/a /tmp/.git/config', 'git config: core.hooksPath is a code-exec pivot'],
+    ['mv /tmp/pkg /tmp/package.json', 'build surface'],
+  ];
+
+  for (const [cmd, why] of sensitive) {
+    test(`${JSON.stringify(cmd)} escalates at balanced — ${why}`, () => {
+      expect(bash(cmd, BALANCED)).toBeNull();
+    });
+    test(`${JSON.stringify(cmd)} escalates at trusted too`, () => {
+      expect(bash(cmd, TRUSTED_ALL)).toBeNull();
+    });
+  }
+
+  test('an ordinary scratch write is untouched — the fix costs no coverage', () => {
+    expect(bash('cp /tmp/a /tmp/b', BALANCED)).not.toBeNull();
+    expect(bash('rm -rf /tmp/junk', BALANCED)).not.toBeNull();
+  });
+
+  test('READING a sensitive path is still allowed: the axis is write-side only', () => {
+    // A first cut applied the axis to every owner, not just the mutating ones,
+    // and broke `jq .version package.json` plus two /dev/null redirect cases.
+    // Reading a sensitive path is exactly what `read-only` exists to allow.
+    expect(bash('jq .version package.json', BALANCED)).not.toBeNull();
   });
 });
 

--- a/packages/daemon/tests/auto-approve/artifact-clean.test.ts
+++ b/packages/daemon/tests/auto-approve/artifact-clean.test.ts
@@ -117,6 +117,10 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['rm -rf */dist', 'glob in a PARENT segment: the name check passes on `dist`'],
   ['rm -rf dist/*', 'glob in a CHILD segment: same'],
   ['rm -rf {a,b}/dist', 'brace in a parent segment: same'],
+  // `?` and `[` sit in the same character class as `*` and `{}` and were left
+  // uncovered when those two were fixed -- dropping either turned nothing red.
+  ['rm -rf ?/dist', 'single-char glob in a parent segment'],
+  ['rm -rf dist/[ab]', 'bracket glob in a child segment'],
   ['rm -rf dist/.env', 'sensitive basename under an artifact dir: the deny axis wins'],
   // A quoted `>` inside a target used to TRUNCATE the token the proof saw:
   // `rewriteRedirectClauses` is quote-blind and runs on raw text, so
@@ -127,7 +131,11 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ["rm -rf 'dist>x/../../src'", 'quoted > truncated the token: this names ../../src'],
   ["rm -rf 'coverage>x/../..'", 'same, ascending out of the tree'],
   ["rm -rf 'node_modules>x/../../../../Documents'", 'same, reaching $HOME/Documents'],
-  ["rm -rf 'dist<x/../../src'", 'input redirect, same truncation shape'],
+  // NOT the same truncation shape, despite the guard accepting `<`:
+  // REDIRECT_CLAUSE_RE is />>?/ and never matches `<`, so this token is never
+  // truncated and the ASCENT guard is what refuses it. Kept as a control with
+  // an honest reason -- dropping the `<` arm of the guard changes nothing.
+  ["rm -rf 'dist<x/../../src'", 'refused by the ascent guard, not the redirect guard'],
   ['rm -rf', 'no target, no proof'],
   // --- flag axis: exact allowlist (5)
   ['rm --no-preserve-root -rf dist', 'long flag outside the exact allowlist'],
@@ -135,6 +143,9 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['rm --force=yes dist', 'a value-carrying spelling is not the exact token'],
   ['rm -rfd dist', 'unknown short flag inside a cluster'],
   ['rmdir --ignore-fail-on-non-empty build', 'rmdir long flag outside the allowlist'],
+  // rmdir's SHORT-flag allowlist was unpinned: widening it to accept `r`
+  // turned nothing red, while rm's equivalent is pinned by `rm -rfd dist`.
+  ['rmdir -pr build', 'unknown short flag inside an rmdir cluster'],
   // --- shell structure (6)
   ['rm -rf $(pwd)/dist', 'command substitution'],
   ['rm -rf dist > deleted.txt', 'redirect to a real file'],
@@ -179,6 +190,15 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
     'idempotent: three of them climb three levels, to ~/.venv',
   ],
   ['if true; then cd /etc; fi\nrm -rf dist', 'a grammar-wrapped cd runs zero or more times'],
+  // The entry above cannot fail on its stated reason: `/etc` is absolute, so
+  // `cdTargetIsPlainDescendant` already refuses it and the `body !== trimmed`
+  // grammar clause is never reached. Deleting that clause turned NOTHING red.
+  // This one has a GOOD target, so only the grammar clause stands between it
+  // and an approval.
+  [
+    'if true; then cd sub; fi\nrm -rf dist',
+    'grammar-wrapped cd poisons even with a good target: it runs zero or more times',
+  ],
   // --- git worktree remove structure (5)
   ['git worktree remove --force --force ../wt', 'a second --force overrides a LOCK'],
   ['git worktree remove .', 'the current worktree'],
@@ -191,13 +211,13 @@ const ADVERSARIAL: ReadonlyArray<[string, string]> = [
   ['git clean -xfd', 'git clean is excluded in every form: untracked is not derived'],
 ];
 
-describe('the adversarial corpus: 58 refusals (ADR 0023)', () => {
-  test('the corpus is the full 58 entries', () => {
+describe('the adversarial corpus: 62 refusals (ADR 0023)', () => {
+  test('the corpus is the full 62 entries', () => {
     // 40 from the design's own corpus; 8 added by the independent adversarial
     // pass ADR 0023 requires before merge: 5 for the `cd -<option>` family
     // (#1047) and 3 that actually pin the expansion guard the two shipped
     // glob/brace entries only appeared to.
-    expect(ADVERSARIAL.length).toBe(58);
+    expect(ADVERSARIAL.length).toBe(62);
   });
 
   for (const [cmd, why] of ADVERSARIAL) {
@@ -322,6 +342,42 @@ describe('the sensitive-destination axis survives the owner union', () => {
     // and broke `jq .version package.json` plus two /dev/null redirect cases.
     // Reading a sensitive path is exactly what `read-only` exists to allow.
     expect(bash('jq .version package.json', BALANCED)).not.toBeNull();
+  });
+});
+
+/**
+ * ADR 0023 says the name list "is an allow surface and will attract additions",
+ * and sets the bar an entry must clear. Nothing enforced it: adding `vendor` or
+ * `tmp` — the two the ADR names as NOT clearing the bar — approved
+ * `rm -rf vendor` at 0ms with the whole suite green.
+ *
+ * A closed-world assertion is the only thing that makes an allow surface's
+ * membership a decision rather than a diff nobody notices.
+ */
+describe('the artifact name list is closed', () => {
+  const EXPECTED = [
+    'node_modules',
+    'dist',
+    'build',
+    'out',
+    'target',
+    'coverage',
+    '__pycache__',
+    '.venv',
+  ];
+
+  for (const name of EXPECTED) {
+    test(`${name} is a proved artifact name`, () => {
+      expect(bash(`rm -rf ${name}`)).toBe('artifact-clean:rm');
+    });
+  }
+
+  test('names the ADR explicitly rejects are NOT on the list', () => {
+    // `vendor` is often tracked; `tmp` proclaims temporariness but regenerates
+    // nothing. Both are called out in ADR 0023 as failing the bar.
+    for (const name of ['vendor', 'tmp', 'src', 'lib', 'assets', 'public', 'data', 'logs']) {
+      expect(bash(`rm -rf ${name}`)).toBeNull();
+    }
   });
 });
 

--- a/packages/daemon/tests/auto-approve/levels.test.ts
+++ b/packages/daemon/tests/auto-approve/levels.test.ts
@@ -53,7 +53,13 @@ describe('the levels are ordered and additive', () => {
       'fs-write',
       'scratch',
     ]);
-    expect(added(groupsForLevel('balanced'), groupsForLevel('trusted'))).toEqual(['vcs-write']);
+    // `artifact-clean` (ADR 0023) is trusted-only by decision, not accident:
+    // the measurement behind it is one machine running `trusted`, and the
+    // precedent (ADR 0016) is to ship narrow and widen deliberately.
+    expect(added(groupsForLevel('balanced'), groupsForLevel('trusted'))).toEqual([
+      'vcs-write',
+      'artifact-clean',
+    ]);
   });
 
   test('every group named by a level actually exists', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -21,6 +21,10 @@ const WRITE_GROUPS = ['fs-write', 'vcs-write'];
 /** The scratch group (#994 follow-up). Never enabled by default. */
 const SCRATCH_GROUPS = ['scratch'];
 
+/** The artifact-clean group (ADR 0023). Gated into `trusted` only; its own
+ *  corpus lives in artifact-clean.test.ts. */
+const ARTIFACT_GROUPS = ['artifact-clean'];
+
 /** Convenience: match a Bash command against the named groups. */
 function bash(command: string, groups: readonly string[] = ALL): string | null {
   return matchGroups('Bash', { command }, groups);
@@ -28,7 +32,7 @@ function bash(command: string, groups: readonly string[] = ALL): string | null {
 
 describe('permission-groups: known groups', () => {
   test('isKnownGroup', () => {
-    for (const name of [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS]) {
+    for (const name of [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS]) {
       expect(isKnownGroup(name)).toBe(true);
     }
     expect(isKnownGroup('bogus')).toBe(false);
@@ -36,7 +40,9 @@ describe('permission-groups: known groups', () => {
   });
 
   test('knownGroupNames lists exactly the built-ins', () => {
-    expect(knownGroupNames().sort()).toEqual([...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS].sort());
+    expect(knownGroupNames().sort()).toEqual(
+      [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS].sort(),
+    );
   });
 });
 
@@ -650,7 +656,13 @@ describe('#959 final pass: every write prefix is covered by a flag policy', () =
   //
   // Walking BUILTIN_GROUPS means this cannot go stale: adding a prefix to a
   // write group without adding a policy turns it red.
-  const WRITE_GROUP_NAMES = ['fs-write', 'vcs-write'];
+  //
+  // `artifact-clean` (ADR 0023) walks here too. Its rm/rmdir prefixes carry
+  // FLAG_POLICIES entries; `git worktree remove` and `bun install` carry
+  // their flag policy inside `artifactCleanVeto` itself (an exact structural
+  // allowlist) -- the probe asserts the same PROPERTY either way: an
+  // unclassified flag is refused, wherever the policy lives.
+  const WRITE_GROUP_NAMES = ['fs-write', 'vcs-write', 'artifact-clean'];
 
   for (const groupName of WRITE_GROUP_NAMES) {
     const group = BUILTIN_GROUPS[groupName];

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -784,6 +784,42 @@ describe('scratch: leading cd establishes the root for later relative targets', 
   }
 });
 
+/**
+ * #1047, found by the independent adversarial pass on ADR 0023. LIVE on
+ * shipped releases, not new-code-only: `advanceScratchCwd` reset its tracked
+ * cwd for a bare `cd` and for `cd -`, testing the exact string `'-'`. But `cd`
+ * reads ANY leading-dash token as OPTIONS, so `cd -P` / `cd -L` / `cd --` /
+ * `cd -LP` are an option with NO operand — and a `cd` with no operand goes to
+ * `$HOME`. Verified in bash on darwin 25.6:
+ *
+ *     $ bash -c 'cd /tmp/work && cd -P && pwd'
+ *     /Users/yahya
+ *
+ * `-P` was therefore tracked as a SUBDIRECTORY NAME: the tracked cwd became
+ * `<scratch>/-P`, still under the root, while the real shell had left for
+ * `$HOME`. So `cd /tmp/work && cd -P && rm -rf out` proved "strictly under a
+ * scratch root", approved at 0ms with no LLM and no card, and deleted
+ * `~/out`. `scratch` is gated into `balanced`, so this was reachable at
+ * `balanced` and `trusted`; under #1024 a subagent got it with no render.
+ */
+describe('#1047 a cd OPTION is not a subdirectory: it resets the tracked root', () => {
+  for (const opt of ['-P', '-L', '--', '-LP']) {
+    test(`cd ${opt} goes to $HOME, so a later relative delete is not proved`, () => {
+      expect(bash(`cd /tmp/work && cd ${opt} && rm -rf out`, SCRATCH_GROUPS)).toBeNull();
+    });
+  }
+
+  test('a plain relative descent still tracks — the fix costs no coverage', () => {
+    expect(bash('cd /tmp/work && cd sub && rm -rf out', SCRATCH_GROUPS)).toBe('scratch:rm');
+  });
+
+  test('./-foo is still reachable: only a LEADING dash is an option', () => {
+    // A directory literally named `-foo` cannot be reached by `cd -foo` in
+    // bash either, so rejecting the leading dash costs nothing real.
+    expect(bash('cd /tmp/work && cd ./-foo && rm -rf out', SCRATCH_GROUPS)).toBe('scratch:rm');
+  });
+});
+
 describe('scratch: output redirection to a scratch target', () => {
   test('a redirect carve-out lets an OTHER covered prefix through, unmodified', () => {
     // `hasShellControl` vetoes any non-/dev/null redirect unconditionally for

--- a/packages/daemon/tests/auto-approve/prompt-levels.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-levels.test.ts
@@ -13,7 +13,10 @@
  *  2. Raising a level widens what is ROUTINE, never what is dangerous. The
  *     DENY FLOOR, deletion, remote mutation, package install and design
  *     questions are fixed at every level, and each is asserted rather than
- *     described.
+ *     described. "Fixed" is a claim about THIS PROMPT: ADR 0023's
+ *     `artifact-clean` approves proved-derived deletion deterministically,
+ *     before any prompt is built, and everything that does reach the model
+ *     still escalates deletion at every level.
  */
 
 import { describe, expect, test } from 'bun:test';
@@ -84,7 +87,11 @@ describe('what every level shares', () => {
 
   test('deletion escalates at every level', () => {
     // #956's rule: deletion is where escalation earns its cost. No level,
-    // including `trusted`, may move it.
+    // including `trusted`, may move it. Amended, not weakened, by ADR 0023:
+    // `artifact-clean` approves proved-derived deletion in the DETERMINISTIC
+    // layer, which never builds a prompt — so what this pins is exactly the
+    // surviving half of the rule: every deletion that REACHES the LLM still
+    // escalates, at every level.
     //
     // Case-insensitive on purpose: `strict` carries develop's original
     // wording ("file creation, modification, or deletion") verbatim, because
@@ -102,7 +109,9 @@ describe('what every level shares', () => {
   test('at balanced and trusted, deletion is the ONLY file operation left escalating', () => {
     // The replace-not-delete property. The pre-#966 line bundles "creation,
     // modification, or deletion" into one entry -- dropping it wholesale to
-    // approve writes would have silently promoted `rm` too.
+    // approve writes would have silently promoted `rm` too. Still true after
+    // ADR 0023: `artifact-clean` lives in the deterministic layer and this
+    // prompt is what governs everything that layer did NOT prove.
     for (const level of ['balanced', 'trusted'] as const) {
       const text = systemPrompt(level);
       const escalate = text.slice(

--- a/packages/daemon/tests/auto-approve/prompt-levels.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-levels.test.ts
@@ -85,7 +85,12 @@ describe('what every level shares', () => {
     for (const format of formats) expect(format).toBe(formats[0] as string);
   });
 
-  test('deletion escalates at every level', () => {
+  // Renamed by the ADR 0023 adversarial pass. It was 'deletion escalates at
+  // every level', which the body already qualified — but the NAME is a claim
+  // too, and at `trusted` a proved-derived deletion does not escalate: it is
+  // approved deterministically before any prompt exists. A name that overstates
+  // what a test pins is the ADR 0011 failure mode in the place it hides best.
+  test('every deletion that REACHES the prompt escalates, at every level', () => {
     // #956's rule: deletion is where escalation earns its cost. No level,
     // including `trusted`, may move it. Amended, not weakened, by ADR 0023:
     // `artifact-clean` approves proved-derived deletion in the DETERMINISTIC


### PR DESCRIPTION
Implements **ADR 0023**: deletion approves only when the target is provably
derived, amending #956's blanket "deletion escalates at every level" rule.

Also fixes **#1047**, a P0-class bypass in already-shipped `scratch` code that
the adversarial pass on this branch turned up.

## Why

Measured on the owner's live daemon (2026-08-10), the blanket rule was the
single largest cost centre of the whole mechanism: **134 escalate vs 129
approve (51%)**, 123 of the 134 Bash. A cold replay of the real escalation
population through the live engine scored **17/21 (81%)**, and three of the
four misses were exactly this rule:

| operation | cost |
|---|---|
| `rm -rf dist` | 3418ms → escalate |
| `rm -rf node_modules && bun install` | 3493ms |
| `git worktree remove --force ../remi-1031` | 3721ms |

Each is ~3.5s of GPU time plus a human interruption, spent on a deletion
regenerable by a command the repo already runs. Covering the three reaches
**20/21 (95.2%)**, the stated target.

The prompt-side rule is **untouched**: deletion still escalates on every path
that reaches the LLM, at every level. The amendment lives entirely in the
deterministic layer, which is where ADR 0016 says policy belongs.

This is not a new kind of exception — `scratch` has deterministically approved
`rm`/`rmdir` under a proved scratch root since #994. "Deletion escalates at
every level" has really meant "unless the destination is PROVED disposable"
since then. This extends the proof from "under `/tmp`" to "at or under a
directory whose exact name proclaims derived state".

## The adversarial pass (ADR 0023's own precondition)

ADR 0023 required at least one independent adversarial pass before merge,
because #959 needed four review rounds and found eleven bypasses — three of
them in code written to fix the previous round (ADR 0018).

Three independent adversaries ran with distinct lenses (lexical/tokenization,
destination/state, integration/composition), each required to EXECUTE every
candidate through `matchGroups` rather than reason about it. **They found two
real bypasses, and one of them was in shipped code.**

### #1047 — a `cd` option is not a directory

`cd` reads any leading-dash token as OPTIONS, so `cd -P`, `cd -L`, `cd --`,
`cd -LP` are an option with **no operand** — and a `cd` with no operand goes to
`$HOME`. Verified in bash on darwin 25.6: all four land in `/Users/<user>`.

Both cwd models rejected only the exact string `-`:

- **`artifact-clean`** (new): `cd -P && rm -rf .venv` read as plain relative
  descent, approved at 0ms, deleted `~/.venv`. A second plain `cd` descends
  normally from there, so `cd -P && cd <anyproject> && rm -rf node_modules`
  reached any project under `$HOME`.
- **`scratch`** (**shipped, live at `balanced` and above**): `-P` was tracked as
  a *subdirectory name*, so the tracked cwd became `<scratch>/-P` — still under
  the root — while bash had left for `$HOME`. `cd /tmp/work && cd -P && rm -rf
  out` approved at 0ms and deleted `~/out`.

The adversary reported `scratch` as failing safe here. It does not — checking
rather than accepting that is what found the live half.

### The owner union silently weakened `fs-write`, at `balanced`

`matchGroups` was rewritten from first-registrant-wins to a union over every
owning group, which fixed a real non-monotonicity. But the union is disjunctive
over **vetoes** too: for the five prefixes owned by both `fs-write` and
`scratch` (`cp`, `mv`, `mkdir`, `touch`, `tee`), scratch's laxer proof
discarded fs-write's sensitive-destination veto. Measured develop → branch at
**`balanced`**, a level this ADR does not even claim to touch:

| command | develop | before the fix |
|---|---|---|
| `cp /tmp/a /tmp/.env` | escalate | `scratch:cp` @ 0ms |
| `mv /tmp/a /tmp/id_rsa` | escalate | `scratch:mv` |
| `cp /tmp/a /tmp/.git/config` | escalate | `scratch:cp` |

ADR 0018's pattern exactly: **the bypass was in code written to make the
feature composable, not in the feature.**

Fixed by checking `segmentTouchesSensitivePath` before any owner's proof, for
every group in a new `MUTATING_GROUPS` set. Monotonicity survives — adding a
group cannot introduce a sensitive destination. A first cut applied it to
*every* owner and broke three read tests (`jq .version package.json`, two
`/dev/null` cases); reading a sensitive path is what `read-only` exists to
allow, so it is scoped to mutating groups and pinned by a test saying so.

**This narrows `scratch` beyond develop's scratch-alone behaviour** — a
genuinely disposable `/tmp/.env` now escalates. Deliberate: consistency beats
"depends which groups happen to be co-active", and it is not in the measured
population. `config.ts` documented the old carve-out and is corrected in the
same change (ADR 0011 rule 3).

### Claim-accuracy findings, all corrected

- **"Bare `bun install` is lockfile-faithful" was false.** Only
  `--frozen-lockfile` guarantees that; bare `bun install` reconciles
  `package.json` against the lockfile and may resolve new versions, rewrite the
  lockfile, and run lifecycle scripts. Coverage unchanged (it is the measured
  miss) but now a **declared residual** rather than a claim of inertness.
- **Two corpus entries could not fail on their claim** — the repo's own ADR 0011
  row-5 anti-pattern. `rm -rf dist*` ('glob') and `rm -rf {dist,build}` ('brace')
  stay green with `*` and `{}` deleted from `ARTIFACT_EXPANSION_RE`, because the
  exact-name check refuses them anyway. Three entries added that do pin it
  (`*/dist`, `dist/*`, `{a,b}/dist`); mutation-verified.
- **The pinned prompt test's name overclaimed.** `'deletion escalates at every
  level'` is false at the system level once this ships. Renamed.

### Accepted, not fixed

`--` end-of-options hides a dash-leading target from the proof, and a **quoted**
`>` truncates the target the proof sees. Both executed; both bounded to deleting
a relative junk-named path whose spelling is constrained to flag-shaped tokens.
Neither reaches source, an absolute path, or code execution, and any real
co-target is still checked. Recorded in the ADR so a future reader knows they
were weighed, not missed.

## Verification

- Adversarial corpus **40 → 48**, every entry executed.
- **Mutation-verified throughout**: restoring the exact `-` test turns 9 pins
  red across two files; dropping `*`/`{}` from the expansion regex turns exactly
  the 3 new entries red; the F1 fix was validated against a develop-vs-branch
  comparison run on both checkouts.
- `git worktree remove`'s safety still rests entirely on git's runtime refusal —
  a declared design choice, restated here so it is not mistaken for a lexical
  guarantee.
- #1024's stated visibility path confirmed accurate: `onSubagentPassthrough`
  does fire on the deterministic hook-time approve, so `subagent_alert` can
  surface it — but only if the user configured a matching pattern. A default
  install is silent, as the ADR says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
