### PR TITLE
Say why mDNS is not advertising (#1051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ All notable changes to Remi are documented here.
   idle-stop, and the `escalate_model` design question.
 
 ### Fixed
+- **A loopback bind stopped mDNS advertising with no log line at all** (#1051).
+  `startMdnsIfNeeded` collapsed three suppression conditions into one bare
+  `return null`, while every other exit from that function logged something.
+  Before #880 that was nearly harmless because `isLocalhostBind` was false on a
+  stock install; since the bind default moved to loopback it is the path
+  **every** stock install takes. The cost was specific: mDNS does not refuse a
+  discovery attempt, it stops answering, so from the phone's side the daemon
+  does not error — it *vanishes*, and nothing in the daemon's own output
+  contradicts "Remi is broken". Each condition now says which one fired, and
+  only the loopback case — the one the user did not ask for, since it arrived
+  with a changed default — names a remedy. `--no-mdns` and `network.mdns =
+  false` state the fact without nagging. The loopback message names
+  `auth.enabled` alongside `daemon.bind`, because widening the bind while auth
+  stays at `"auto"` (which resolves to `false`) walks straight back into the
+  #880 exposure.
+- **A `typos` false positive that a version bump would have turned into a CI
+  failure.** `ACCEPTs` in `port-discovery.ts` is flagged by typos ≥1.49 but not
+  by the pinned 1.28.4, so the repo was one dependency bump away from a red
+  gate on a comment. Unrelated to the above; called out rather than folded in
+  silently.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -192,6 +192,10 @@ import {
 import type { RemiConfig } from './config/index.ts';
 import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
 import type { HookInput, PermissionRequestHookInput, StopHookInput } from './hooks/index.ts';
+// Static, unlike the publisher below it: this is a pure decision with no
+// side effects and nothing to load, so there is nothing for a dynamic import
+// to defer -- and it is needed on the path where mDNS never starts at all.
+import { mdnsSuppression, mdnsSuppressionMessage } from './mdns/advertise-decision.ts';
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
@@ -1624,7 +1628,21 @@ const wrapperPtyGate = new PtyQuiescenceGate();
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
 ): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
-  if (cliNoMdns || !remiConfig.network.mdns || isLocalhostBind) return null;
+  // #1051: say WHICH condition suppressed it. This used to be a bare
+  // `return null` while every other exit from this function logged, and since
+  // #880 moved the bind default to loopback it became the path every stock
+  // install takes -- so the daemon silently stopped being discoverable and
+  // nothing in its own output said why.
+  const suppression = mdnsSuppression({
+    cliNoMdns,
+    configMdns: remiConfig.network.mdns,
+    isLocalhostBind,
+    bindHost,
+  });
+  if (suppression !== null) {
+    logFn(mdnsSuppressionMessage(suppression));
+    return null;
+  }
   try {
     const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
     const publisher = new MdnsPublisher({

--- a/packages/daemon/src/mdns/advertise-decision.ts
+++ b/packages/daemon/src/mdns/advertise-decision.ts
@@ -1,0 +1,74 @@
+/**
+ * Why mDNS is or is not advertising (#1051).
+ *
+ * `startMdnsIfNeeded` used to collapse three suppression conditions into one
+ * bare `return null`, while every OTHER exit from that function said something
+ * ("Advertising on local network", "Failed to start: ..."). Before #880 that
+ * was nearly harmless, because `isLocalhostBind` was false on a stock install.
+ * Since the bind default moved to loopback it is the path EVERY stock install
+ * takes — so the one unexplained exit became the common one.
+ *
+ * What that costs: mDNS does not refuse a discovery attempt, it stops
+ * answering. From the phone's side the daemon does not error, it VANISHES. The
+ * user's reading is "Remi is broken" or "my network is broken", and nothing in
+ * the daemon's own output contradicts it.
+ *
+ * This module is the decision only — a pure function so it can be tested
+ * without booting a daemon, since the caller in `cli.ts` is module-level
+ * startup code with no seam. The caller owns the sink, which is deliberate:
+ * before the stdout redirect (daemon/serve mode) the terminal is reachable,
+ * after it (wrapper mode) the terminal belongs to Claude's TUI and the log file
+ * is the only honest destination. Both are already passed in as `logFn`.
+ */
+
+/** What is suppressing the advertisement, in the order the caller checks. */
+export type MdnsSuppression =
+  /** `--no-mdns` on the command line. */
+  | { readonly kind: 'cli-flag' }
+  /** `network.mdns = false` in config.toml. */
+  | { readonly kind: 'config' }
+  /** The daemon is bound to loopback, so there is nothing off-machine to find. */
+  | { readonly kind: 'loopback'; readonly bindHost: string };
+
+export interface MdnsAdvertiseInputs {
+  readonly cliNoMdns: boolean;
+  readonly configMdns: boolean;
+  readonly isLocalhostBind: boolean;
+  readonly bindHost: string;
+}
+
+/**
+ * Which condition suppresses advertising, or null when it should advertise.
+ *
+ * Order matches the caller's `||` chain exactly, and that matters: with both
+ * `--no-mdns` and a loopback bind in play, reporting the loopback would hand
+ * the user a remedy (`set daemon.bind`) that their own explicit flag would then
+ * override. Naming the most deliberate cause first is the only ordering that
+ * cannot produce advice which does not work.
+ */
+export function mdnsSuppression(inputs: MdnsAdvertiseInputs): MdnsSuppression | null {
+  if (inputs.cliNoMdns) return { kind: 'cli-flag' };
+  if (!inputs.configMdns) return { kind: 'config' };
+  if (inputs.isLocalhostBind) return { kind: 'loopback', bindHost: inputs.bindHost };
+  return null;
+}
+
+/**
+ * The line to log for a suppression.
+ *
+ * Deliberate suppressions state the fact and stop. The loopback case is the
+ * only one the user did not ask for — it arrived with a changed default — so it
+ * is the only one that names a remedy. #1051 is explicit that the other two
+ * must not nag: someone who passed `--no-mdns` does not need to be told how to
+ * undo it every boot.
+ */
+export function mdnsSuppressionMessage(suppression: MdnsSuppression): string {
+  switch (suppression.kind) {
+    case 'cli-flag':
+      return '[mDNS] Not advertising: --no-mdns was passed.';
+    case 'config':
+      return '[mDNS] Not advertising: network.mdns = false in ~/.remi/config.toml.';
+    case 'loopback':
+      return `[mDNS] Not advertising: bound to ${suppression.bindHost}, so there is nothing to discover off this machine (loopback is the default since #880). Set daemon.bind in ~/.remi/config.toml to advertise on your network — and set auth.enabled = true with it, because "auto" resolves to false on every bind.`;
+  }
+}

--- a/packages/daemon/src/mdns/index.ts
+++ b/packages/daemon/src/mdns/index.ts
@@ -1,4 +1,10 @@
 export { MDNS_SERVICE_TYPE } from './constants.ts';
+export {
+  mdnsSuppression,
+  mdnsSuppressionMessage,
+  type MdnsAdvertiseInputs,
+  type MdnsSuppression,
+} from './advertise-decision.ts';
 export { MdnsPublisher, type MdnsPublisherConfig } from './mdns-publisher.ts';
 export {
   discoverDaemons,

--- a/packages/daemon/tests/mdns/advertise-decision.test.ts
+++ b/packages/daemon/tests/mdns/advertise-decision.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #1051: a loopback bind stopped mDNS advertising with no log line at all.
+ *
+ * These test the DECISION, which is the part that can be tested — the caller is
+ * module-level startup code in cli.ts with no seam. What they cannot prove is
+ * that cli.ts calls it; that is pinned separately by asserting the bare
+ * `return null` is gone from the source.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  type MdnsAdvertiseInputs,
+  mdnsSuppression,
+  mdnsSuppressionMessage,
+} from '../../src/mdns/advertise-decision.ts';
+
+describe('cli.ts actually uses the decision', () => {
+  // Everything below tests a pure function. Without this, all of it would stay
+  // green if someone restored the bare `return null` in cli.ts -- a suite that
+  // passes while the bug is back is the ADR 0011 row-5 anti-pattern, and this
+  // file is defending a user-visible regression that shipped once already.
+  const cli = fs.readFileSync(path.join(import.meta.dir, '..', '..', 'src', 'cli.ts'), 'utf8');
+
+  test('the silent suppression return is gone', () => {
+    expect(cli).not.toContain('|| isLocalhostBind) return null;');
+  });
+
+  test('the suppression path logs the decision', () => {
+    expect(cli).toContain('mdnsSuppression(');
+    expect(cli).toContain('logFn(mdnsSuppressionMessage(');
+  });
+});
+
+/** Advertising: network bind, mDNS on, no flag. */
+const ADVERTISING: MdnsAdvertiseInputs = {
+  cliNoMdns: false,
+  configMdns: true,
+  isLocalhostBind: false,
+  bindHost: '0.0.0.0',
+};
+
+describe('mdnsSuppression', () => {
+  test('a network bind with mDNS enabled advertises', () => {
+    expect(mdnsSuppression(ADVERTISING)).toBeNull();
+  });
+
+  test('a loopback bind suppresses, carrying the host', () => {
+    // The case #880 made universal: every stock install takes this path now.
+    const s = mdnsSuppression({ ...ADVERTISING, isLocalhostBind: true, bindHost: '127.0.0.1' });
+    expect(s).toEqual({ kind: 'loopback', bindHost: '127.0.0.1' });
+  });
+
+  test('--no-mdns suppresses', () => {
+    expect(mdnsSuppression({ ...ADVERTISING, cliNoMdns: true })).toEqual({ kind: 'cli-flag' });
+  });
+
+  test('network.mdns = false suppresses', () => {
+    expect(mdnsSuppression({ ...ADVERTISING, configMdns: false })).toEqual({ kind: 'config' });
+  });
+
+  test('the CLI flag is reported ahead of a loopback bind', () => {
+    // Precedence is not cosmetic. Reporting 'loopback' here would tell the user
+    // to set daemon.bind -- advice their own --no-mdns would then override, so
+    // they would follow it and still see nothing.
+    const s = mdnsSuppression({ ...ADVERTISING, cliNoMdns: true, isLocalhostBind: true });
+    expect(s).toEqual({ kind: 'cli-flag' });
+  });
+
+  test('config is reported ahead of a loopback bind', () => {
+    const s = mdnsSuppression({ ...ADVERTISING, configMdns: false, isLocalhostBind: true });
+    expect(s).toEqual({ kind: 'config' });
+  });
+
+  test('the CLI flag outranks a config that also disables it', () => {
+    const s = mdnsSuppression({ ...ADVERTISING, cliNoMdns: true, configMdns: false });
+    expect(s).toEqual({ kind: 'cli-flag' });
+  });
+});
+
+describe('mdnsSuppressionMessage', () => {
+  test('the loopback message names the remedy AND the auth trap', () => {
+    const msg = mdnsSuppressionMessage({ kind: 'loopback', bindHost: '127.0.0.1' });
+    expect(msg).toContain('127.0.0.1');
+    expect(msg).toContain('daemon.bind');
+    // Naming bind alone would walk the user into the #880 exposure: "auto"
+    // resolves to false on every bind, so a widened bind with default auth is
+    // the unauthenticated LAN path 0.7.6 just closed.
+    expect(msg).toContain('auth.enabled');
+  });
+
+  test('deliberate suppressions state the fact without prescribing a remedy', () => {
+    // #1051 is explicit that these must not nag: someone who passed --no-mdns
+    // does not need to be told how to undo it on every boot.
+    for (const s of [{ kind: 'cli-flag' } as const, { kind: 'config' } as const]) {
+      const msg = mdnsSuppressionMessage(s);
+      expect(msg).toContain('Not advertising');
+      expect(msg).not.toContain('daemon.bind');
+      expect(msg).not.toContain('auth.enabled');
+    }
+  });
+
+  test('every suppression produces a non-empty [mDNS] line', () => {
+    // The whole point of #1051: no suppression path may be silent. A new kind
+    // added without a message would fail here rather than reintroduce the bug.
+    const all = [
+      { kind: 'cli-flag' } as const,
+      { kind: 'config' } as const,
+      { kind: 'loopback', bindHost: '127.0.0.1' } as const,
+    ];
+    for (const s of all) {
+      const msg = mdnsSuppressionMessage(s);
+      expect(msg.startsWith('[mDNS]')).toBe(true);
+      expect(msg.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('each suppression says something DIFFERENT', () => {
+    // Three conditions behind one message would be the same defect in a new
+    // costume: the user still could not tell which one fired.
+    const msgs = [
+      mdnsSuppressionMessage({ kind: 'cli-flag' }),
+      mdnsSuppressionMessage({ kind: 'config' }),
+      mdnsSuppressionMessage({ kind: 'loopback', bindHost: '127.0.0.1' }),
+    ];
+    expect(new Set(msgs).size).toBe(3);
+  });
+});

--- a/packages/web/src/lib/port-discovery.ts
+++ b/packages/web/src/lib/port-discovery.ts
@@ -31,7 +31,7 @@ export const DEFAULT_PORT_RANGE = DAEMON_PORT_RANGE;
  *
  * Budget: a healthy LAN daemon answers `/auth-info` in single-digit ms; an
  * unreachable host returns ECONNREFUSED in microseconds. The interesting
- * case is a host that ACCEPTs the TCP connection but never responds (broken
+ * case is a host that ACCEPTS the TCP connection but never responds (broken
  * proxy, half-dead daemon). 1500 ms gives enough slack for slow VPN paths
  * while keeping the worst-case scan under ~2 s before the modal surfaces an
  * error.


### PR DESCRIPTION
Closes #1051. The 0.7.6 follow-up we deferred when shipping #880.

## The defect

`startMdnsIfNeeded` collapsed three suppression conditions into one bare
`return null`:

```ts
if (cliNoMdns || !remiConfig.network.mdns || isLocalhostBind) return null;
```

Every OTHER exit from that function logged — `Advertising on local network`,
`Failed to start: ...`. Only the suppression path was silent.

Before #880 that was nearly harmless, because `isLocalhostBind` was false on a
stock install. **Since the bind default moved to loopback it is the path every
stock install takes.** And mDNS does not refuse a discovery attempt — it stops
answering, so from the phone's side the daemon does not error, it *vanishes*.
The user's reading is "Remi is broken" or "my network is broken", and nothing in
the daemon's own output contradicts that.

The #880 boot warning does not cover this population either: it fires
`if (!isLocalhostBind)`, i.e. exactly the users who still HAVE discovery.

## The fix

Each condition now says which one fired. Only the loopback case names a
remedy — it is the one the user did not ask for, since it arrived with a
changed default. `--no-mdns` and `network.mdns = false` state the fact and stop;
#1051 is explicit that they must not nag.

The loopback message names `auth.enabled` alongside `daemon.bind`, because
telling someone to widen the bind while `auth.enabled` stays `"auto"` (which
resolves to **false** on every bind) walks them straight back into the #880
exposure this release just closed.

## Two things I checked rather than assumed

**The sink.** Per #1043 the obvious mistake here is picking a sink that is dead
at that point in startup. Both call sites already pass a working one, and they
differ for a real reason: `cli.ts:2600` runs BEFORE `process.stdout.write` is
redirected (line ~2858), so console reaches the terminal; `cli.ts:2918` runs
after, where the terminal belongs to Claude's TUI and the log file is the only
honest destination. Using the caller's `logFn` — the same sink the success line
uses — is correct at both without inventing a third rule.

**Precedence.** The order matches the original `||` chain, and that is
load-bearing: with both `--no-mdns` and a loopback bind in play, reporting the
loopback would hand the user a remedy (`set daemon.bind`) their own flag would
then override, so they would follow the advice and still see nothing. Pinned by
a test.

## Verification

The decision is extracted to `mdns/advertise-decision.ts` as a pure function
precisely so it can be tested — the caller is module-level startup code with no
seam. 13 tests, mutation-verified:

| mutation | result |
|---|---|
| loopback checked before the CLI flag | 2 red |
| loopback message drops the `auth.enabled` warning | 1 red |
| all three conditions share one message | 1 red |
| **cli.ts reverts to the bare silent `return null`** | **1 red** |

That last row is the one that matters. Every other test here exercises a pure
function and would stay green if someone restored the silent return — a suite
that passes while the bug is back is the ADR 0011 row-5 anti-pattern, in a file
defending a regression that shipped once already. So a source-level pin asserts
`cli.ts` actually wires the decision. There is existing precedent for that shape
(`question-store-single-owner.test.ts`, `process-guards.test.ts`).

Full suite: 6129 pass, 1 skip, 3 fail — the 3 are the known pre-existing
`discoverDaemons` mDNS timeouts, unchanged by this branch and green on CI.
`biome check .`, all four typecheck targets, `typos`: clean.

## Also here, called out rather than folded in silently

`ACCEPTs` in `packages/web/src/lib/port-discovery.ts` is flagged by `typos`
>=1.49 but not by CI's pinned 1.28.4, so the repo was one dependency bump away
from a red gate on a code comment. One word, unrelated to the above.
