### PR TITLE
Supervise llama-server instead of asking for a nohup (#822 slice 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,7 @@ from it. One hardcoded default is wrong on one of the two supported targets.
 | Target | `provider` | `model` default | Who runs it |
 |---|---|---|---|
 | macOS Apple Silicon | `yooz` | `YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx` | remi fetches + supervises the helper (#834) |
-| Linux (any arch) | `llamacpp` | `YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0` | **you**, for now — remi prints the command at boot |
+| Linux (any arch) | `llamacpp` | `YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0` | **you** install `llama-server` once; remi spawns + supervises it (#822) |
 | macOS Intel, Windows | `yooz` (kept deliberately, so the boot warning fires) | (engine's, unused) | nothing; boot says so |
 
 Same trained weights, but **not the same artifact**: QAT was trained against
@@ -291,6 +291,19 @@ differs is everything *around* the weights, and three things bite:
   `/v1`, so it would be requested at `/v1/v1/models`. Every verb but `use`
   refuses with the restart command instead of emitting a 404. Router mode
   (`--models-dir`) is out of scope for all of remi's engine shapes.
+
+**remi supervises `llama-server` but never installs it** (#822 slice 1). It
+spawns it on demand through the same `EngineHost` the engine uses — attach
+first, claim the pidfile before spawning, health-probe `/health` (NOT
+`/v1/llm/status`, which llama.cpp has never served), stop what it started — and
+reports an actionable "install it" reason when the binary is absent. The line is
+drawn there deliberately: the macOS path fetches a **pinned artifact remi
+controls** (#834), while `llama-server` is a third-party binary across an arch
+matrix, so supervising one the user installed is a different trust proposition
+from downloading and executing one. The GGUF is not remi's job either — `-hf`
+makes llama.cpp pull it — which narrows what #822 originally assumed
+("Download is remi's job"). Still open on that issue: acquiring the binary,
+`keep_alive`/idle-stop, and the `escalate_model` design question.
 
 `warmModel()` is engine-only for the same reason, and the `llamacpp` base URL
 already carries `/v1` — calling it there requests `/v1/v1/llm/preload`. Its one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **remi supervises `llama-server` on Linux** (#822). Auto-approve's local
+  backend no longer has to be started by hand: remi spawns it on demand,
+  health-probes it, and stops what it started — the same `EngineHost` the macOS
+  engine path already used, so it inherits attach-first, claim-the-pidfile-
+  before-spawning, and the redundant-start race resolution rather than
+  reimplementing them. What differs is only the launch (`-hf`, argv rather than
+  env), the readiness question (`/health`, since llama.cpp has never served
+  `/v1/llm/status`), and how the executable is found.
+  **remi still does not install it** — `brew install llama.cpp`, your distro's
+  package, or a prebuilt binary, once. That line is deliberate: the macOS helper
+  is a pinned artifact remi controls (#834), whereas `llama-server` is a
+  third-party binary across an arch matrix, so supervising one the user
+  installed is a different trust proposition from downloading and executing one.
+  A missing binary now reports how to install it instead of the engine path's
+  generic "no helper available", which implied a download that was never coming.
+  The GGUF is not remi's job either — `-hf` pulls it — which narrows what #822
+  assumed ("Download is remi's job"). Still open there: acquiring the binary,
+  idle-stop, and the `escalate_model` design question.
+
+### Fixed
+- **The `escalate_model` warning could be silenced for the users it was for**
+  (#822). It was nested inside the llamacpp boot warning, which was harmless
+  only while that warning fired on every llamacpp boot. Now that the boot
+  warning fires only for a *missing* binary, the nesting would have hidden the
+  "your second opinion comes from the primary model" notice from exactly the
+  people whose setup works. Lifted out to its own condition. Introduced and
+  fixed within this change; it never shipped.
+
 ## [0.7.6] - 2026-08-11
 
 Closes a P0 that shipped in every release to date: the daemon bound `0.0.0.0`

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -66,13 +66,60 @@ import { errorToString } from '@remi/shared';
 import { ensureHelperInstalled } from './engine-install.ts';
 import { probeEngine } from './engine-models.ts';
 import { FileEnginePidStore, spawnDetachedEngine } from './engine-process.ts';
+import {
+  LLAMACPP_LOG_FILE,
+  llamaServerArgs,
+  llamaServerMissingHint,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from './llamacpp-backend.ts';
 
 /** How remi relates to the engine on its port. */
 export type EngineOwnership = 'owned' | 'shared';
 
+/**
+ * Which local backend answers on the port (#822). The platform probe decides —
+ * Apple Silicon gets the Yooz engine, Linux gets llama.cpp — and by
+ * construction the two never coexist, so this is a discriminator, not a
+ * preference.
+ *
+ * Everything `EngineHost` does ABOVE the launch is identical for both: attach
+ * first, claim before spawning, resolve the redundant-start race, never reap on
+ * exit. Only the argv, the readiness question and how the executable is
+ * acquired differ, which is why this is a field rather than a subclass.
+ */
+export type EngineBackendKind = 'yooz' | 'llamacpp';
+
+/**
+ * Reachability, which is ALL this class asks of a probe.
+ *
+ * Narrower than `probeEngine`'s return on purpose: `EngineHost` reads only
+ * `.reachable` at every one of its four probe sites and never touches
+ * `.status`. Typing the seam as what it actually uses lets llama.cpp's
+ * `/health` satisfy it without inventing an `EngineStatus` it cannot produce
+ * (#822 — llama-server serves none of the `/v1/llm/*` control plane).
+ * `probeEngine` remains assignable, so nothing on the engine path changes.
+ */
+export type ReachabilityProbe = (
+  baseUrl: string,
+  timeoutMs?: number,
+) => Promise<{ readonly reachable: boolean }>;
+
 export interface EngineHostConfig {
   /** Loopback root, e.g. `http://127.0.0.1:19924`. */
   readonly baseUrl: string;
+  /**
+   * Which backend to launch and probe. Defaults to `yooz` so every existing
+   * construction keeps its behaviour unchanged.
+   */
+  readonly backend?: EngineBackendKind;
+  /**
+   * The model id, needed only by `llamacpp`: llama-server loads one GGUF at
+   * process start (`-hf`), so the id is a LAUNCH argument there rather than a
+   * per-request field. On the engine path the model is chosen per request and
+   * this is ignored.
+   */
+  readonly model?: string | undefined;
   /** `owned` (spawn + supervise) or `shared` (read-only guest). */
   readonly ownership: EngineOwnership;
   /**
@@ -101,11 +148,11 @@ export interface EngineHostDeps {
    * engine survives this process; it returns only the pid because there is no
    * child handle to hold onto afterwards. Tests supply a fake.
    */
-  readonly spawn?: (path: string, env: Record<string, string>) => number;
+  readonly spawn?: (path: string, args: readonly string[], env: Record<string, string>) => number;
   /** Kill a pid. Needed on the failure paths: a helper we started that lost
    *  the race, or never bound, must not be left running. */
   readonly kill?: (pid: number) => void;
-  readonly probe?: typeof probeEngine;
+  readonly probe?: ReachabilityProbe;
   readonly sleep?: (ms: number) => Promise<void>;
   /** Pidfile seam (`~/.remi/engine.pid` in production). */
   readonly pidStore?: PidStore;
@@ -150,7 +197,7 @@ export class EngineHost {
   /** In-flight helper download, so concurrent callers share one fetch. */
   private installInFlight: Promise<string | undefined> | undefined;
   private readonly log: EngineHostDeps['log'];
-  private readonly probe: typeof probeEngine;
+  private readonly probe: ReachabilityProbe;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly spawnFn: EngineHostDeps['spawn'];
   private readonly killFn: (pid: number) => void;
@@ -162,12 +209,34 @@ export class EngineHost {
     deps: EngineHostDeps,
   ) {
     this.log = deps.log;
-    this.probe = deps.probe ?? probeEngine;
+    // Probe by backend: llama.cpp has never served `/v1/llm/status`, so the
+    // engine probe would report a permanently-unreachable server that is in
+    // fact answering evals (#822).
+    this.probe = deps.probe ?? (this.isLlamaCpp ? probeLlamaCpp : probeEngine);
     this.sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.spawnFn = deps.spawn;
     this.killFn = deps.kill ?? ((pid) => process.kill(pid));
     this.pids = deps.pidStore;
-    this.installFn = deps.installHelper ?? (() => ensureHelperInstalled({ log: this.log }));
+    // Acquisition by backend. The engine FETCHES its helper (#834, a pinned
+    // artifact remi controls); llama.cpp only RESOLVES one the user installed.
+    // remi deliberately does not download llama-server -- see the module doc in
+    // llamacpp-backend.ts for why that line is drawn here.
+    this.installFn =
+      deps.installHelper ??
+      (this.isLlamaCpp
+        ? () => Promise.resolve(resolveLlamaServer())
+        : () => ensureHelperInstalled({ log: this.log }));
+  }
+
+  private get isLlamaCpp(): boolean {
+    return this.config.backend === 'llamacpp';
+  }
+
+  /** How this backend is named in logs and reasons. Not cosmetic: "the engine
+   *  did not come up" pointing at a llama-server is the wrong-but-plausible
+   *  description ADR 0011 is about. */
+  private get label(): string {
+    return this.isLlamaCpp ? 'llama-server' : 'engine';
   }
 
   /** True when remi may load/unload/delete models on this engine. The single
@@ -218,6 +287,16 @@ export class EngineHost {
       return { kind: 'unavailable', reason };
     }
 
+    // llama.cpp loads ONE model at process start, so an empty id is not a
+    // degraded launch -- it is `-hf ''`, which fails in the child where the
+    // only trace is a log file nobody is looking at. The engine path cannot hit
+    // this: it picks a model per request, long after startup.
+    if (this.isLlamaCpp && (this.config.model === undefined || this.config.model.length === 0)) {
+      const reason = `cannot start ${this.label}: auto_approve.model is empty and llama.cpp needs the model id at launch (it serves one GGUF per process)`;
+      this.log(`[Engine] ${reason}`);
+      return { kind: 'unavailable', reason };
+    }
+
     // Resolve, then acquire. `engine_path` wins when set -- someone pointing at
     // their own build is making a deliberate choice and must not have it
     // second-guessed by a download. Otherwise use the helper remi has already
@@ -234,7 +313,14 @@ export class EngineHost {
       helperPath = await this.installHelper();
     }
     if (helperPath === undefined || helperPath.length === 0) {
-      const reason = `no engine on ${this.config.baseUrl} and no helper available to start it`;
+      // Name the ACTIONABLE thing. On the engine path "no helper available"
+      // means a download failed and retrying may fix it; on llama.cpp it means
+      // the user has not installed anything, and remi will never install it for
+      // them (#822) -- so the generic wording would leave them waiting for an
+      // acquisition that is never coming.
+      const reason = this.isLlamaCpp
+        ? `no ${this.label} on ${this.config.baseUrl}: ${llamaServerMissingHint()}`
+        : `no engine on ${this.config.baseUrl} and no helper available to start it`;
       this.log(`[Engine] ${reason}`);
       return { kind: 'unavailable', reason };
     }
@@ -293,9 +379,17 @@ export class EngineHost {
    * booting daemon and the two would fight over the port.
    */
   static real(config: EngineHostConfig, log: (msg: string) => void): EngineHost {
+    // Same pidfile for both backends, deliberately: it is a mutual-exclusion
+    // record for "something remi started owns port 19924", and only one backend
+    // can hold that port. Separate records would let a stale engine entry and a
+    // live llama-server entry coexist and both believe they had the claim.
+    const logFile = config.backend === 'llamacpp' ? LLAMACPP_LOG_FILE : undefined;
     return new EngineHost(config, {
       log,
-      spawn: spawnDetachedEngine,
+      spawn:
+        logFile === undefined
+          ? spawnDetachedEngine
+          : (p, args, env) => spawnDetachedEngine(p, args, env, logFile),
       pidStore: new FileEnginePidStore(),
     });
   }
@@ -325,17 +419,8 @@ export class EngineHost {
 
     let pid: number;
     try {
-      const cache = this.config.modelCache;
-      pid = spawnFn(helperPath, {
-        // Headless: no menu-bar UI for a helper nobody looks at.
-        YOOZ_ENGINE_HEADLESS: '1',
-        // remi's reserved port, in every configuration (see the module doc).
-        YOOZ_ENGINE_PORT: String(portOf(this.config.baseUrl)),
-        // Weights location, via the standard HuggingFace variable the engine
-        // already reads. Omitted entirely when unset so the engine keeps its
-        // own default rather than being handed an empty path.
-        ...(cache !== undefined && cache.length > 0 ? { HF_HUB_CACHE: cache } : {}),
-      });
+      const launch = this.buildLaunch();
+      pid = spawnFn(helperPath, launch.args, launch.env);
     } catch (err) {
       // Release the claim we took above, or the next attempt is blocked by a
       // record for a process that never existed.
@@ -389,6 +474,42 @@ export class EngineHost {
     const reason = `engine started (pid ${pid}) but never answered on ${this.config.baseUrl}`;
     this.log(`[Engine] ${reason}`);
     return { kind: 'unavailable', reason };
+  }
+
+  /**
+   * How this backend is launched: argv plus environment.
+   *
+   * The split is not arbitrary. The Yooz engine is configured entirely through
+   * the environment and takes NO arguments (`spawn(helperPath, [], ...)` was
+   * literal before #822); llama.cpp is the mirror image, taking everything on
+   * the command line. Keeping both in one place means the difference is data a
+   * reader can see at once, rather than a branch buried in the spawn path.
+   */
+  private buildLaunch(): { args: string[]; env: Record<string, string> } {
+    const cache = this.config.modelCache;
+    if (this.isLlamaCpp) {
+      return {
+        args: llamaServerArgs(this.config.model ?? '', portOf(this.config.baseUrl)),
+        // `LLAMA_CACHE` is llama.cpp's own download location for `-hf`, NOT
+        // `HF_HUB_CACHE` (which is the Python huggingface_hub variable the Yooz
+        // engine reads). Naming the wrong one would silently ignore a
+        // configured cache and re-download multi-GB weights into the default.
+        env: cache !== undefined && cache.length > 0 ? { LLAMA_CACHE: cache } : {},
+      };
+    }
+    return {
+      args: [],
+      env: {
+        // Headless: no menu-bar UI for a helper nobody looks at.
+        YOOZ_ENGINE_HEADLESS: '1',
+        // remi's reserved port, in every configuration (see the module doc).
+        YOOZ_ENGINE_PORT: String(portOf(this.config.baseUrl)),
+        // Weights location, via the standard HuggingFace variable the engine
+        // already reads. Omitted entirely when unset so the engine keeps its
+        // own default rather than being handed an empty path.
+        ...(cache !== undefined && cache.length > 0 ? { HF_HUB_CACHE: cache } : {}),
+      },
+    };
   }
 
   /**

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -216,14 +216,21 @@ export class FileEnginePidStore implements PidStore {
  */
 export function spawnDetachedEngine(
   helperPath: string,
+  args: readonly string[],
   env: Record<string, string>,
   logFile: string = ENGINE_LOG_FILE,
 ): number {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });
   const logFd = fs.openSync(logFile, 'a');
   try {
-    fs.writeSync(logFd, `\n--- Engine starting at ${new Date().toISOString()} ---\n`);
-    const child = spawn(helperPath, [], {
+    // Name the executable rather than saying "Engine": since #822 this also
+    // launches `llama-server`, and a log banner that calls it the engine is the
+    // kind of wrong-but-plausible description ADR 0011 exists to prevent.
+    fs.writeSync(
+      logFd,
+      `\n--- ${path.basename(helperPath)} starting at ${new Date().toISOString()} ---\n`,
+    );
+    const child = spawn(helperPath, [...args], {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       env: { ...process.env, ...env },

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -13,7 +13,23 @@ export type { AuthorityBoundaryResult } from './authority.ts';
 export { enforceDenyFloor, matchesCatastrophicPattern } from './deny-floor.ts';
 export type { DenyFloorResult } from './deny-floor.ts';
 export { EngineHost } from './engine-host.ts';
-export type { EngineHostState, EngineOwnership, PidStore } from './engine-host.ts';
+export type {
+  EngineBackendKind,
+  EngineHostState,
+  EngineOwnership,
+  PidStore,
+  ReachabilityProbe,
+} from './engine-host.ts';
+// #822: the boot path asks whether a llama-server exists before telling the
+// user anything about it, so both the probe-for-presence and the remedy text
+// are exported here rather than reached for through a deep import.
+export {
+  LLAMACPP_LOG_FILE,
+  llamaServerArgs,
+  llamaServerMissingHint,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from './llamacpp-backend.ts';
 export {
   ENGINE_LOG_FILE,
   ENGINE_PID_FILE,

--- a/packages/daemon/src/auto-approve/llamacpp-backend.ts
+++ b/packages/daemon/src/auto-approve/llamacpp-backend.ts
@@ -1,0 +1,167 @@
+/**
+ * The llama.cpp half of the local-eval backend (#822 Phase B, slice 1).
+ *
+ * `EngineHost` (#818) already owns the hard part — attach-first, claim before
+ * spawning, resolve the redundant-start race, never reap on exit — and none of
+ * that is engine-specific. So llama.cpp reuses the class outright and supplies
+ * only what actually differs: how the process is launched, and how you ask it
+ * whether it is up.
+ *
+ * WHAT REMI DOES NOT DO HERE, deliberately. It does not download or install
+ * `llama-server`. #822's own scope says "remi owns download + process
+ * lifetime", and this module implements the second half only. Supervising a
+ * binary the user installed is a different trust proposition from fetching and
+ * executing a third-party binary across an arch matrix: the macOS path fetches
+ * a PINNED artifact from a release remi controls (#834), which llama.cpp is
+ * not. The install stays a documented step; the nohup does not.
+ *
+ * The GGUF itself is NOT remi's job either, which is a real narrowing of what
+ * #822 assumed ("Download is remi's job. No engine to auto-pull from
+ * HuggingFace"). `-hf` makes llama.cpp pull from HuggingFace on first run, so
+ * the model half of Phase B is already solved by the transport.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+
+/** Where a remi-started `llama-server`'s stdout/stderr go. Separate from
+ *  `engine.log` so the two backends' diagnostics never interleave — only one
+ *  can run per machine (the platform probe decides), but a machine that has
+ *  run both over its life should not have to untangle one file. */
+export const LLAMACPP_LOG_FILE = path.join(REMI_DIR, 'llama-server.log');
+
+/** The executable remi looks for. Not configurable by design: `engine_path`
+ *  already exists for "point at my own build", and it is backend-agnostic. */
+export const LLAMA_SERVER_BIN = 'llama-server';
+
+/**
+ * Reachability against `llama-server`.
+ *
+ * Deliberately NOT `probeEngine`: that asks `/v1/llm/status`, which is the Yooz
+ * engine's control plane and something llama.cpp has never served (#822 —
+ * "llama-server has none of /v1/llm/{models,status,preload,unload}"). Pointing
+ * the engine probe at it would report a permanently-unreachable backend that is
+ * in fact answering evals perfectly well.
+ *
+ * `/health` is the right question and it distinguishes the two states that
+ * matter during startup: 503 while the model is still loading, 200 once it can
+ * serve. `waitForReady` polls this, so a cold multi-GB load reads as "not ready
+ * yet" rather than as a failure.
+ *
+ * Never throws, for the same reason `probeEngine` never throws: "nothing is
+ * listening" must be a reportable value, not an exception that escapes into a
+ * silent permanent escalation (#818).
+ */
+export async function probeLlamaCpp(
+  baseUrl: string,
+  timeoutMs = 2_000,
+): Promise<{ readonly reachable: boolean; readonly reason?: string }> {
+  const url = healthUrl(baseUrl);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // 200 = ready to serve. 503 = alive but still loading the GGUF, which is
+    // NOT reachable for our purposes: dispatching an eval into a loading server
+    // would burn the hook budget waiting. Report it as unreachable-with-reason
+    // so the startup poll keeps waiting instead of giving up.
+    if (res.ok) return { reachable: true };
+    return { reachable: false, reason: `HTTP ${res.status} from ${url}` };
+  } catch (err) {
+    return { reachable: false, reason: errorToString(err) };
+  }
+}
+
+/**
+ * `<origin>/health` from an OpenAI-style base URL.
+ *
+ * The llamacpp base URL carries a `/v1` suffix (`llm-client.ts`'s
+ * `PROVIDER_URLS`) because it is dispatched through the `openai` kind, which
+ * appends `/chat/completions` directly. `/health` is served at the ROOT, not
+ * under `/v1`, so naively joining would request `/v1/health` — the same
+ * `/v1/v1/...` class of bug AGENTS.md already records for `warmModel`.
+ */
+export function healthUrl(baseUrl: string): string {
+  try {
+    return `${new URL(baseUrl).origin}/health`;
+  } catch {
+    // A malformed base URL is a config error that belongs to the caller; the
+    // probe's contract is to report unreachable, not to throw. Returning the
+    // input unchanged makes the fetch fail cleanly with the real reason.
+    return baseUrl;
+  }
+}
+
+/**
+ * argv for `llama-server`.
+ *
+ * `-hf <repo>:<quant>` pulls from HuggingFace on first run and reuses the cache
+ * after. The quant suffix is load-bearing: `-hf` with no tag prefers
+ * `Q4_K_M`/`Q8_0` and the YoozLabs repos publish only `Q4_0`, so a bare repo id
+ * resolves no file (see `defaultModel`).
+ *
+ * `--host` is pinned to loopback and NOT derived from `daemon.bind`. The eval
+ * backend is remi's own sidecar, not a service anyone else may reach: widening
+ * it would hand any host that can reach the port a free LLM, and after #880
+ * that is precisely the class of default this repo just spent a release
+ * closing.
+ */
+export function llamaServerArgs(model: string, port: number, host = '127.0.0.1'): string[] {
+  return ['-hf', model, '--host', host, '--port', String(port)];
+}
+
+/**
+ * Find `llama-server` on PATH.
+ *
+ * Returns the absolute path, or undefined when it is not installed — which
+ * `EngineHost` turns into a reported `unavailable`, never a throw. Scans PATH
+ * by hand rather than shelling out to `which`/`where`: this runs on the boot
+ * path, a subprocess per boot to answer a filesystem question is waste, and the
+ * seam stays synchronous so the caller does not have to be async to ask.
+ */
+export function resolveLlamaServer(
+  env: NodeJS.ProcessEnv = process.env,
+  isExecutable: (p: string) => boolean = defaultIsExecutable,
+): string | undefined {
+  const rawPath = env['PATH'];
+  if (rawPath === undefined || rawPath.length === 0) return undefined;
+  // `delimiter` rather than a literal ':' — Windows uses ';' and, while no
+  // local backend exists there today (`detectLocalLLMPlatform` returns
+  // 'unsupported'), a resolver that silently returns nothing on one platform
+  // for a reason unrelated to the actual question is a trap for whoever adds
+  // that support later.
+  for (const dir of rawPath.split(path.delimiter)) {
+    if (dir.length === 0) continue;
+    const candidate = path.join(dir, LLAMA_SERVER_BIN);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function defaultIsExecutable(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    // A directory can carry the execute bit (it means "traversable"), so the
+    // access check alone would happily return a path that cannot be spawned.
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What to tell a user who has no `llama-server`.
+ *
+ * Shared by the boot path and the host's unavailable reason so the two can
+ * never drift into naming different remedies — the failure mode AGENTS.md
+ * records for `help.ts` still claiming `default: 0.0.0.0` after the default
+ * moved.
+ */
+export function llamaServerMissingHint(): string {
+  return `${LLAMA_SERVER_BIN} is not on PATH, so remi has nothing to supervise. Install it once (remi does not download it, #822): "brew install llama.cpp", your distro's package, or a prebuilt binary from github.com/ggml-org/llama.cpp/releases. remi starts and stops it for you after that.`;
+}

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -134,6 +134,8 @@ import {
   SubagentAlerter,
   alertBody,
   alertTitle,
+  llamaServerMissingHint,
+  resolveLlamaServer,
   resolveProviderUrl,
 } from './auto-approve/index.ts';
 import type { PrecedentStore } from './auto-approve/precedent.ts';
@@ -887,53 +889,68 @@ let autoApproveService: AutoApproveService | null = null;
       logError(
         `[AutoApprove] No local LLM backend exists for ${process.platform}/${process.arch}: the Yooz engine needs Apple Silicon (MLX) and the llama.cpp path is Linux. Auto-approve will escalate every permission until you point auto_approve.provider at a reachable backend (e.g. openrouter, or a custom URL).`,
       );
-    } else if (provider === 'llamacpp') {
-      // Linux resolves to `llamacpp`, but NOTHING installs or supervises a
-      // llama-server yet (#822) -- remi only supervises the engine transport.
-      // Left unsaid, a Linux user enabling auto-approve gets silence and then
-      // every permission escalated, which is precisely the unexplained
-      // degradation #818 was filed to remove, reintroduced on another platform.
-      // The macOS path fetches its own helper (#834); this one cannot yet, so
-      // the honest thing is to say so at boot rather than at the first
-      // permission -- and to say exactly what to run, since the weights and
-      // the transport both already exist. `-hf` pulls from HuggingFace on
-      // first run; the quant suffix is explicit for determinism, not
-      // because a bare id fails (see `defaultModel`).
+    } else if (provider === 'llamacpp' && resolveLlamaServer() === undefined) {
+      // remi SUPERVISES llama-server since #822 (spawn, health-probe, stop) but
+      // deliberately never INSTALLS it -- see llamacpp-backend.ts for where that
+      // line is drawn. So the only remaining boot-time gap is a missing binary,
+      // and it is worth saying here rather than at the first permission: left
+      // unsaid, a Linux user enabling auto-approve gets silence and then every
+      // permission escalated, which is precisely the unexplained degradation
+      // #818 was filed to remove, reintroduced on another platform.
+      //
+      // Nothing is printed when the binary IS present: remi starts it on
+      // demand, so there is no action for the user to take and a warning would
+      // describe a problem that does not exist.
       logError(
-        `[AutoApprove] provider = "llamacpp": remi does not yet download or supervise a llama.cpp server (#822), so start one yourself and auto-approve works:
-    ${llamaServerCommand(model)}
-  Until it answers on ${baseUrl}, every permission escalates. A remote provider (openrouter, a custom URL) also works.`,
+        `[AutoApprove] provider = "llamacpp": ${llamaServerMissingHint()}
+  Until something answers on ${baseUrl}, every permission escalates. A remote provider (openrouter, a custom URL) also works.
+  Once installed, remi runs it for you as: ${llamaServerCommand(model)}`,
       );
-      // llama-server ignores the request's `model` field in single-model mode
-      // (verified against its README), so a configured escalate_model is
-      // answered by whatever GGUF was loaded at process start -- a "second
-      // opinion" from the same weights, reported as if a heavier model had
-      // agreed. Silent, and it makes escalate_model actively misleading rather
-      // than merely absent. #822's own scope calls this out as an open design
-      // question ("one model per process"); until it is decided, say so.
-      if (aaCfg.escalate_model && aaCfg.escalate_model !== model) {
-        logError(
-          `[AutoApprove] escalate_model = "${aaCfg.escalate_model}" has no effect on provider = "llamacpp": llama-server serves the one model it was started with and ignores the requested model id, so the "second opinion" would come from the primary model (#822). There is no per-model base URL in the config, so there is no way to route it elsewhere today (#822 owns that design question) -- leave it empty until then.`,
-        );
-      }
+    }
+
+    // llama-server ignores the request's `model` field in single-model mode
+    // (verified against its README), so a configured escalate_model is
+    // answered by whatever GGUF was loaded at process start -- a "second
+    // opinion" from the same weights, reported as if a heavier model had
+    // agreed. Silent, and it makes escalate_model actively misleading rather
+    // than merely absent. #822's own scope calls this out as an open design
+    // question ("one model per process"); until it is decided, say so.
+    //
+    // Deliberately OUTSIDE the branch above. It used to be nested inside the
+    // llamacpp warning, which was harmless only because that warning fired for
+    // every llamacpp boot. Now that it fires just for a MISSING binary, nesting
+    // would silence this for exactly the users whose setup works -- i.e.
+    // everyone who would actually get the misleading second opinion.
+    if (provider === 'llamacpp' && aaCfg.escalate_model && aaCfg.escalate_model !== model) {
+      logError(
+        `[AutoApprove] escalate_model = "${aaCfg.escalate_model}" has no effect on provider = "llamacpp": llama-server serves the one model it was started with and ignores the requested model id, so the "second opinion" would come from the primary model (#822). There is no per-model base URL in the config, so there is no way to route it elsewhere today (#822 owns that design question) -- leave it empty until then.`,
+      );
     }
 
     // #818: who starts the engine. Only meaningful for the engine transport —
     // an OpenRouter or llama.cpp base URL is not something remi supervises, and
     // handing those an EngineHost would mean spawning a Yooz helper for a
     // provider that never talks to one.
-    const engineHost =
-      provider === 'yooz'
-        ? EngineHost.real(
-            {
-              baseUrl,
-              ownership: aaCfg.engine,
-              helperPath: aaCfg.engine_path,
-              modelCache: aaCfg.model_cache,
-            },
-            writeToLog,
-          )
-        : undefined;
+    // #822: llamacpp is supervised too now. Both are local sidecars remi owns
+    // on its reserved port; what differs is the launch and the readiness probe,
+    // which `EngineHost` takes as configuration. A remote provider (OpenRouter,
+    // a custom URL) is still never supervised -- handing those a host would
+    // mean spawning a local backend for something that never talks to one.
+    const engineHost = localProvider
+      ? EngineHost.real(
+          {
+            baseUrl,
+            backend: provider === 'llamacpp' ? 'llamacpp' : 'yooz',
+            // llama.cpp needs the id at launch (one GGUF per process); the
+            // engine ignores it and selects per request.
+            model,
+            ownership: aaCfg.engine,
+            helperPath: aaCfg.engine_path,
+            modelCache: aaCfg.model_cache,
+          },
+          writeToLog,
+        )
+      : undefined;
 
     autoApproveService = new AutoApproveService(
       {

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -38,7 +38,11 @@ function host(
 ) {
   const logs: string[] = [];
   const killed: number[] = [];
-  const spawnCalls: Array<{ path: string; env: Record<string, string> }> = [];
+  const spawnCalls: Array<{
+    path: string;
+    args: readonly string[];
+    env: Record<string, string>;
+  }> = [];
   const probes = opts.probes ?? [UNREACHABLE];
   let probeIndex = 0;
   const h = new EngineHost(
@@ -54,8 +58,8 @@ function host(
       log: (m) => logs.push(m),
       sleep: async () => {},
       probe: async () => probes[Math.min(probeIndex++, probes.length - 1)] as EngineProbe,
-      spawn: (path, env) => {
-        spawnCalls.push({ path, env });
+      spawn: (path, args, env) => {
+        spawnCalls.push({ path, args, env });
         if (opts.spawnThrows) throw new Error(opts.spawnThrows);
         return opts.spawnPid ?? 4242;
       },

--- a/packages/daemon/tests/auto-approve/engine-process.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-process.test.ts
@@ -170,7 +170,7 @@ describe('spawnDetachedEngine', () => {
   const SLEEP = '/bin/sleep';
 
   test('starts a real process and returns its pid', () => {
-    const pid = spawnDetachedEngine(SLEEP, { YOOZ_ENGINE_PORT: '19924' }, LOG_FILE);
+    const pid = spawnDetachedEngine(SLEEP, [], { YOOZ_ENGINE_PORT: '19924' }, LOG_FILE);
     try {
       expect(pid).toBeGreaterThan(0);
       // Signal 0: alive without delivering anything.
@@ -189,15 +189,18 @@ describe('spawnDetachedEngine', () => {
     // A silent failure would leave a record for a process that never existed,
     // blocking every later attempt.
     const missing = path.join(TEST_DIR, 'no-such-helper');
-    expect(() => spawnDetachedEngine(missing, {}, LOG_FILE)).toThrow();
+    expect(() => spawnDetachedEngine(missing, [], {}, LOG_FILE)).toThrow();
   });
 
   test('writes a start banner to the log file', () => {
     // The helper's own diagnostics are the only evidence available when it
     // starts but never binds, so the log has to exist and be appended to.
-    const pid = spawnDetachedEngine(SLEEP, {}, LOG_FILE);
+    const pid = spawnDetachedEngine(SLEEP, [], {}, LOG_FILE);
     try {
-      expect(fs.readFileSync(LOG_FILE, 'utf8')).toContain('Engine starting at');
+      // Names the EXECUTABLE, not "Engine" (#822): the same function now also
+      // launches llama-server, and a banner calling that the engine is the
+      // wrong-but-plausible description ADR 0011 exists to prevent.
+      expect(fs.readFileSync(LOG_FILE, 'utf8')).toContain('sleep starting at');
     } finally {
       try {
         process.kill(pid);
@@ -213,7 +216,7 @@ describe('spawnDetachedEngine', () => {
     const before = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
     const pids: number[] = [];
     try {
-      for (let i = 0; i < 12; i++) pids.push(spawnDetachedEngine(SLEEP, {}, LOG_FILE));
+      for (let i = 0; i < 12; i++) pids.push(spawnDetachedEngine(SLEEP, [], {}, LOG_FILE));
       const after = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
       const beforeCount = before?.openFileDescriptors?.length;
       const afterCount = after?.openFileDescriptors?.length;

--- a/packages/daemon/tests/auto-approve/llamacpp-backend.test.ts
+++ b/packages/daemon/tests/auto-approve/llamacpp-backend.test.ts
@@ -1,0 +1,404 @@
+/**
+ * #822 slice 1: remi supervises `llama-server` instead of making the user run
+ * it under nohup.
+ *
+ * Everything here drives the REAL thing it names — a real HTTP server for the
+ * probe, real files with real permission bits for PATH resolution. The probe
+ * tests in particular would be worthless against a stubbed `fetch`: the bug
+ * this module exists to avoid is requesting `/v1/health` instead of `/health`,
+ * and only a server that actually 404s the wrong path can catch it.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  EngineHost,
+  type EngineHostConfig,
+  type PidStore,
+} from '../../src/auto-approve/engine-host.ts';
+import { spawnDetachedEngine } from '../../src/auto-approve/engine-process.ts';
+import {
+  healthUrl,
+  llamaServerArgs,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from '../../src/auto-approve/llamacpp-backend.ts';
+
+const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-llamacpp-'));
+afterAll(() => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('healthUrl', () => {
+  test('drops the /v1 suffix the llamacpp base URL carries', () => {
+    // The regression this pins: `llamacpp`'s base URL ends in /v1 (it is
+    // dispatched through the openai kind), but /health is served at the ROOT.
+    // Naively joining yields /v1/health -- the same /v1/v1 class of bug
+    // AGENTS.md already records for warmModel.
+    expect(healthUrl('http://127.0.0.1:19924/v1')).toBe('http://127.0.0.1:19924/health');
+  });
+
+  test('works on a root base URL too', () => {
+    expect(healthUrl('http://127.0.0.1:19924')).toBe('http://127.0.0.1:19924/health');
+  });
+
+  test('a malformed base URL is returned as-is rather than throwing', () => {
+    // The probe's contract is to REPORT unreachable, never to throw: an
+    // exception escaping here becomes a silent permanent escalation (#818).
+    expect(healthUrl('not a url')).toBe('not a url');
+  });
+});
+
+describe('llamaServerArgs', () => {
+  test('passes the model to -hf with its quant suffix intact', () => {
+    const args = llamaServerArgs('YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0', 19924);
+    // The suffix is load-bearing: -hf with no tag prefers Q4_K_M/Q8_0 and the
+    // YoozLabs repos publish only Q4_0, so a stripped tag resolves no file.
+    expect(args).toEqual([
+      '-hf',
+      'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '19924',
+    ]);
+  });
+
+  test('binds loopback, never the daemon bind address', () => {
+    // The eval backend is remi's own sidecar. Widening it would hand any host
+    // that can reach the port a free LLM -- the exact class of default #880
+    // spent a release closing.
+    expect(llamaServerArgs('m', 19924)).toContain('127.0.0.1');
+    expect(llamaServerArgs('m', 19924)).not.toContain('0.0.0.0');
+  });
+});
+
+describe('resolveLlamaServer', () => {
+  const binDir = path.join(TEST_DIR, 'bin');
+  const emptyDir = path.join(TEST_DIR, 'empty');
+
+  beforeAll(() => {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(emptyDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'llama-server'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  });
+
+  test('finds an executable llama-server on PATH', () => {
+    const found = resolveLlamaServer({ PATH: `${emptyDir}${path.delimiter}${binDir}` });
+    expect(found).toBe(path.join(binDir, 'llama-server'));
+  });
+
+  test('returns undefined when it is not installed', () => {
+    // This is what turns into the actionable "install it" reason rather than a
+    // throw: remi never installs llama-server, so the user must be told.
+    expect(resolveLlamaServer({ PATH: emptyDir })).toBeUndefined();
+  });
+
+  test('returns undefined when PATH is unset', () => {
+    expect(resolveLlamaServer({})).toBeUndefined();
+  });
+
+  test('a non-executable file of the right name is not accepted', () => {
+    const noExecDir = path.join(TEST_DIR, 'noexec');
+    fs.mkdirSync(noExecDir, { recursive: true });
+    fs.writeFileSync(path.join(noExecDir, 'llama-server'), 'not executable', { mode: 0o644 });
+    expect(resolveLlamaServer({ PATH: noExecDir })).toBeUndefined();
+  });
+
+  test('a DIRECTORY named llama-server is not accepted', () => {
+    // Directories carry the execute bit (it means "traversable"), so an
+    // access(X_OK) check alone would happily return a path that cannot be
+    // spawned -- and the failure would surface as a spawn error at boot.
+    const dirTrap = path.join(TEST_DIR, 'dirtrap');
+    fs.mkdirSync(path.join(dirTrap, 'llama-server'), { recursive: true });
+    expect(resolveLlamaServer({ PATH: dirTrap })).toBeUndefined();
+  });
+});
+
+describe('probeLlamaCpp against a real server', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let base: string;
+  /** Flipped per test to drive the two states that matter at startup. */
+  let health: { status: number } = { status: 200 };
+  /** Every path the probe requested, so a wrong URL is provable, not assumed. */
+  let requested: string[] = [];
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        requested.push(url.pathname);
+        // Only /health answers. Anything else 404s, which is what makes the
+        // "/v1/health would be wrong" assertion real rather than decorative.
+        if (url.pathname === '/health') return new Response('', { status: health.status });
+        return new Response('not found', { status: 404 });
+      },
+    });
+    base = `http://127.0.0.1:${server.port}/v1`;
+  });
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  test('200 on /health is reachable, and /health is the path actually requested', async () => {
+    requested = [];
+    health = { status: 200 };
+    const probe = await probeLlamaCpp(base);
+    expect(probe.reachable).toBe(true);
+    expect(requested).toEqual(['/health']);
+    expect(requested).not.toContain('/v1/health');
+  });
+
+  test('503 while the GGUF loads is NOT reachable', async () => {
+    // llama-server answers 503 until the model is loaded. Treating that as
+    // reachable would dispatch an eval into a server that cannot serve it and
+    // burn the hook budget waiting.
+    health = { status: 503 };
+    const probe = await probeLlamaCpp(base);
+    expect(probe.reachable).toBe(false);
+    expect(probe.reason).toContain('503');
+  });
+
+  test('a closed port is unreachable with a reason, never a throw', async () => {
+    // Port 1 on loopback: nothing listens, and the probe must turn that into a
+    // value. An exception here is the silent-escalation failure of #818.
+    const probe = await probeLlamaCpp('http://127.0.0.1:1/v1', 500);
+    expect(probe.reachable).toBe(false);
+    expect(probe.reason).toBeDefined();
+  });
+});
+
+/** A real in-memory PidStore with production semantics. */
+function pidStore(): PidStore & { current: number | null } {
+  const store = {
+    current: null as number | null,
+    read: () => store.current,
+    claim: (pid: number) => {
+      if (store.current !== null) return false;
+      store.current = pid;
+      return true;
+    },
+    release: (pid: number) => {
+      if (store.current === pid) store.current = null;
+    },
+  };
+  return store;
+}
+
+function llamaHost(
+  over: Partial<EngineHostConfig> = {},
+  opts: { reachable?: boolean[]; installed?: string | undefined } = {},
+) {
+  const logs: string[] = [];
+  const spawnCalls: Array<{
+    path: string;
+    args: readonly string[];
+    env: Record<string, string>;
+  }> = [];
+  const reach = opts.reachable ?? [false, true];
+  let i = 0;
+  const h = new EngineHost(
+    {
+      baseUrl: 'http://127.0.0.1:19924/v1',
+      backend: 'llamacpp',
+      model: 'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      ownership: 'owned',
+      startupTimeoutMs: 500,
+      probeIntervalMs: 50,
+      ...over,
+    },
+    {
+      log: (m) => logs.push(m),
+      sleep: async () => {},
+      probe: async () => ({ reachable: reach[Math.min(i++, reach.length - 1)] ?? false }),
+      spawn: (p, args, env) => {
+        spawnCalls.push({ path: p, args, env });
+        return 5150;
+      },
+      kill: () => {},
+      // Keep the test off the developer's real PATH: whether this machine
+      // happens to have llama-server installed must not decide the outcome.
+      installHelper: async () => ('installed' in opts ? opts.installed : '/usr/bin/llama-server'),
+      pidStore: pidStore(),
+    },
+  );
+  return { h, logs, spawnCalls };
+}
+
+describe('EngineHost with backend = llamacpp', () => {
+  test('spawns llama-server with -hf and the reserved port', async () => {
+    const { h, spawnCalls } = llamaHost();
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('spawned');
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.path).toBe('/usr/bin/llama-server');
+    expect(spawnCalls[0]?.args).toEqual([
+      '-hf',
+      'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '19924',
+    ]);
+  });
+
+  test('passes NO YOOZ_ENGINE_* environment to llama-server', async () => {
+    // Those variables configure the Yooz engine and mean nothing here.
+    // Setting them anyway would be a misleading description in the process
+    // table and in the log.
+    const { h, spawnCalls } = llamaHost();
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.env).toEqual({});
+  });
+
+  test('a model cache goes to LLAMA_CACHE, not HF_HUB_CACHE', async () => {
+    // HF_HUB_CACHE is the Python huggingface_hub variable the ENGINE reads.
+    // Naming it here would silently ignore the configured cache and
+    // re-download multi-GB weights into llama.cpp's default.
+    const { h, spawnCalls } = llamaHost({ modelCache: '/models' });
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.env).toEqual({ LLAMA_CACHE: '/models' });
+    expect(spawnCalls[0]?.env['HF_HUB_CACHE']).toBeUndefined();
+  });
+
+  test('attaches to a llama-server already running, without spawning', async () => {
+    const { h, spawnCalls } = llamaHost({}, { reachable: [true] });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('attached');
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test('a missing binary reports how to install it, and never spawns', async () => {
+    const { h, logs, spawnCalls } = llamaHost({}, { installed: undefined });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('unavailable');
+    if (state.kind !== 'unavailable') throw new Error('unreachable');
+    // The generic engine wording ("no helper available") would imply a
+    // download that is never coming: remi does not install llama-server.
+    expect(state.reason).toContain('not on PATH');
+    expect(state.reason).toContain('brew install llama.cpp');
+    expect(spawnCalls).toHaveLength(0);
+    expect(logs.join('\n')).toContain('not on PATH');
+  });
+
+  test('an empty model is refused before anything is spawned', async () => {
+    // llama.cpp loads ONE model at process start, so an empty id is `-hf ''`,
+    // which fails inside the child where the only trace is a log file nobody
+    // is reading.
+    const { h, spawnCalls } = llamaHost({ model: '' });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('unavailable');
+    if (state.kind !== 'unavailable') throw new Error('unreachable');
+    expect(state.reason).toContain('auto_approve.model is empty');
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test('END TO END: really spawns a server that binds the port it was told', async () => {
+    // The unit tests above inject `spawn`, so none of them exercises
+    // `spawnDetachedEngine` with argv -- the very thing #822 widened. A stand-in
+    // "llama-server" makes the whole chain real: EngineHost builds the argv,
+    // the production detached spawn passes it, the child PARSES --port and
+    // binds it, and the production /health probe finds it.
+    //
+    // The port is the assertion. A child that binds a port it was not told
+    // about never answers, so this cannot pass on a wrong or dropped argv --
+    // which an `expect(args).toEqual([...])` against a fake spawn can.
+    const port = 18000 + (Math.floor(process.uptime() * 1000) % 900);
+    const argvLog = path.join(TEST_DIR, 'argv.json');
+    const serverTs = path.join(TEST_DIR, 'fake-llama-server.ts');
+    fs.writeFileSync(
+      serverTs,
+      `const argv = process.argv.slice(2);
+require('node:fs').writeFileSync(${JSON.stringify(argvLog)}, JSON.stringify(argv));
+const port = Number(argv[argv.indexOf('--port') + 1]);
+const host = argv[argv.indexOf('--host') + 1];
+Bun.serve({ port, hostname: host, fetch(req) {
+  return new URL(req.url).pathname === '/health'
+    ? new Response('', { status: 200 })
+    : new Response('no', { status: 404 });
+} });
+await new Promise(() => {});
+`,
+    );
+    const binDir = path.join(TEST_DIR, 'realbin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeBin = path.join(binDir, 'llama-server');
+    fs.writeFileSync(fakeBin, `#!/bin/sh\nexec ${process.execPath} ${serverTs} "$@"\n`, {
+      mode: 0o755,
+    });
+
+    const logs: string[] = [];
+    // The PRODUCTION spawn and the PRODUCTION probe (both defaulted), with only
+    // the pidfile and log file redirected: `EngineHost.real` would otherwise
+    // claim the developer's real ~/.remi/engine.pid and fight a running daemon.
+    const testLog = path.join(TEST_DIR, 'llama-server.log');
+    const real = new EngineHost(
+      {
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        backend: 'llamacpp',
+        model: 'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+        ownership: 'owned',
+        helperPath: fakeBin,
+        startupTimeoutMs: 15_000,
+        probeIntervalMs: 200,
+      },
+      {
+        log: (m) => logs.push(m),
+        pidStore: pidStore(),
+        spawn: (p, args, env) => spawnDetachedEngine(p, args, env, testLog),
+      },
+    );
+
+    try {
+      const state = await real.ensureRunning();
+      expect(state.kind).toBe('spawned');
+      // It answered on /health, through the real probe, at the real port.
+      expect(await real.probeOnce()).toBe(true);
+      // And it was launched with the model on -hf.
+      const argv = JSON.parse(fs.readFileSync(argvLog, 'utf8')) as string[];
+      expect(argv).toContain('-hf');
+      expect(argv[argv.indexOf('-hf') + 1]).toBe('YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0');
+    } finally {
+      real.stopStartedEngine();
+    }
+  }, 30_000);
+
+  test('the engine path is unchanged: no args, YOOZ_ENGINE_* env', async () => {
+    // The two-sided half of this change. Widening the spawn seam must not have
+    // altered what the engine is launched with.
+    const spawnCalls: Array<{ args: readonly string[]; env: Record<string, string> }> = [];
+    const h = new EngineHost(
+      {
+        baseUrl: 'http://127.0.0.1:19924',
+        ownership: 'owned',
+        helperPath: '/Applications/Yooz.app/Contents/MacOS/Yooz',
+        startupTimeoutMs: 500,
+        probeIntervalMs: 50,
+      },
+      {
+        log: () => {},
+        sleep: async () => {},
+        probe: (() => {
+          let n = 0;
+          return async () => ({ reachable: n++ > 0 });
+        })(),
+        spawn: (_p, args, env) => {
+          spawnCalls.push({ args, env });
+          return 4242;
+        },
+        kill: () => {},
+        installHelper: async () => undefined,
+        pidStore: pidStore(),
+      },
+    );
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.args).toEqual([]);
+    expect(spawnCalls[0]?.env).toEqual({
+      YOOZ_ENGINE_HEADLESS: '1',
+      YOOZ_ENGINE_PORT: '19924',
+    });
+  });
+});


### PR DESCRIPTION
Toward #822. Linux auto-approve no longer requires the user to start
`llama-server` by hand.

## Why this shape

`EngineHost` (#818) already owns the hard part — attach-first, claim the pidfile
BEFORE spawning, resolve the redundant-start race, never reap on exit — and none
of that is engine-specific. So llama.cpp reuses the class outright rather than
getting a parallel `OwnedLlamaCppHost` that would have to re-derive the same
race handling. Three things actually differ, and they are now configuration:

| | engine | llamacpp |
|---|---|---|
| launch | env (`YOOZ_ENGINE_*`), **no argv** | argv (`-hf`, `--host`, `--port`), no env |
| readiness | `/v1/llm/status` | `/health` |
| acquisition | fetches a pinned release (#834) | resolves PATH |

## The line remi does not cross

**remi supervises `llama-server`; it never installs it.** #822's title says
"remi owns download + process lifetime" and this implements the second half
only. The macOS path gets away with fetching because it is a **pinned artifact
remi controls**; `llama-server` is a third-party binary across an arch matrix,
and supervising one the user installed is a different trust proposition from
downloading and executing one. Install stays `brew install llama.cpp` (or a
distro package, or a release binary), once.

A missing binary now reports **how to install it**. Previously it would have hit
the engine path's generic "no helper available", which implies a download that
is never coming.

## A narrowing of #822 worth recording

The issue states: *"Download is remi's job. No engine to auto-pull from
HuggingFace."* That is no longer true — `-hf` makes llama.cpp pull the GGUF
itself, which is why the boot command already used that form. So the model half
of Phase B is solved by the transport, and what remained was process lifetime.

## Bug found and fixed inside this change

The `escalate_model` warning ("your second opinion comes from the primary
model") was **nested inside** the llamacpp boot warning. That was harmless only
while the outer warning fired on every llamacpp boot. Once it fires only for a
*missing binary*, the nesting would have silenced the notice for exactly the
users whose setup works — i.e. everyone who would actually get the misleading
second opinion. Lifted to its own condition. Never shipped; introduced and fixed
here, and called out in the code comment so it is not re-nested later.

## Verification

- Full suite: **6116 pass, 1 skip, 3 fail**. The 3 are `discoverDaemons` in
  `mdns/mdns-browser.test.ts` — **pre-existing**, and not taken on faith:
  `git diff --name-only origin/main..origin/develop -- '*mdns*'` is empty and
  the same three fail identically on an `origin/main` worktree on this machine.
- `biome check .`, all four typecheck targets, `typos`: clean.

**21 new tests, all driving the real thing they name** — a real `Bun.serve` for
the probe, real files with real permission bits for PATH resolution. A stubbed
`fetch` could not catch the bug this module exists to avoid (requesting
`/v1/health` instead of `/health`); only a server that actually 404s the wrong
path can.

**Mutation-verified**, because the unit tests inject `spawn` and would otherwise
prove nothing about the real launch:

| mutation | result |
|---|---|
| `healthUrl` joins naively (the `/v1/v1` bug) | 5 red |
| `resolveLlamaServer` drops the `isFile` check | 1 red |
| probe treats any response as reachable | 1 red |
| llamacpp cache uses `HF_HUB_CACHE` | 1 red |
| argv drops `--port` | E2E red |
| argv drops `-hf <model>` | E2E red |

The end-to-end test is the one that matters: it puts a stand-in `llama-server`
on disk, spawns it through the **production** `spawnDetachedEngine` (only the
pidfile and log file are redirected), and the child **parses `--port` and binds
it**. A wrong or dropped argv means nothing ever answers, so it cannot pass the
way an `expect(args).toEqual([...])` against a fake spawn can.

Two-sided: a test pins that the engine path still launches with **no argv** and
the same `YOOZ_ENGINE_*` env, since widening the spawn seam is exactly the kind
of change that quietly alters the path it was not aimed at.

## Docs

`AGENTS.md`'s backend table said Linux was **"you, for now — remi prints the
command at boot"**, which this makes false; corrected in the same change per
ADR 0011 rule 3, along with a paragraph stating the supervise/install boundary
and what remains open on #822.

## Still open on #822 (not claimed here)

Acquiring the binary, `keep_alive`/idle-stop (which on llama.cpp means
terminating the process, not calling an unload endpoint), and the
`escalate_model` design question. Also unchanged: the 38/38 permission-grid
measurement remains **MLX-only** — the GGUF has still never been benchmarked
against llama.cpp.
