### PR TITLE
Say console.error, which is what the warning uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ longer freezes for as long as you deliberate.
   exemption (#869). Installs that already materialized `bind = "0.0.0.0"` via
   `remi config init` keep the old behavior — a value on disk beats a changed
   default — and nothing breaks to make them look, so the boot warning is their
-  only signal. It now names the remedy and goes to `logError`, since
-  `console.warn` is dropped in wrapper mode (#1043).
+  only signal. It now names the exact remedy, and is emitted with
+  `console.error` — deliberately **not** `logError`, which at that point in
+  module init routes to a `writeToLog` that is still a no-op until
+  `startLogFileSession` runs ~490 lines later, so the message would go nowhere
+  (#1043).
 
 ### Fixed
 - **P0: any LAN host could drive the daemon** (#880, #1046, [ADR 0024]). Five


### PR DESCRIPTION
One-line correction to the 0.7.6 changelog, before it is tagged.

The entry described the #880 boot warning as going to `logError`. I took that
from PR #1046's description, which a later review round on that same PR had
already reversed — the shipped code uses `console.error`, and carries a comment
at `cli.ts:2317` explaining that the `logError` version routed to a `writeToLog`
that is a no-op until `startLogFileSession` runs ~490 lines below, so the
message went nowhere.

Describing a security warning as reaching a sink it does not reach, in the
release notes for the release that fixes the P0, is the [ADR 0011] pattern
exactly — and it got in the same way row 1 did: a stale description read as
evidence instead of the code.

Found while tracing the mDNS suppression path for #1051, not by re-reading the
changelog. Which is the argument for rule 1.

## Rechecked while here

The other concrete claims I had taken from PR bodies rather than source, now
verified against the code:

- `DEFAULT_EVAL_MODEL_GGUF = 'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0'` (`config.ts:87`)
  — the `:Q4_0` suffix claim is accurate
- `MUTATING_GROUPS` = `fs-write`, `vcs-write`, `scratch`, `artifact-clean`
  (`permission-groups.ts:122`)
- `extractToolCommand` imported by both `deny-floor.ts` and `risk-bands.ts`
- `onAttachStateChanged` emitted at exactly the two `attachedConnections`
  mutation sites
- the `questionLive && !onset` early return is absent from `status-bar.ts`

No other corrections needed.

[ADR 0011]: .context/decisions/0011-verify-before-you-describe.md
