### PR TITLE
Cut the escalation volume: agent-scoped permissions, net-read, matcher gaps, cancel-on-answer

### DIFF
--- a/.context/decisions/0025-agent-scoped-permissions.md
+++ b/.context/decisions/0025-agent-scoped-permissions.md
@@ -7,7 +7,7 @@
 ## Context
 
 A live 0.7.6 session on the owner's machine escalated a burst of subagent
-permissions without the LLM ever running. Traced from `~/.remi/remi.log`, the
+permissions without the LLM ever running. Traced from `~/.remi/daemon.log`, the
 mechanism was not the one the daemon's own docs would suggest:
 
 - The #1024 hook-time deterministic path worked exactly as designed
@@ -38,7 +38,11 @@ Two things are wrong here, and they are separable.
 reaching for a bare tool-name `allow` to get them.
 
 It is **not** in `strict`, `balanced`, or `trusted`, and not in
-`DEFAULT_CONFIG.approve_groups`. Every shipped preset stays entirely local.
+`DEFAULT_CONFIG.approve_groups`. No shipped preset grants **arbitrary-URL
+egress** — stated that way because "the presets are entirely local" would be
+false: `vcs-read` carries fifteen `gh` subcommands that call api.github.com and
+`build-test` has `uv run pytest`, which resolves from PyPI. The line `net-read`
+crosses is not network-vs-local, it is *whose choice the destination is*.
 
 Adding it to `trusted` was considered and rejected. `trusted` is selected for
 git mutation and proved-derived deletion; someone who chose it for those reasons
@@ -105,11 +109,14 @@ it to nobody.
   unchanged here.
 - `deny` remains substring-matched and `approve_groups` whole-command-matched
   (ADR 0010); per-agent scoping inherits both behaviours unchanged.
-- Agent *names* are not validated against anything. There is no registry of
-  agent types to check against, so a typo in `[auto_approve.agents.Explor]`
-  silently never matches. The daemon logs the agent types it has actually seen
-  resolve a policy, which is the only honest mitigation available without
-  inventing a registry.
+- Agent *names* are not validated against anything, and **a typo in a section
+  name is currently undetectable**. There is no registry of agent types to
+  check against, so `[auto_approve.agents.Explor]` silently never matches and
+  NOTHING reports it — not at load, not at evaluation. An earlier draft of this
+  ADR claimed "the daemon logs the agent types it has actually seen resolve a
+  policy"; it does not, and shipping that sentence would have been the ADR 0011
+  failure inside the ADR itself. Group names inside a section ARE validated
+  (they have a registry), which is the half that was closeable.
 
 ## Verification obligation
 

--- a/.context/decisions/0025-agent-scoped-permissions.md
+++ b/.context/decisions/0025-agent-scoped-permissions.md
@@ -1,0 +1,118 @@
+# ADR 0025: Permissions may be scoped per agent type; network egress is never a default
+
+**Status:** accepted
+**Date:** 2026-08-11
+**Owner:** Seyed Yahya Shirazi
+
+## Context
+
+A live 0.7.6 session on the owner's machine escalated a burst of subagent
+permissions without the LLM ever running. Traced from `~/.remi/remi.log`, the
+mechanism was not the one the daemon's own docs would suggest:
+
+- The #1024 hook-time deterministic path worked exactly as designed
+  (`approve-matched group: "read-only:grep"`, `ls`, `cat`, `sed -n`).
+- `WebFetch` and `WebSearch` matched **nothing**. No group lists them —
+  `read-only` is `['Read','Glob','Grep','NotebookRead']` plus shell commands.
+- So every web call from every subagent parked, rendered, and entered the
+  **serial** eval queue.
+- Under a fan-out of five concurrent `general-purpose` agents the queue
+  saturated, and waiters escalated on `queue_timeout` (default 240s) — the
+  `eval queue wait exceeded` branch, which returns before any LLM call.
+
+So the most common operation a research subagent performs took the most
+expensive path available, and under load degraded to "escalate everything"
+while looking like the LLM was broken.
+
+The available workaround was `allow = ["WebFetch", "WebSearch"]` — a bare
+tool-name entry, which ADR 0010 and #1032 both record as the blunt instrument:
+it carries no destination veto at all.
+
+Two things are wrong here, and they are separable.
+
+## Decision
+
+### 1. A `net-read` group exists, and is in no level preset
+
+`net-read` covers `WebFetch` and `WebSearch` as a real group, so users stop
+reaching for a bare tool-name `allow` to get them.
+
+It is **not** in `strict`, `balanced`, or `trusted`, and not in
+`DEFAULT_CONFIG.approve_groups`. Every shipped preset stays entirely local.
+
+Adding it to `trusted` was considered and rejected. `trusted` is selected for
+git mutation and proved-derived deletion; someone who chose it for those reasons
+would silently acquire arbitrary outbound network egress on upgrade. That is
+precisely the failure ADR 0023 fixed in `matchGroups` — a group union quietly
+widening an axis nobody opted into — and repeating it in the level presets a
+release later would be indefensible.
+
+The asymmetry is deliberate and worth stating plainly: **a wrongly-escalated
+web fetch is a nuisance; a wrongly-approved one is an exfiltration channel.**
+`WebFetch` takes an arbitrary URL, subagents are exactly the context no human is
+watching, and a prompt-injected subagent needs only a URL with a query string.
+Opting in is one line; opting out of a default you never noticed is not.
+
+### 2. Permissions may be scoped by `agent_type`
+
+```toml
+[auto_approve.agents.Explore]
+approve_groups = ["read-only", "vcs-read", "net-read"]
+
+[auto_approve.agents.pr-review]
+approve_groups = ["read-only", "vcs-read"]
+allow = ["gh pr view", "gh pr diff"]
+```
+
+`agent_type` is already on the `PermissionRequest` hook input, already logged at
+the decision points, and already used by `precedent.ts` for operation identity.
+Nothing new is trusted: it is Claude Code's own value, the same provenance as
+`agent_id`, which the subagent policy has keyed on since #756.
+
+**Merge semantics, chosen so the safe direction is the monotone one:**
+
+| key | agent section present |
+|---|---|
+| `deny` | **union** with base |
+| `deny_groups` | **union** with base |
+| `allow` | **replaces** base |
+| `approve_groups` | **replaces** base |
+
+Deny unions because a per-agent rule must never be able to *weaken* a
+machine-wide prohibition — an agent section is a place to say "this role is
+narrower", and a reader must be able to trust that adding one cannot remove a
+deny. Allow and approve_groups replace because the entire point is per-role
+scoping: if they merged additively, an agent section could only ever widen, and
+"give the pr-review agent LESS than the base" would be inexpressible — which is
+the case that motivated the feature.
+
+Replacement can widen, when the user writes a wider list. That is their choice,
+made explicitly, and it is visible in one table in one file.
+
+## Consequences
+
+**A per-agent section is the only way to grant `net-read` to just the agents
+that need it.** That is the intended shape: `Explore` and research agents get
+network reads, a `pr-review` agent does not, and the machine-wide default grants
+it to nobody.
+
+**Not closed by this ADR:**
+
+- The serial eval queue itself. Moving web calls to the deterministic layer
+  relieves the measured saturation but does not bound it; a large enough
+  fan-out of genuinely-unmatched operations still queues and still escalates on
+  timeout. The queue is serial to protect the GPU and that trade-off is
+  unchanged here.
+- `deny` remains substring-matched and `approve_groups` whole-command-matched
+  (ADR 0010); per-agent scoping inherits both behaviours unchanged.
+- Agent *names* are not validated against anything. There is no registry of
+  agent types to check against, so a typo in `[auto_approve.agents.Explor]`
+  silently never matches. The daemon logs the agent types it has actually seen
+  resolve a policy, which is the only honest mitigation available without
+  inventing a registry.
+
+## Verification obligation
+
+Per ADR 0011, the claim "a per-agent section cannot weaken a deny" is a security
+claim and must be pinned by a test that fails when the union is changed to a
+replacement — not merely by this document asserting it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,22 @@ amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-
   sensitive destinations a curated `approve_groups` write group would block. Already true for
   main-context requests; #1024 is the first time it applies with zero chance of a human ever
   seeing the prompt. Tracked as #1032 (not yet decided).
+- **Permissions can be scoped per `agent_type`**
+  ([ADR 0025](.context/decisions/0025-agent-scoped-permissions.md)). Because the deterministic
+  layers are the ONLY ones a subagent reaches at hook time, they are also the only place a
+  per-role grant can live: `[auto_approve.agents.Explore]` with
+  `approve_groups = [..., "net-read"]` lets research agents read the web while nothing else
+  does. `deny`/`deny_groups` UNION with the base (a section can never weaken a machine-wide
+  prohibition — pinned by test); `allow`/`approve_groups` REPLACE it (the motivating case is
+  giving a role LESS). An unmatched agent type falls through to the base, so a typo in a
+  section name silently does nothing — there is no registry to validate against.
+- **`net-read` (WebFetch + WebSearch) is in no preset and no default.** It exists because
+  those tools previously matched *nothing*, so every web call from every subagent parked,
+  rendered and entered the serial eval queue; a measured fan-out of five `general-purpose`
+  agents saturated it and the waiters escalated on `queue_timeout` **without the LLM ever
+  running**. Not added to `trusted`: that level is chosen for git mutation, and quietly
+  attaching outbound egress to it is the same widening ADR 0023 fixed in `matchGroups`.
+  A wrongly-escalated fetch is a nuisance; a wrongly-approved one is an exfil channel.
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,26 +60,13 @@ All notable changes to Remi are documented here.
 [ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
-- **A leading variable assignment sank otherwise-covered reads.**
-  `matchCoveredCommand` requires every compound segment covered, and `S=/tmp/x`
-  matched neither a neutral prefix nor a read prefix — so
-  `SCRIPTS_DIR="…"; ls "$SCRIPTS_DIR"; cat "$SCRIPTS_DIR/x.py" | head -100`
-  matched nothing and cost an 8-second LLM eval despite being pure `ls`/`cat`.
-  Agents habitually open a script by assigning a path, which is why
-  agent-written commands escalated so reliably. A segment is now inert when it
-  is **entirely** assignments — and that is the whole safety argument, because
-  an assignment *prefix* is not inert: `PATH=/evil ls` runs `ls` and chooses
-  which one. Command substitution needs no handling here, since
-  `hasShellControl` rejects `$(…)` and backticks first; that ordering is
-  load-bearing and pinned by a test.
 - **`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du` and `df` join
   `read-only`.** None opens a file for writing or takes an output-path flag,
   and `which` resolves a PATH entry rather than running it. `mdutil` — the
   mutating Spotlight sibling — is deliberately absent and pinned as such.
-- **Answering a permission on the terminal now cancels its eval.**
-  `onHooklessQuestionGone` is the only evidence remi gets that a prompt was
-  answered directly in the terminal: no hook fires, the render just disappears.
-  It cleared the card and released the hold but never cancelled the evaluation,
+- **A superseded prompt now cancels its eval.** When
+  `onHooklessQuestionGone` fires, it cleared the card and released the hold but
+  never cancelled the evaluation,
   so a queued waiter kept its place in the **serial** eval lane to decide a
   question a human had already answered — then pushed a card for it. Measured
   on a live 0.7.6 session where evals cost 7–10s each, every such survivor
@@ -87,6 +74,12 @@ All notable changes to Remi are documented here.
   exactly `240001ms` having never reached the model. `cancelEvalForQuestion`
   already handled both the running eval and splicing a queued waiter; it simply
   was not wired to this path.
+  **Scope, stated so it does not read as more than it is:** that callback has
+  exactly one trigger — a confirmed replacement render from the SAME agent
+  (`adoptRenderOwnedQuestion`). A prompt answered in the terminal with no
+  follow-up prompt rendering does NOT fire it, and still burns the full
+  `queue_timeout`. Covering that case needs a second trigger and is not in this
+  release.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Added
+- **Permissions can be scoped per agent type** ([ADR 0025]). A
+  `[auto_approve.agents.<type>]` section keyed by the hook's `agent_type` lets
+  one role get what another does not:
+  ```toml
+  [auto_approve.agents.Explore]
+  approve_groups = ["read-only", "vcs-read", "net-read"]
+
+  [auto_approve.agents.pr-review]
+  approve_groups = ["read-only", "vcs-read"]
+  allow = ["gh pr view", "gh pr diff"]
+  ```
+  The deterministic layers are the **only** ones a subagent reaches at hook time
+  (the LLM never runs there — [ADR 0004]), so they are also the only place a
+  per-role grant can live. `deny`/`deny_groups` **union** with the base, so a
+  section can never weaken a machine-wide prohibition; `allow`/`approve_groups`
+  **replace** it, because the motivating case is giving a role *less*. An
+  unmatched agent type falls through to the base, which also means a typo in a
+  section name silently does nothing — there is no registry of agent types to
+  validate against, and ADR 0025 records that rather than pretending otherwise.
+- **A `net-read` group** (`WebFetch`, `WebSearch`), in **no** preset and no
+  default. It exists because those tools previously matched *nothing*: every web
+  call from every subagent parked, rendered, and entered the serial eval queue.
+  Measured on a live 0.7.6 session, a fan-out of five concurrent
+  `general-purpose` agents saturated that queue and the waiters escalated on
+  `queue_timeout` **without the LLM ever running** — so the most common thing a
+  research subagent does took the most expensive path available, and under load
+  degraded to "escalate everything" while looking like the model was broken.
+  Deliberately not added to `trusted`: that level is chosen for git mutation and
+  proved-derived deletion, and silently attaching outbound egress to it on
+  upgrade is the same quiet widening ADR 0023 fixed in `matchGroups` one release
+  earlier. A wrongly-escalated fetch is a nuisance; a wrongly-approved one is an
+  exfiltration channel.
 - **remi supervises `llama-server` on Linux** (#822). Auto-approve's local
   backend no longer has to be started by hand: remi spawns it on demand,
   health-probes it, and stops what it started — the same `EngineHost` the macOS
@@ -23,6 +55,9 @@ All notable changes to Remi are documented here.
   The GGUF is not remi's job either — `-hf` pulls it — which narrows what #822
   assumed ("Download is remi's job"). Still open there: acquiring the binary,
   idle-stop, and the `escalate_model` design question.
+
+[ADR 0004]: .context/decisions/0004-pty-as-arbiter-subagent-questions.md
+[ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
 - **The `escalate_model` warning could be silenced for the users it was for**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,10 @@ All notable changes to Remi are documented here.
   stays at `"auto"` (which resolves to `false`) walks straight back into the
   #880 exposure.
 - **A `typos` false positive that a version bump would have turned into a CI
-  failure.** `ACCEPTs` in `port-discovery.ts` is flagged by typos ≥1.49 but not
-  by the pinned 1.28.4, so the repo was one dependency bump away from a red
-  gate on a comment. Unrelated to the above; called out rather than folded in
+  failure.** A mixed-case word in a `port-discovery.ts` comment is flagged by
+  typos >=1.49 but not by the pinned 1.28.4, so the repo was one dependency
+  bump away from a red gate on a comment. (Spelled around here deliberately:
+  quoting the word verbatim would reintroduce the very hit this describes.) Unrelated to the above; called out rather than folded in
   silently.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,33 @@ All notable changes to Remi are documented here.
 [ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
+- **A leading variable assignment sank otherwise-covered reads.**
+  `matchCoveredCommand` requires every compound segment covered, and `S=/tmp/x`
+  matched neither a neutral prefix nor a read prefix — so
+  `SCRIPTS_DIR="…"; ls "$SCRIPTS_DIR"; cat "$SCRIPTS_DIR/x.py" | head -100`
+  matched nothing and cost an 8-second LLM eval despite being pure `ls`/`cat`.
+  Agents habitually open a script by assigning a path, which is why
+  agent-written commands escalated so reliably. A segment is now inert when it
+  is **entirely** assignments — and that is the whole safety argument, because
+  an assignment *prefix* is not inert: `PATH=/evil ls` runs `ls` and chooses
+  which one. Command substitution needs no handling here, since
+  `hasShellControl` rejects `$(…)` and backticks first; that ordering is
+  load-bearing and pinned by a test.
+- **`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du` and `df` join
+  `read-only`.** None opens a file for writing or takes an output-path flag,
+  and `which` resolves a PATH entry rather than running it. `mdutil` — the
+  mutating Spotlight sibling — is deliberately absent and pinned as such.
+- **Answering a permission on the terminal now cancels its eval.**
+  `onHooklessQuestionGone` is the only evidence remi gets that a prompt was
+  answered directly in the terminal: no hook fires, the render just disappears.
+  It cleared the card and released the hold but never cancelled the evaluation,
+  so a queued waiter kept its place in the **serial** eval lane to decide a
+  question a human had already answered — then pushed a card for it. Measured
+  on a live 0.7.6 session where evals cost 7–10s each, every such survivor
+  delayed every real question behind it, and `WebFetch`/`WebSearch` escalated at
+  exactly `240001ms` having never reached the model. `cancelEvalForQuestion`
+  already handled both the running eval and splicing a queued waiter; it simply
+  was not wired to this path.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/packages/daemon/src/auto-approve/agent-policy.ts
+++ b/packages/daemon/src/auto-approve/agent-policy.ts
@@ -1,0 +1,121 @@
+/**
+ * Per-agent-type policy resolution (ADR 0025).
+ *
+ * `AutoApproveService` holds ONE base policy but serves every agent in the
+ * session. This resolves "what policy applies to THIS request" from the base
+ * plus an optional `[auto_approve.agents.<type>]` section.
+ *
+ * Pure and separate from the service for the usual reason this repo keeps
+ * doing it: the merge asymmetry below is a security contract, and a contract
+ * that can only be tested by standing up a whole service is a contract that
+ * gets tested loosely.
+ */
+
+import type { AgentPolicyOverride } from './types.ts';
+
+/** The four deterministic lists, resolved for one request. */
+export interface ResolvedPolicy {
+  readonly allow: readonly string[];
+  readonly deny: readonly string[];
+  readonly approveGroups: readonly string[];
+  readonly denyGroups: readonly string[];
+}
+
+/**
+ * Resolve the policy for `agentType`.
+ *
+ * `agentType` is undefined for a main-context request, and for any subagent
+ * whose hook did not carry one — both correctly fall through to the base.
+ * An agent type with no section also falls through, which is why a TYPO in a
+ * section name silently does nothing (ADR 0025 records this: there is no
+ * registry of agent types to validate against).
+ *
+ * THE ASYMMETRY IS THE POINT:
+ *
+ * - deny / deny_groups UNION. A per-agent section must never weaken a
+ *   machine-wide prohibition. Adding a section can only ever add denies, so a
+ *   reader can trust that `deny` in the base holds for every agent no matter
+ *   what any section says.
+ * - allow / approve_groups REPLACE when present. Per-role scoping is the whole
+ *   feature; merging additively would make a section able only to widen, and
+ *   the motivating case is "give this role LESS".
+ *
+ * `present` means the key exists, not that it is non-empty: `allow = []` in a
+ * section is a deliberate "this agent gets no allow patterns", and treating it
+ * as absent would silently restore the base's — turning an explicit narrowing
+ * into a widening, which is the one direction this must never fail.
+ */
+export function resolvePolicy(
+  base: ResolvedPolicy,
+  agents: Readonly<Record<string, AgentPolicyOverride>>,
+  agentType: string | undefined,
+): ResolvedPolicy {
+  if (agentType === undefined || agentType.length === 0) return base;
+  const override = agents[agentType];
+  if (override === undefined) return base;
+  return {
+    allow: override.allow ?? base.allow,
+    approveGroups: override.approve_groups ?? base.approveGroups,
+    deny: union(base.deny, override.deny),
+    denyGroups: union(base.denyGroups, override.deny_groups),
+  };
+}
+
+/** Order-preserving union. Base entries keep their positions so a deny's
+ *  reported pattern does not shuffle depending on which agent asked. */
+function union(base: readonly string[], extra: readonly string[] | undefined): readonly string[] {
+  if (extra === undefined || extra.length === 0) return base;
+  const seen = new Set(base);
+  const merged = [...base];
+  for (const e of extra) {
+    if (!seen.has(e)) {
+      seen.add(e);
+      merged.push(e);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Validate the `agents` table shape, throwing with an actionable message.
+ *
+ * Mirrors `validateAutoApprove`'s style: a malformed policy table must fail
+ * loudly at load rather than silently resolve to "no overrides", which would
+ * present as the agent quietly running under the base policy — the exact
+ * class of silent-degradation this epic keeps producing.
+ */
+export function validateAgents(value: unknown, configPath: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Invalid auto_approve.agents in ${configPath}: must be a table keyed by agent type. Example:\n  [auto_approve.agents.Explore]\n  approve_groups = ["read-only", "net-read"]`,
+    );
+  }
+  for (const [agentType, section] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof section !== 'object' || section === null || Array.isArray(section)) {
+      throw new Error(
+        `Invalid auto_approve.agents.${agentType} in ${configPath}: must be a table. Example:\n  [auto_approve.agents.${agentType}]\n  approve_groups = ["read-only", "net-read"]`,
+      );
+    }
+    for (const key of ['allow', 'deny', 'approve_groups', 'deny_groups'] as const) {
+      const v = (section as Record<string, unknown>)[key];
+      if (v === undefined) continue;
+      if (!Array.isArray(v) || v.some((e) => typeof e !== 'string')) {
+        throw new Error(
+          `Invalid auto_approve.agents.${agentType}.${key} in ${configPath}: must be an array of strings, got ${JSON.stringify(v)}.`,
+        );
+      }
+    }
+    for (const key of Object.keys(section as Record<string, unknown>)) {
+      if (!['allow', 'deny', 'approve_groups', 'deny_groups'].includes(key)) {
+        // Loud, not ignored. A misspelled `approve_group` would otherwise leave
+        // the agent on the base policy while the config file plainly appears to
+        // grant something -- a doc/behaviour mismatch of exactly the kind
+        // ADR 0011 exists to stop shipping.
+        throw new Error(
+          `Unknown key auto_approve.agents.${agentType}.${key} in ${configPath}. Valid keys: allow, deny, approve_groups, deny_groups.`,
+        );
+      }
+    }
+  }
+}

--- a/packages/daemon/src/auto-approve/agent-policy.ts
+++ b/packages/daemon/src/auto-approve/agent-policy.ts
@@ -11,6 +11,7 @@
  * gets tested loosely.
  */
 
+import { isKnownGroup, knownGroupNames } from './permission-groups.ts';
 import type { AgentPolicyOverride } from './types.ts';
 
 /** The four deterministic lists, resolved for one request. */
@@ -104,6 +105,29 @@ export function validateAgents(value: unknown, configPath: string): void {
         throw new Error(
           `Invalid auto_approve.agents.${agentType}.${key} in ${configPath}: must be an array of strings, got ${JSON.stringify(v)}.`,
         );
+      }
+    }
+    // Group NAMES are checkable and must be checked, unlike agent names (no
+    // registry exists for those -- ADR 0025 records that). Skipping this was
+    // worse than a no-op: because `approve_groups` REPLACES, a typo does not
+    // merely fail to grant the group, it drops the agent's inherited base
+    // grants too. `approve_groups = ["net-reed"]` silently leaves that agent
+    // with less than the base, and the user-visible result is the 240s queue
+    // stall this feature exists to remove. The base path already warns for the
+    // same typo one section up, so the asymmetry was indefensible.
+    //
+    // WARN, not throw, matching the base. A throw reaches `cli.ts`'s exit(1),
+    // and under the `--install` LaunchAgent (`KeepAlive.SuccessfulExit=false`)
+    // that is a crash-restart loop over a one-character typo.
+    for (const key of ['approve_groups', 'deny_groups'] as const) {
+      const groups = (section as Record<string, unknown>)[key];
+      if (!Array.isArray(groups)) continue;
+      for (const g of groups) {
+        if (typeof g === 'string' && !isKnownGroup(g)) {
+          console.warn(
+            `[AutoApprove] Warning: unknown permission group "${g}" in auto_approve.agents.${agentType}.${key} (${configPath}); ignored. Known groups: ${knownGroupNames().join(', ')}.`,
+          );
+        }
       }
     }
     for (const key of Object.keys(section as Record<string, unknown>)) {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -273,6 +273,10 @@ export interface AutoApproveEvaluator {
      *  `AutoApproveGateDeps.getPrecedent`; the matrix that bounds what a
      *  precedent may authorize lives inside the evaluator, not here. */
     precedent?: PrecedentReader,
+    /** ADR 0025: the hook's `agent_type`, selecting a
+     *  `[auto_approve.agents.<type>]` section for the deterministic layers.
+     *  Undefined = base policy, so every pre-0025 caller is unchanged. */
+    agentType?: string,
   ): Promise<AutoApproveResult>;
   /**
    * Abort an in-flight `evaluate`. With `evalId`, aborts ONLY when that id is the
@@ -312,6 +316,11 @@ export interface AutoApproveEvaluator {
   evaluateDeterministic?(
     toolName: string,
     toolInput: Record<string, unknown>,
+    /** ADR 0025: selects this agent's `[auto_approve.agents.<type>]` section.
+     *  This is the only layer a subagent reaches at hook time, so a per-agent
+     *  grant that did not arrive here would be unreachable for exactly the
+     *  requests it was written for. */
+    agentType?: string,
   ):
     | { decision: 'approve'; reasoning: string }
     | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
@@ -1432,7 +1441,15 @@ export class AutoApproveGate {
     // included) and answers it by PTY inject, or pushes a card the phone can
     // answer. That is the async route this hook response could never take.
     if (isSubagent) {
-      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      // ADR 0025: the agent's own section decides here. This is the ONLY layer
+      // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
+      // without this a per-agent grant would be unreachable for exactly the
+      // requests it was written for.
+      const deterministic = service?.evaluateDeterministic?.(
+        input.tool_name,
+        input.tool_input,
+        input.agent_type,
+      );
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
@@ -2068,6 +2085,10 @@ export class AutoApproveGate {
         true,
         this.authorityForEval(),
         this.precedentForEval(),
+        // ADR 0025: the same agent section that governs the hook-time path must
+        // govern the render-time one, or a parked request would be judged under
+        // a different policy than the one that declined to approve it.
+        input.agent_type,
       );
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Parked-render eval threw; escalating:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1445,7 +1445,11 @@ export class AutoApproveGate {
       // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
       // without this a per-agent grant would be unreachable for exactly the
       // requests it was written for.
-      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      const deterministic = service?.evaluateDeterministic?.(
+        input.tool_name,
+        input.tool_input,
+        input.agent_type,
+      );
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
@@ -2265,6 +2269,12 @@ export class AutoApproveGate {
     isSubagent: boolean,
     evalId?: number,
   ): Promise<AutoApproveResult | null> {
+    // ADR 0025: the second opinion re-runs `evaluateDeterministic`, so it needs
+    // the SAME agent policy the first eval used. Omitting it resolved to the
+    // BASE policy and silently undid a per-agent narrowing: a `pr-review`
+    // section restricting `approve_groups` is escalated by the first eval, then
+    // deterministically approved at 0ms by this one under the base groups --
+    // and logged as if the heavy model had agreed.
     const escalateModel = this.deps.escalateModel;
     const service = this.deps.service;
     if (!escalateModel || service === null) return null;
@@ -2280,6 +2290,7 @@ export class AutoApproveGate {
         isSubagent,
         this.authorityForEval(),
         this.precedentForEval(),
+        input.agent_type,
       );
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalate_model second opinion threw:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1445,11 +1445,7 @@ export class AutoApproveGate {
       // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
       // without this a per-agent grant would be unreachable for exactly the
       // requests it was written for.
-      const deterministic = service?.evaluateDeterministic?.(
-        input.tool_name,
-        input.tool_input,
-        input.agent_type,
-      );
+      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -10,6 +10,7 @@
  */
 
 import { errorToString } from '@remi/shared';
+import { resolvePolicy } from './agent-policy.ts';
 import { reconcileCounterfactual, shouldCounterfactual } from './authority-counterfactual.ts';
 import { enforceAuthorityBoundary } from './authority.ts';
 import { AuthorizationAssessment, matrixDecision } from './authorization-assessment.ts';
@@ -144,6 +145,8 @@ export class AutoApproveService {
   private readonly deny: readonly string[];
   private readonly approveGroups: readonly string[];
   private readonly denyGroups: readonly string[];
+  /** Per-agent-type overrides (ADR 0025). Empty = every agent uses the base. */
+  private readonly agents: Readonly<Record<string, import('./types.ts').AgentPolicyOverride>>;
   private readonly instructions: string;
   /** Strictness preset, threaded into the prompt's default guidelines (#966). */
   private readonly level: AutoApproveLevel;
@@ -266,6 +269,7 @@ export class AutoApproveService {
     this.deny = config.deny;
     this.approveGroups = config.approve_groups;
     this.denyGroups = config.deny_groups;
+    this.agents = config.agents ?? {};
     this.instructions = config.instructions;
     // #966: the LLM handles whatever no group covers, so its DEFAULT
     // GUIDELINES must agree with the level the user chose. Without this the
@@ -666,11 +670,24 @@ export class AutoApproveService {
   evaluateDeterministic(
     toolName: string,
     toolInput: Record<string, unknown>,
+    agentType?: string,
   ):
     | { decision: 'approve'; reasoning: string }
     | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
     | null {
-    const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
+    // ADR 0025. Undefined agentType (main context, or a hook without one)
+    // resolves to the base, so every pre-0025 caller is unchanged.
+    const policy = resolvePolicy(
+      {
+        allow: this.allow,
+        deny: this.deny,
+        approveGroups: this.approveGroups,
+        denyGroups: this.denyGroups,
+      },
+      this.agents,
+      agentType,
+    );
+    const denyMatch = matchSubstringPattern(toolName, toolInput, policy.deny);
     if (denyMatch !== null) {
       return {
         decision: 'deny-covered',
@@ -682,7 +699,7 @@ export class AutoApproveService {
     // command to be covered and is right for the allow question below; asking
     // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
     // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
-    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
+    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, policy.denyGroups);
     if (denyGroupMatch !== null) {
       return {
         decision: 'deny-covered',
@@ -690,11 +707,11 @@ export class AutoApproveService {
         denySource: { kind: 'config', pattern: denyGroupMatch },
       };
     }
-    const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
+    const allowMatch = matchAllowPattern(toolName, toolInput, policy.allow);
     if (allowMatch !== null) {
       return { decision: 'approve', reasoning: `allow-matched pattern: "${allowMatch}"` };
     }
-    const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
+    const approveGroupMatch = matchGroups(toolName, toolInput, policy.approveGroups);
     if (approveGroupMatch !== null) {
       return { decision: 'approve', reasoning: `approve-matched group: "${approveGroupMatch}"` };
     }
@@ -757,6 +774,13 @@ export class AutoApproveService {
      * omits it behaves exactly as it did pre-#976.
      */
     precedent?: PrecedentReader,
+    /**
+     * The hook's `agent_type` (ADR 0025). Selects a
+     * `[auto_approve.agents.<type>]` section for the deterministic layers.
+     * Undefined = main context, or a subagent hook that carried none; both
+     * resolve to the base policy, so every pre-0025 caller is unchanged.
+     */
+    agentType?: string,
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     // #820: push the idle-unload deadline out. Called at the START so a long
@@ -790,7 +814,7 @@ export class AutoApproveService {
       // Deny/allow/group: checked first, always win, no LLM call. Shared with
       // the gate's subagent hook-time path (#1024) via `evaluateDeterministic`
       // so the two can never drift apart -- see that method's doc.
-      const deterministic = this.evaluateDeterministic(toolName, toolInput);
+      const deterministic = this.evaluateDeterministic(toolName, toolInput, agentType);
       if (deterministic !== null) {
         if (deterministic.decision === 'deny-covered') {
           this.logFn(`${prefix} DENIED ${toolName}: ${deterministic.reasoning} (0ms)`);

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -860,6 +860,19 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'uniq',
       'jq',
       'ls',
+      // Pure lookups and string operations, added after a live session showed
+      // them sinking otherwise-covered compound reads. None opens a file for
+      // writing, none takes an output-path flag, and none executes what it
+      // finds -- `which` resolves a PATH entry, it does not run it.
+      'which',
+      'basename',
+      'dirname',
+      'realpath',
+      // macOS Spotlight query. Read-only by construction (`mdutil` is the
+      // mutating sibling and is deliberately absent).
+      'mdfind',
+      'du',
+      'df',
     ],
   },
   'vcs-read': {

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -931,6 +931,34 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       // code by design (and may write coverage/report artifacts).
     ],
   },
+  /**
+   * Outbound reads (ADR 0025). In NO level preset and in no shipped default —
+   * every preset stays entirely local, and this one must be asked for by name.
+   *
+   * It exists because `WebFetch`/`WebSearch` previously matched nothing at all,
+   * so every web call from every subagent parked, rendered and entered the
+   * serial eval queue. Measured on a live 0.7.6 session: a fan-out of five
+   * concurrent `general-purpose` agents saturated that queue and the waiters
+   * escalated on `queue_timeout` WITHOUT the LLM ever running. The most common
+   * thing a research subagent does took the most expensive path available.
+   *
+   * Deliberately NOT added to `trusted`: that level is chosen for git mutation
+   * and proved-derived deletion, and someone who selected it for those reasons
+   * would silently gain arbitrary outbound egress on upgrade — the exact
+   * quiet-widening ADR 0023 fixed in `matchGroups` one release earlier.
+   *
+   * The asymmetry that settles it: a wrongly-escalated fetch is a nuisance, a
+   * wrongly-approved one is an exfiltration channel. `WebFetch` takes an
+   * arbitrary URL and a subagent is the context no human is watching.
+   */
+  'net-read': {
+    tools: ['WebFetch', 'WebSearch'],
+    // No commands. `curl`/`wget` are deliberately absent: they are general
+    // process-executing tools whose flags write files (`-o`, `-O`) and whose
+    // output is routinely piped into a shell. Covering them here would smuggle
+    // a write and an exec path into a group whose name promises a read.
+    commands: [],
+  },
   // --- Write-side groups (#959). Opt-in via `approve_groups`; none is on by
   // --- default, so this addition changes no shipped behavior on its own.
   'fs-write': {

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -16,35 +16,41 @@
 /** Benign segments that may appear in a compound command without needing coverage. */
 export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
 
-/**
- * A segment that is ENTIRELY variable assignments, e.g. `S=/tmp/x` or
- * `A=1 B=2`. Such a segment runs no command at all, so it needs no coverage.
+/*
+ * ATTEMPT 5, REVERTED BEFORE MERGE: "a segment whose every word is an
+ * assignment runs no command, so it needs no coverage."
  *
- * Measured cause of escalation: agents habitually open a script by assigning a
- * path, and `SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"` matched NOTHING — because
- * `matchCoveredCommand` requires every segment covered and an assignment
- * matched neither a neutral prefix nor a read prefix. The rest of the command
- * was pure `ls`/`cat`, so an 8-second LLM eval was spent on a read.
+ * It rejected `PATH=/evil ls` (the glued form) and AUTO-APPROVED the
+ * semicolon form, which is strictly worse because a bare assignment persists
+ * for every later segment:
  *
- * EVERY word must be an assignment, and that is the whole safety argument.
- * An assignment PREFIX to a command (`PATH=/evil ls`, `LD_PRELOAD=x cat f`) is
- * not inert: it runs `ls`, and it chooses WHICH `ls`. Accepting a segment that
- * merely STARTS with an assignment would auto-approve exactly that, so the
- * predicate is all-or-nothing and a trailing command disqualifies the segment.
+ *     PATH=/tmp/evil ls     -> escalate            (guarded)
+ *     PATH=/tmp/evil; ls    -> APPROVE read-only:ls  at 0ms
  *
- * Command substitution needs no handling here: `hasShellControl` has already
- * rejected the segment for `$(…)` and backticks before this is reached, so
- * `FOO=$(rm -rf /)` never gets this far. That ordering is load-bearing — this
- * predicate on its own would call it inert.
+ * `splitCompound` splits on `;`/`&&`/`||`/newline, so identical shell
+ * semantics arrive as two segments — an "inert" assignment plus a covered
+ * read. Verified against real bash: both spellings run the attacker's binary
+ * (`PATH`/`HOME` are already exported, so a bare assignment keeps the export
+ * attribute). `export PATH=…; git status` was a second route, since `export`
+ * is peeled by `stripShellGrammar` first. This lands on `read-only`, which is
+ * in EVERY preset including the default, and via #1024 is answered at hook
+ * time for a subagent with no render and no card.
+ *
+ * This is attempt (1) of the post-mortem below, and that post-mortem's
+ * conclusion stands: no property of an assignment inspected IN ISOLATION
+ * separates benign from dangerous, because the danger is what the assignment
+ * does to LATER segments. A correct fix must carry inertness FORWARD — a
+ * pure-assignment segment poisoning every subsequent non-neutral segment, the
+ * way `artifactCleanPoisonWalk` poisons on `cd` — not judge the segment alone.
+ * Name-denylisting (`PATH`/`LD_*`/`BASH_ENV`/…) is item (2) and is rejected
+ * there.
+ *
+ * Do not re-add without the forward-poison walk AND test cases in the `;`,
+ * `&&` and newline spellings. The reverted version's own test block was named
+ * "an assignment PREFIX to a command is NOT inert" and pinned five cases,
+ * every one the glued spelling that already worked — so it passed green while
+ * the hole was open.
  */
-export function isPureAssignment(body: string): boolean {
-  const words = body.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return false;
-  // NAME=..., POSIX name rules. The value may be empty (`FOO=`) and may be
-  // quoted; anything after the first `=` is data, not a command, because a
-  // substitution would already have been vetoed above.
-  return words.every((w) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(w));
-}
 
 /**
  * Shell keywords that PREFIX a real command (#999).
@@ -714,7 +720,7 @@ export function matchCoveredCommand(
     const stripped = stripShellGrammar(seg);
     if (stripped.structural) continue;
     const body = stripped.command;
-    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null || isPureAssignment(body)) {
+    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null) {
       // Neutral segments are vetoed before they can be waved through. Ordering
       // note: `extraVeto` used to run ahead of this neutral check for EVERY
       // segment, so moving it inside is behavior-preserving only because a

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -17,6 +17,36 @@
 export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
 
 /**
+ * A segment that is ENTIRELY variable assignments, e.g. `S=/tmp/x` or
+ * `A=1 B=2`. Such a segment runs no command at all, so it needs no coverage.
+ *
+ * Measured cause of escalation: agents habitually open a script by assigning a
+ * path, and `SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"` matched NOTHING — because
+ * `matchCoveredCommand` requires every segment covered and an assignment
+ * matched neither a neutral prefix nor a read prefix. The rest of the command
+ * was pure `ls`/`cat`, so an 8-second LLM eval was spent on a read.
+ *
+ * EVERY word must be an assignment, and that is the whole safety argument.
+ * An assignment PREFIX to a command (`PATH=/evil ls`, `LD_PRELOAD=x cat f`) is
+ * not inert: it runs `ls`, and it chooses WHICH `ls`. Accepting a segment that
+ * merely STARTS with an assignment would auto-approve exactly that, so the
+ * predicate is all-or-nothing and a trailing command disqualifies the segment.
+ *
+ * Command substitution needs no handling here: `hasShellControl` has already
+ * rejected the segment for `$(…)` and backticks before this is reached, so
+ * `FOO=$(rm -rf /)` never gets this far. That ordering is load-bearing — this
+ * predicate on its own would call it inert.
+ */
+export function isPureAssignment(body: string): boolean {
+  const words = body.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return false;
+  // NAME=..., POSIX name rules. The value may be empty (`FOO=`) and may be
+  // quoted; anything after the first `=` is data, not a command, because a
+  // substitution would already have been vetoed above.
+  return words.every((w) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(w));
+}
+
+/**
  * Shell keywords that PREFIX a real command (#999).
  *
  * Every one of these is followed by a command that actually runs, so the ONLY
@@ -684,7 +714,7 @@ export function matchCoveredCommand(
     const stripped = stripShellGrammar(seg);
     if (stripped.structural) continue;
     const body = stripped.command;
-    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null) {
+    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null || isPureAssignment(body)) {
       // Neutral segments are vetoed before they can be waved through. Ordering
       // note: `extraVeto` used to run ahead of this neutral check for EVERY
       // segment, so moving it inside is behavior-preserving only because a

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -107,6 +107,30 @@ export type MultiChoiceMode = 'skip' | 'evaluate';
  */
 export const DEFAULT_ALWAYS_ESCALATE_TOOLS: readonly string[] = ['AskUserQuestion', 'ExitPlanMode'];
 
+/**
+ * One agent type's policy overrides (ADR 0025).
+ *
+ * Every key optional: a section that sets only `approve_groups` leaves `allow`
+ * and the deny side inheriting the base, so the common case ("this role also
+ * gets net-read") is one line.
+ *
+ * The merge is NOT uniform, and the asymmetry is the security contract:
+ *
+ * - `deny` / `deny_groups` UNION with the base. A per-agent section must never
+ *   be able to weaken a machine-wide prohibition, so adding one cannot remove
+ *   a deny. Pinned by test, per ADR 0025's verification obligation.
+ * - `allow` / `approve_groups` REPLACE the base. Per-role scoping is the point:
+ *   if these merged additively, a section could only ever widen, and "give
+ *   pr-review LESS than the base" — the case that motivated the feature —
+ *   would be inexpressible.
+ */
+export interface AgentPolicyOverride {
+  readonly allow?: readonly string[];
+  readonly deny?: readonly string[];
+  readonly approve_groups?: readonly string[];
+  readonly deny_groups?: readonly string[];
+}
+
 /** Configuration for the auto-approve feature */
 export interface AutoApproveConfig {
   readonly enabled: boolean;
@@ -190,6 +214,29 @@ export interface AutoApproveConfig {
    * Default: empty.
    */
   readonly deny_groups: readonly string[];
+  /**
+   * Per-agent-type policy overrides (ADR 0025), keyed by the hook's
+   * `agent_type` (`Explore`, `general-purpose`, `pr-review`, ...).
+   *
+   * ```toml
+   * [auto_approve.agents.Explore]
+   * approve_groups = ["read-only", "vcs-read", "net-read"]
+   * ```
+   *
+   * Exists because the deterministic layers are the ONLY ones a subagent can
+   * reach at hook time (ADR 0004: an `agent_id`-tagged request never sees the
+   * LLM there), so "let research agents read the web, and nothing else" was
+   * previously inexpressible except as a machine-wide grant.
+   *
+   * Empty object = no overrides; every agent uses the base policy, which is
+   * exactly the pre-ADR-0025 behaviour.
+   *
+   * OPTIONAL rather than required-and-defaulted, deliberately: the service
+   * already reads it as `config.agents ?? {}`, and making it required would
+   * force a meaningless `agents: {}` into every existing construction site
+   * (and every test fixture) to assert something none of them are about.
+   */
+  readonly agents?: Readonly<Record<string, AgentPolicyOverride>>;
   /**
    * Natural-language guidance appended to the LLM system prompt.
    * Lets users steer the LLM for ambiguous cases not covered by allow/deny.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1743,6 +1743,29 @@ async function createNewSession(
           `[QuestionPresenceTracker] gate cleanup for superseded ${questionId.slice(0, 8)} threw: ${errorToString(err)}`,
         );
       }
+      // The prompt left the screen, which for a permission answered directly in
+      // the terminal is the ONLY evidence remi gets. Until this call the card
+      // cleared but the EVAL did not: a queued waiter kept its place in the
+      // serial lane and ran (or burned the full `queue_timeout`) to decide a
+      // question a human had already answered — then pushed a card for it.
+      //
+      // Measured on a live 0.7.6 session: evals cost 7-10s each and run one at
+      // a time, so every already-answered survivor delayed every real one
+      // behind it, and WebFetch/WebSearch escalated at exactly 240001ms having
+      // never reached the model.
+      //
+      // Separately guarded from the release above, deliberately: these are two
+      // independent cleanups and a throw in either must not skip the other —
+      // the zombie-card pattern #661 fixed in input-events.ts's answer paths.
+      // `cancelEvalForQuestion` is a no-op when no eval is tracked, so this is
+      // safe to call on every disappearance.
+      try {
+        sessionGateHandles.get(sessionId)?.cancelEvalForQuestion?.(questionId as UUID, reason);
+      } catch (err) {
+        logError(
+          `[QuestionPresenceTracker] eval cancel for gone ${questionId.slice(0, 8)} threw: ${errorToString(err)}`,
+        );
+      }
     },
   });
   // #920: register this session's tracker so the answer handler's

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
 import { parse as parseToml } from 'smol-toml';
+import { validateAgents } from '../auto-approve/agent-policy.ts';
 import {
   AUTO_APPROVE_LEVELS,
   DEFAULT_AUTO_APPROVE_LEVEL,
@@ -500,6 +501,9 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Always escalate these to the user; never auto-decided by the LLM (#572):
     // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
     always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
+    // ADR 0025. Empty = every agent uses the base policy, i.e. exactly the
+    // pre-0025 behaviour. No shipped default grants any agent anything extra.
+    agents: {},
     // Reuse an answer the user already gave THIS SESSION for the identical
     // operation (#976). Session-scoped, in-memory, cleared on rotation -- a
     // durable rule is what `allow` is for. The deny-direction half (an earlier
@@ -624,6 +628,10 @@ export function loadConfig(configPath: string = CONFIG_PATH): RemiConfig {
     const parsed = parseToml(raw) as Record<string, unknown>;
     const merged = deepMerge(DEFAULT_CONFIG, parsed);
     validateAutoApprove(merged.auto_approve, configPath);
+    // ADR 0025. Validated against the MERGED value, which is safe here because
+    // `mergeSection` replaces the `agents` table wholesale rather than deep-
+    // merging it -- a user table never blends with the empty default.
+    validateAgents(merged.auto_approve.agents, configPath);
     // Apply the level preset AFTER merge, but decide from the RAW parsed
     // table (#963). By this point `merged.approve_groups` is populated either
     // way, so it cannot answer "did the user write this?" — reading it here
@@ -1369,6 +1377,26 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 # level = "strict"
 # approve_groups = ["read-only", "vcs-read", "build-test"]
 # deny_groups = []
+#
+# "net-read" (WebFetch + WebSearch) is a real group but is in NO preset and no
+# default -- every shipped preset is entirely local. Ask for it by name, and
+# prefer asking per agent (below) over machine-wide: WebFetch takes an
+# arbitrary URL, and a subagent is the context nobody is watching (ADR 0025).
+#
+# Per-agent-type overrides, keyed by the hook's agent_type. This is the only
+# layer a subagent reaches at hook time (the LLM never runs there -- ADR 0004),
+# so it is where "let research agents read the web, and nothing else" belongs.
+#
+#   deny / deny_groups   UNION with the base -- a section can never weaken a
+#                        machine-wide prohibition.
+#   allow / approve_groups   REPLACE the base, so a role can be given LESS.
+#
+# [auto_approve.agents.Explore]
+# approve_groups = ["read-only", "vcs-read", "net-read"]
+#
+# [auto_approve.agents.pr-review]
+# approve_groups = ["read-only", "vcs-read"]
+# allow = ["gh pr view", "gh pr diff"]
 #
 # Natural-language guidance appended to the LLM system prompt:
 # instructions = """

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -1,0 +1,325 @@
+/**
+ * ADR 0025: per-agent-type permission scoping.
+ *
+ * The merge asymmetry here IS the security contract — deny unions, allow
+ * replaces — so the tests that matter are the ones that fail when the
+ * asymmetry is flattened in either direction. ADR 0025 carries an explicit
+ * verification obligation for exactly that, because a document asserting "a
+ * section cannot weaken a deny" is the ADR 0011 failure mode unless a test
+ * fails when it stops being true.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type ResolvedPolicy,
+  resolvePolicy,
+  validateAgents,
+} from '../../src/auto-approve/agent-policy.ts';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import { AUTO_APPROVE_LEVELS, groupsForLevel } from '../../src/auto-approve/levels.ts';
+import { knownGroupNames } from '../../src/auto-approve/permission-groups.ts';
+import { DEFAULT_CONFIG } from '../../src/config/config.ts';
+
+const BASE: ResolvedPolicy = {
+  allow: ['uv run'],
+  deny: ['rm -rf /'],
+  approveGroups: ['read-only', 'vcs-read'],
+  denyGroups: ['fs-write'],
+};
+
+describe('resolvePolicy falls through to the base', () => {
+  test('main context (no agent type)', () => {
+    expect(resolvePolicy(BASE, {}, undefined)).toEqual(BASE);
+  });
+
+  test('an empty-string agent type', () => {
+    expect(resolvePolicy(BASE, { Explore: { allow: ['x'] } }, '')).toEqual(BASE);
+  });
+
+  test('an agent type with no section', () => {
+    expect(resolvePolicy(BASE, { Explore: { allow: ['x'] } }, 'general-purpose')).toEqual(BASE);
+  });
+
+  test('a MISSPELLED section silently does nothing', () => {
+    // ADR 0025 records this as an accepted consequence: there is no registry of
+    // agent types to validate a name against. Pinned so the behaviour is a
+    // known one rather than a surprise discovered in the field.
+    const resolved = resolvePolicy(BASE, { Explor: { approve_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.approveGroups).toEqual(['read-only', 'vcs-read']);
+  });
+});
+
+describe('deny UNIONS — a section can never weaken a prohibition', () => {
+  test('the base deny survives a section that omits it', () => {
+    // THE obligation from ADR 0025. If `deny` were treated like `allow`
+    // (replace-when-present), a section setting only approve_groups would be
+    // fine, but one setting its own `deny` would silently drop `rm -rf /`.
+    const resolved = resolvePolicy(BASE, { Explore: { deny: ['curl'] } }, 'Explore');
+    expect(resolved.deny).toContain('rm -rf /');
+    expect(resolved.deny).toContain('curl');
+  });
+
+  test('the base deny survives a section with an EMPTY deny', () => {
+    // The adversarial shape: an explicit `deny = []` is the most direct way to
+    // try to clear a machine-wide prohibition for one agent.
+    const resolved = resolvePolicy(BASE, { Explore: { deny: [] } }, 'Explore');
+    expect(resolved.deny).toEqual(['rm -rf /']);
+  });
+
+  test('deny_groups unions the same way', () => {
+    const resolved = resolvePolicy(BASE, { Explore: { deny_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.denyGroups).toEqual(['fs-write', 'net-read']);
+  });
+
+  test('a duplicate deny is not repeated', () => {
+    const resolved = resolvePolicy(BASE, { Explore: { deny: ['rm -rf /'] } }, 'Explore');
+    expect(resolved.deny).toEqual(['rm -rf /']);
+  });
+
+  test('base deny order is preserved, so a reported pattern does not shuffle', () => {
+    const base = { ...BASE, deny: ['a', 'b', 'c'] };
+    const resolved = resolvePolicy(base, { Explore: { deny: ['d'] } }, 'Explore');
+    expect(resolved.deny).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+describe('allow / approve_groups REPLACE — per-role scoping must be able to narrow', () => {
+  test('approve_groups replaces rather than merging', () => {
+    // The motivating case: give this role LESS. If it merged additively, a
+    // section could only ever widen and this would be inexpressible.
+    const resolved = resolvePolicy(
+      BASE,
+      { 'pr-review': { approve_groups: ['read-only'] } },
+      'pr-review',
+    );
+    expect(resolved.approveGroups).toEqual(['read-only']);
+    expect(resolved.approveGroups).not.toContain('vcs-read');
+  });
+
+  test('an EMPTY approve_groups means none, not "inherit the base"', () => {
+    // Treating empty as absent would turn an explicit narrowing into a
+    // widening — the one direction this must never fail.
+    const resolved = resolvePolicy(BASE, { locked: { approve_groups: [] } }, 'locked');
+    expect(resolved.approveGroups).toEqual([]);
+  });
+
+  test('an EMPTY allow means none, not "inherit the base"', () => {
+    const resolved = resolvePolicy(BASE, { locked: { allow: [] } }, 'locked');
+    expect(resolved.allow).toEqual([]);
+  });
+
+  test('a section may also widen, which is the user saying so explicitly', () => {
+    const resolved = resolvePolicy(
+      BASE,
+      { Explore: { approve_groups: ['read-only', 'vcs-read', 'net-read'] } },
+      'Explore',
+    );
+    expect(resolved.approveGroups).toContain('net-read');
+  });
+
+  test('keys not set by the section inherit the base', () => {
+    // The common case is one line: "this role also gets net-read".
+    const resolved = resolvePolicy(BASE, { Explore: { approve_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.allow).toEqual(['uv run']);
+    expect(resolved.deny).toEqual(['rm -rf /']);
+    expect(resolved.denyGroups).toEqual(['fs-write']);
+  });
+
+  test('the base object is never mutated', () => {
+    const snapshot = structuredClone(BASE);
+    resolvePolicy(BASE, { Explore: { deny: ['x'], approve_groups: ['y'] } }, 'Explore');
+    expect(BASE).toEqual(snapshot);
+  });
+});
+
+describe('the real AutoApproveService applies the agent section', () => {
+  // Everything above is a pure function. Without this block, all of it would
+  // stay green if the service never passed `agentType` through -- the feature
+  // would be inert and the suite would not notice. No LLM is involved: these
+  // are deterministic-layer decisions, which is exactly the layer a subagent
+  // reaches at hook time (ADR 0004).
+  function service(agents: Record<string, unknown>) {
+    return new AutoApproveService(
+      {
+        enabled: true,
+        provider: 'yooz',
+        model: 'm',
+        api_key: '',
+        base_url: 'http://127.0.0.1:19924',
+        timeout: 30,
+        log_decisions: false,
+        allow: [],
+        deny: [],
+        subagent_alert: [],
+        approve_groups: ['read-only'],
+        level: 'strict',
+        deny_groups: [],
+        instructions: '',
+        multichoice: 'skip',
+        multichoice_model: '',
+        escalate_model: '',
+        escalate_timeout: 0,
+        queue_timeout: 240,
+        cache_idle: 0,
+        keep_alive: 0,
+        engine: 'owned' as const,
+        engine_path: '',
+        model_cache: '',
+        disable_thinking: false,
+        always_escalate_tools: [],
+        session_precedent: true,
+        hold_timeout: 0,
+        push_hold_timeout: 0,
+        delivery_confirm_timeout: 0,
+        hold_unconfirmed_timeout: 0,
+        agents,
+      } as never,
+      () => {},
+    );
+  }
+
+  const NET_AGENTS = { Explore: { approve_groups: ['read-only', 'net-read'] } };
+
+  test('WebFetch is approved for the agent granted net-read', () => {
+    const d = service(NET_AGENTS).evaluateDeterministic(
+      'WebFetch',
+      { url: 'https://x' },
+      'Explore',
+    );
+    expect(d?.decision).toBe('approve');
+    expect(d?.reasoning).toContain('net-read');
+  });
+
+  test('the SAME call is not approved for an agent without the section', () => {
+    // The whole point of scoping: general-purpose does not inherit Explore's
+    // grant. This is the measured case -- a WebFetch with no match parks,
+    // renders, and enters the serial queue.
+    const d = service(NET_AGENTS).evaluateDeterministic(
+      'WebFetch',
+      { url: 'https://x' },
+      'general-purpose',
+    );
+    expect(d).toBeNull();
+  });
+
+  test('and not for the main context either', () => {
+    expect(service(NET_AGENTS).evaluateDeterministic('WebFetch', { url: 'https://x' })).toBeNull();
+  });
+
+  test('with no agent section, WebFetch matches nothing', () => {
+    expect(
+      service({}).evaluateDeterministic('WebFetch', { url: 'https://x' }, 'Explore'),
+    ).toBeNull();
+  });
+
+  test('a base deny still wins inside an agent that was granted the group', () => {
+    const svc = new AutoApproveService(
+      {
+        enabled: true,
+        provider: 'yooz',
+        model: 'm',
+        api_key: '',
+        base_url: 'http://127.0.0.1:19924',
+        timeout: 30,
+        log_decisions: false,
+        allow: [],
+        deny: ['WebFetch'],
+        subagent_alert: [],
+        approve_groups: ['read-only'],
+        level: 'strict',
+        deny_groups: [],
+        instructions: '',
+        multichoice: 'skip',
+        multichoice_model: '',
+        escalate_model: '',
+        escalate_timeout: 0,
+        queue_timeout: 240,
+        cache_idle: 0,
+        keep_alive: 0,
+        engine: 'owned' as const,
+        engine_path: '',
+        model_cache: '',
+        disable_thinking: false,
+        always_escalate_tools: [],
+        session_precedent: true,
+        hold_timeout: 0,
+        push_hold_timeout: 0,
+        delivery_confirm_timeout: 0,
+        hold_unconfirmed_timeout: 0,
+        agents: NET_AGENTS,
+      } as never,
+      () => {},
+    );
+    const d = svc.evaluateDeterministic('WebFetch', { url: 'https://x' }, 'Explore');
+    expect(d?.decision).toBe('deny-covered');
+  });
+});
+
+describe('net-read is in no shipped default (ADR 0025)', () => {
+  // Written after a mutation exposed the first version of this claim as
+  // untestable: it hardcoded `approve_groups` and so could not fail when
+  // net-read was added to a LEVEL preset. Reading the presets themselves is
+  // the only form of this assertion that can fail on what it claims.
+  test('no level preset grants net-read', () => {
+    for (const level of AUTO_APPROVE_LEVELS) {
+      expect(groupsForLevel(level)).not.toContain('net-read');
+    }
+  });
+
+  test('the shipped approve_groups default does not grant net-read', () => {
+    expect(DEFAULT_CONFIG.auto_approve.approve_groups).not.toContain('net-read');
+  });
+
+  test('net-read IS a real, known group — absent from presets, not missing', () => {
+    // Without this, deleting the group entirely would also satisfy the two
+    // assertions above, and "opt-in" would silently become "unavailable".
+    expect(knownGroupNames()).toContain('net-read');
+  });
+});
+
+describe('validateAgents', () => {
+  test('undefined is fine (no table)', () => {
+    expect(() => validateAgents(undefined, '/c.toml')).not.toThrow();
+  });
+
+  test('an empty table is fine', () => {
+    expect(() => validateAgents({}, '/c.toml')).not.toThrow();
+  });
+
+  test('a valid table passes', () => {
+    expect(() =>
+      validateAgents({ Explore: { approve_groups: ['read-only'], deny: ['curl'] } }, '/c.toml'),
+    ).not.toThrow();
+  });
+
+  test('an array instead of a table throws', () => {
+    expect(() => validateAgents([], '/c.toml')).toThrow(/must be a table/);
+  });
+
+  test('a non-table section throws, naming the agent', () => {
+    expect(() => validateAgents({ Explore: 'read-only' }, '/c.toml')).toThrow(
+      /agents\.Explore.*must be a table/s,
+    );
+  });
+
+  test('a non-array list throws, naming the key', () => {
+    expect(() => validateAgents({ Explore: { approve_groups: 'read-only' } }, '/c.toml')).toThrow(
+      /agents\.Explore\.approve_groups/,
+    );
+  });
+
+  test('a non-string element throws', () => {
+    expect(() => validateAgents({ Explore: { deny: ['ok', 3] } }, '/c.toml')).toThrow(
+      /agents\.Explore\.deny/,
+    );
+  });
+
+  test('a MISSPELLED key throws instead of being ignored', () => {
+    // `approve_group` (singular) would otherwise leave the agent on the base
+    // policy while the config file plainly appears to grant something — a
+    // config/behaviour mismatch of exactly the kind ADR 0011 exists to stop.
+    expect(() => validateAgents({ Explore: { approve_group: ['read-only'] } }, '/c.toml')).toThrow(
+      /Unknown key.*approve_group/s,
+    );
+  });
+});

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -134,13 +134,56 @@ describe('allow / approve_groups REPLACE — per-role scoping must be able to na
   });
 });
 
+/** A real service with only `agents` varying. Module-scope so both the
+ *  deterministic and the async-evaluate describes drive the SAME construction. */
+function svcWithAgents(agents: Record<string, unknown>) {
+  return new AutoApproveService(
+    {
+      enabled: true,
+      provider: 'yooz',
+      model: 'm',
+      api_key: '',
+      base_url: 'http://127.0.0.1:19924',
+      timeout: 30,
+      log_decisions: false,
+      allow: [],
+      deny: [],
+      subagent_alert: [],
+      approve_groups: ['read-only'],
+      level: 'strict',
+      deny_groups: [],
+      instructions: '',
+      multichoice: 'skip',
+      multichoice_model: '',
+      escalate_model: '',
+      escalate_timeout: 0,
+      queue_timeout: 240,
+      cache_idle: 0,
+      keep_alive: 0,
+      engine: 'owned' as const,
+      engine_path: '',
+      model_cache: '',
+      disable_thinking: false,
+      always_escalate_tools: [],
+      session_precedent: true,
+      hold_timeout: 0,
+      push_hold_timeout: 0,
+      delivery_confirm_timeout: 0,
+      hold_unconfirmed_timeout: 0,
+      agents,
+    } as never,
+    () => {},
+  );
+}
+
 describe('the real AutoApproveService applies the agent section', () => {
   // Everything above is a pure function. Without this block, all of it would
   // stay green if the service never passed `agentType` through -- the feature
   // would be inert and the suite would not notice. No LLM is involved: these
   // are deterministic-layer decisions, which is exactly the layer a subagent
   // reaches at hook time (ADR 0004).
-  function service(agents: Record<string, unknown>) {
+  const service = svcWithAgents;
+  function _unusedService(agents: Record<string, unknown>) {
     return new AutoApproveService(
       {
         enabled: true,
@@ -349,13 +392,15 @@ describe('the gate actually threads agent_type to every evaluation site', () => 
     expect(gate.slice(i, i + 200)).toContain('input.agent_type');
   });
 
-  test('all three evaluation sites pass it', () => {
-    // hook-time deterministic, parked-render evaluate, escalate_model second
-    // opinion. The third was missed in the first draft and re-ran the
-    // deterministic layers under the BASE policy, silently undoing a per-agent
-    // narrowing — so the count, not just the presence, is the assertion.
-    const sites = gate.split('input.agent_type,').length - 1;
-    expect(sites).toBe(3);
+  test('the parked-render evaluate receives agent_type', () => {
+    // Its own bounded assertion, not a whole-file count. A count of 3 was the
+    // first draft and had a proven false negative: delete this site and add any
+    // unrelated fourth occurrence and the count still reads 3. This was the one
+    // of the three sites left unguarded by that version.
+    const i = gate.indexOf('arbitrateParkedRender(');
+    expect(i).toBeGreaterThan(-1);
+    const body = gate.slice(i, gate.indexOf('\n  }', i));
+    expect(body).toContain('input.agent_type,');
   });
 
   test('runSecondOpinion specifically forwards it', () => {
@@ -363,5 +408,59 @@ describe('the gate actually threads agent_type to every evaluation site', () => 
     expect(i).toBeGreaterThan(-1);
     const body = gate.slice(i, gate.indexOf('\n  }', i));
     expect(body).toContain('input.agent_type,');
+  });
+});
+
+describe('the async evaluate() path also honours the agent policy', () => {
+  // Criticality-8 gap found by review: deleting the `agentType` argument from
+  // `evaluate()`'s internal `evaluateDeterministic` call left the ENTIRE suite
+  // green. That is the async path — parked-render arbitration, the second
+  // opinion, main-context evals — so a per-agent narrowing silently reverted to
+  // base policy on every non-hook-time decision. Same class as the
+  // `runSecondOpinion` bug one layer up, and equally invisible.
+  //
+  // Driven through the real `evaluate()`, which short-circuits on a
+  // deterministic match and never reaches the network, so no engine is needed.
+  const NET_AGENTS = { Explore: { approve_groups: ['read-only', 'net-read'] } };
+
+  test('an agent-granted group approves through evaluate(), not just evaluateDeterministic()', async () => {
+    const svc = svcWithAgents(NET_AGENTS);
+    const r = await svc.evaluate(
+      'WebFetch',
+      { url: 'https://x' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      'Explore',
+    );
+    expect(r.decision).toBe('approve');
+    expect(r.durationMs).toBe(0);
+    expect(r.reasoning).toContain('net-read');
+  });
+
+  test('and an agent WITHOUT the section does not get it', async () => {
+    // Without a network call this cannot reach a decision, so assert the thing
+    // that distinguishes: it did NOT short-circuit to a 0ms deterministic
+    // approve the way the granted agent did.
+    const svc = svcWithAgents(NET_AGENTS);
+    const r = await svc.evaluate(
+      'WebFetch',
+      { url: 'https://x' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      'general-purpose',
+    );
+    expect(r.decision === 'approve' && r.durationMs === 0).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   type ResolvedPolicy,
   resolvePolicy,
@@ -321,5 +323,45 @@ describe('validateAgents', () => {
     expect(() => validateAgents({ Explore: { approve_group: ['read-only'] } }, '/c.toml')).toThrow(
       /Unknown key.*approve_group/s,
     );
+  });
+});
+
+describe('the gate actually threads agent_type to every evaluation site', () => {
+  // Proven necessary by incident, not by imagination: during this PR's review a
+  // mutation removed `input.agent_type` from the hook-time
+  // `evaluateDeterministic` call and the ENTIRE suite stayed green, because
+  // every test above calls the service directly. The feature was inert on the
+  // path that matters most (ADR 0004: the hook-time deterministic layer is the
+  // only one a subagent reaches) and nothing said so.
+  //
+  // A behavioural test cannot reach these: `AutoApproveGate`'s call sites are
+  // reached only through a live hook dispatch. So this pins the three sites by
+  // source, which is the same shape `cancel.test.ts` uses and has the same
+  // limitation — it proves the argument is passed, not that it is honoured.
+  const gate = fs.readFileSync(
+    path.join(import.meta.dir, '..', '..', 'src', 'auto-approve', 'auto-approve-gate.ts'),
+    'utf8',
+  );
+
+  test('hook-time evaluateDeterministic receives agent_type', () => {
+    const i = gate.indexOf('evaluateDeterministic?.(');
+    expect(i).toBeGreaterThan(-1);
+    expect(gate.slice(i, i + 200)).toContain('input.agent_type');
+  });
+
+  test('all three evaluation sites pass it', () => {
+    // hook-time deterministic, parked-render evaluate, escalate_model second
+    // opinion. The third was missed in the first draft and re-ran the
+    // deterministic layers under the BASE policy, silently undoing a per-agent
+    // narrowing — so the count, not just the presence, is the assertion.
+    const sites = gate.split('input.agent_type,').length - 1;
+    expect(sites).toBe(3);
+  });
+
+  test('runSecondOpinion specifically forwards it', () => {
+    const i = gate.indexOf('private async runSecondOpinion(');
+    expect(i).toBeGreaterThan(-1);
+    const body = gate.slice(i, gate.indexOf('\n  }', i));
+    expect(body).toContain('input.agent_type,');
   });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 
@@ -277,5 +279,33 @@ describe('AutoApproveService.cancel()', () => {
     // Reasoning should NOT include 'Hard kill' or 'Cancelled' — the leak
     // would surface as one of those.
     expect(second.reasoning).not.toMatch(/hard kill|cancelled/i);
+  });
+});
+
+describe('a prompt leaving the screen cancels its eval (terminal-answered permissions)', () => {
+  // `onHooklessQuestionGone` is the ONLY evidence remi gets that a permission
+  // was answered directly in the terminal: no hook fires, the prompt simply
+  // disappears. It cleared the card and released the hold, but did NOT cancel
+  // the eval -- so a queued waiter kept its place in the serial lane and ran,
+  // or burned the full queue_timeout, to decide something a human had already
+  // answered, then pushed a card for it.
+  //
+  // Measured on a live 0.7.6 session: 7-10s per eval, run one at a time, with
+  // WebFetch/WebSearch escalating at exactly 240001ms having never reached the
+  // model. Every already-answered survivor delayed every real question behind
+  // it.
+  const cli = fs.readFileSync(path.join(import.meta.dir, '..', '..', 'src', 'cli.ts'), 'utf8');
+
+  test('the disappearance handler cancels the eval', () => {
+    // A behavioural test cannot reach this: the wiring lives in module-level
+    // startup code in cli.ts with no seam. Without this pin, the queued-waiter
+    // cancel below stays green while nothing calls it -- the ADR 0011 row-5
+    // shape, in a fix for a measured production stall.
+    // Asserted on the EXACT call, not on a window around the handler: the
+    // first version of this pin scanned 3000 chars from the handler and so
+    // reached input-events.ts's own `cancelEvalForQuestion` call sites, which
+    // meant deleting this one left it green. Verified by mutation.
+    expect(cli).toContain('onHooklessQuestionGone:');
+    expect(cli).toContain('cancelEvalForQuestion?.(questionId as UUID, reason)');
   });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -305,7 +305,12 @@ describe('a prompt leaving the screen cancels its eval (terminal-answered permis
     // first version of this pin scanned 3000 chars from the handler and so
     // reached input-events.ts's own `cancelEvalForQuestion` call sites, which
     // meant deleting this one left it green. Verified by mutation.
-    expect(cli).toContain('onHooklessQuestionGone:');
-    expect(cli).toContain('cancelEvalForQuestion?.(questionId as UUID, reason)');
+    // Bounded to the handler BODY, not the whole file. A whole-file
+    // `toContain` stayed green when the call was deleted from the handler and
+    // the same string added to a never-called function -- verified by mutation.
+    const i = cli.indexOf('onHooklessQuestionGone:');
+    expect(i).toBeGreaterThan(-1);
+    const handler = cli.slice(i, cli.indexOf('\n  });', i));
+    expect(handler).toContain('cancelEvalForQuestion');
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1217,3 +1217,75 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
     );
   });
 });
+
+describe('a pure variable-assignment segment is inert (measured escalation cause)', () => {
+  // Agents habitually open a script by assigning a path, and that one segment
+  // matched neither a neutral prefix nor a read prefix -- sinking commands that
+  // were otherwise pure `ls`/`cat` into an 8-second LLM eval. Taken verbatim
+  // from a live 0.7.6 session.
+  test('the reported figure-qa command', () => {
+    const cmd =
+      'SCRIPTS_DIR="/Users/y/.claude/figure-qa-scripts"\n' +
+      'ls "$SCRIPTS_DIR/examples" 2>/dev/null\n' +
+      'cat "$SCRIPTS_DIR/check_raster.py" | head -100';
+    expect(bash(cmd)).toBe('read-only:ls');
+  });
+
+  test('semicolon form', () => {
+    expect(bash('SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"')).toBe('read-only:ls');
+    expect(bash('S=/tmp/x; grep -o "a" $S')).toBe('read-only:grep');
+  });
+
+  test('multiple assignments in one segment', () => {
+    expect(bash('A=1 B=2; ls')).toBe('read-only:ls');
+  });
+
+  test('assignments alone are still not "a read"', () => {
+    // Same rule every neutral segment obeys: a command that runs nothing is
+    // not a read, so it must not be approved on its own.
+    expect(bash('S=/tmp/x')).toBeNull();
+  });
+});
+
+describe('an assignment PREFIX to a command is NOT inert', () => {
+  // The whole safety argument for the rule above. `PATH=/evil ls` runs `ls`
+  // AND chooses which one; accepting a segment that merely STARTS with an
+  // assignment would auto-approve exactly that.
+  const mustBeNull = [
+    'PATH=/evil ls',
+    'LD_PRELOAD=/evil.so cat /etc/passwd',
+    'PATH=/evil ls && cat x',
+    'FOO=bar cat /etc/shadow',
+    'FOO=bar; PATH=/evil ls',
+  ];
+  for (const cmd of mustBeNull) {
+    test(cmd, () => expect(bash(cmd)).toBeNull());
+  }
+
+  test('command substitution in the value is refused before the assignment rule is reached', () => {
+    // `hasShellControl` rejects `$(...)`/backticks first. That ordering is
+    // load-bearing: the assignment predicate alone would call these inert.
+    const R = ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('');
+    expect(bash(`FOO=$(${R})`)).toBeNull();
+    expect(bash(`FOO=\`${R}\``)).toBeNull();
+  });
+});
+
+describe('read-only utilities added after the live-session measurement', () => {
+  const cases: Array<[string, string]> = [
+    ['which inkscape rsvg-convert', 'read-only:which'],
+    ['basename /a/b/c.txt', 'read-only:basename'],
+    ['dirname /a/b/c.txt', 'read-only:dirname'],
+    ['realpath ./x', 'read-only:realpath'],
+    ['mdfind "kMDItemFSName == \'X.app\'" 2>/dev/null | head -3', 'read-only:mdfind'],
+    ['du -sh node_modules', 'read-only:du'],
+    ['df -h', 'read-only:df'],
+  ];
+  for (const [cmd, expected] of cases) {
+    test(cmd, () => expect(bash(cmd)).toBe(expected));
+  }
+
+  test('the mutating Spotlight sibling is deliberately absent', () => {
+    expect(bash('mdutil -E /')).toBeNull();
+  });
+});

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1218,59 +1218,6 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
   });
 });
 
-describe('a pure variable-assignment segment is inert (measured escalation cause)', () => {
-  // Agents habitually open a script by assigning a path, and that one segment
-  // matched neither a neutral prefix nor a read prefix -- sinking commands that
-  // were otherwise pure `ls`/`cat` into an 8-second LLM eval. Taken verbatim
-  // from a live 0.7.6 session.
-  test('the reported figure-qa command', () => {
-    const cmd =
-      'SCRIPTS_DIR="/Users/y/.claude/figure-qa-scripts"\n' +
-      'ls "$SCRIPTS_DIR/examples" 2>/dev/null\n' +
-      'cat "$SCRIPTS_DIR/check_raster.py" | head -100';
-    expect(bash(cmd)).toBe('read-only:ls');
-  });
-
-  test('semicolon form', () => {
-    expect(bash('SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"')).toBe('read-only:ls');
-    expect(bash('S=/tmp/x; grep -o "a" $S')).toBe('read-only:grep');
-  });
-
-  test('multiple assignments in one segment', () => {
-    expect(bash('A=1 B=2; ls')).toBe('read-only:ls');
-  });
-
-  test('assignments alone are still not "a read"', () => {
-    // Same rule every neutral segment obeys: a command that runs nothing is
-    // not a read, so it must not be approved on its own.
-    expect(bash('S=/tmp/x')).toBeNull();
-  });
-});
-
-describe('an assignment PREFIX to a command is NOT inert', () => {
-  // The whole safety argument for the rule above. `PATH=/evil ls` runs `ls`
-  // AND chooses which one; accepting a segment that merely STARTS with an
-  // assignment would auto-approve exactly that.
-  const mustBeNull = [
-    'PATH=/evil ls',
-    'LD_PRELOAD=/evil.so cat /etc/passwd',
-    'PATH=/evil ls && cat x',
-    'FOO=bar cat /etc/shadow',
-    'FOO=bar; PATH=/evil ls',
-  ];
-  for (const cmd of mustBeNull) {
-    test(cmd, () => expect(bash(cmd)).toBeNull());
-  }
-
-  test('command substitution in the value is refused before the assignment rule is reached', () => {
-    // `hasShellControl` rejects `$(...)`/backticks first. That ordering is
-    // load-bearing: the assignment predicate alone would call these inert.
-    const R = ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('');
-    expect(bash(`FOO=$(${R})`)).toBeNull();
-    expect(bash(`FOO=\`${R}\``)).toBeNull();
-  });
-});
-
 describe('read-only utilities added after the live-session measurement', () => {
   const cases: Array<[string, string]> = [
     ['which inkscape rsvg-convert', 'read-only:which'],

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -558,8 +558,11 @@ describe('#959 superseded by ADR 0025: net-read ships, but TOOLS ONLY', () => {
   test('net-read covers exactly WebFetch and WebSearch', () => {
     expect(matchGroups('WebFetch', {}, NET_GROUPS)).toBe('net-read:WebFetch');
     expect(matchGroups('WebSearch', {}, NET_GROUPS)).toBe('net-read:WebSearch');
-    // Not a blanket network grant: Bash is still Bash.
-    expect(bash('echo hi', NET_GROUPS)).toBeNull();
+    // NOT asserted here: "Bash is still Bash". That reads like a guard and is
+    // vacuous -- `matchGroups` never consults a group's `tools` list for Bash
+    // (it routes through the command machinery), so the assertion holds for any
+    // possible `tools` content, including `tools: ['Bash']`. The live defence is
+    // `commands: []`, pinned directly by the test above.
   });
 });
 describe('#960 regression: case-insensitive filesystem', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -14,8 +14,9 @@ import {
 const ALL = ['read-only', 'vcs-read', 'build-test'];
 
 /** The write-side groups added in #959. Never enabled by default.
- *  `net-read` was designed alongside these and CUT before merge -- see the
- *  `no network group` block for what that absence must keep looking like. */
+ *  `net-read` was designed alongside these and CUT before merge; it is back as
+ *  of ADR 0025 but TOOLS ONLY, which is the distinction that permitted the
+ *  re-add -- see the '#959 superseded' block. */
 const WRITE_GROUPS = ['fs-write', 'vcs-write'];
 
 /** The scratch group (#994 follow-up). Never enabled by default. */
@@ -25,6 +26,11 @@ const SCRATCH_GROUPS = ['scratch'];
  *  corpus lives in artifact-clean.test.ts. */
 const ARTIFACT_GROUPS = ['artifact-clean'];
 
+/** The net-read group (ADR 0025). TOOLS ONLY, and in no level preset -- see
+ *  the '#959 superseded' block below for why the distinction is the whole
+ *  reason it was allowed back. */
+const NET_GROUPS = ['net-read'];
+
 /** Convenience: match a Bash command against the named groups. */
 function bash(command: string, groups: readonly string[] = ALL): string | null {
   return matchGroups('Bash', { command }, groups);
@@ -32,7 +38,13 @@ function bash(command: string, groups: readonly string[] = ALL): string | null {
 
 describe('permission-groups: known groups', () => {
   test('isKnownGroup', () => {
-    for (const name of [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS]) {
+    for (const name of [
+      ...ALL,
+      ...WRITE_GROUPS,
+      ...SCRATCH_GROUPS,
+      ...ARTIFACT_GROUPS,
+      ...NET_GROUPS,
+    ]) {
       expect(isKnownGroup(name)).toBe(true);
     }
     expect(isKnownGroup('bogus')).toBe(false);
@@ -41,7 +53,7 @@ describe('permission-groups: known groups', () => {
 
   test('knownGroupNames lists exactly the built-ins', () => {
     expect(knownGroupNames().sort()).toEqual(
-      [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS].sort(),
+      [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS, ...NET_GROUPS].sort(),
     );
   });
 });
@@ -504,11 +516,24 @@ describe('#960 regression: long-option abbreviation', () => {
   });
 });
 
-describe('#959: no network group ships', () => {
-  // `net-read` was cut after three review rounds found ten bypasses, five of
-  // them curl's. These assert the ABSENCE is real, so a future re-add has to
-  // delete a test rather than silently widen coverage.
-  test('curl, wget and gh api are covered by nothing', () => {
+describe('#959 superseded by ADR 0025: net-read ships, but TOOLS ONLY', () => {
+  // #959 cut `net-read` after three review rounds found ten bypasses, five of
+  // them curl's, and left a test asserting the absence so that any re-add had
+  // to be deliberate rather than a silent widening. This is that deliberate
+  // re-add, and the distinction that permits it is narrow and load-bearing:
+  //
+  //   #959's net-read covered COMMANDS (curl, wget, gh api). Every bypass it
+  //   died of was command-shaped -- curl's `-o`/`-O` write files, its output
+  //   is routinely piped into a shell, and `gh api` reaches mutating verbs.
+  //
+  //   ADR 0025's net-read covers TOOLS ONLY (`WebFetch`, `WebSearch`) and
+  //   ships `commands: []`. None of those five bypasses has a path back,
+  //   which the first test below proves rather than asserts.
+  //
+  // So the absence test is not deleted, it is INVERTED in the only direction
+  // that was ever the point: the commands must still be covered by nothing,
+  // now including when net-read itself is enabled.
+  test('curl, wget and gh api are covered by nothing — even with net-read on', () => {
     for (const cmd of [
       'curl https://example.com/data.json',
       'curl -sSL https://api.github.com/repos/o/r',
@@ -517,11 +542,24 @@ describe('#959: no network group ships', () => {
     ]) {
       expect(bash(cmd, WRITE_GROUPS)).toBeNull();
       expect(bash(cmd, [...ALL, ...WRITE_GROUPS])).toBeNull();
+      // The new coverage: enabling net-read must not resurrect #959's bypasses.
+      expect(bash(cmd, NET_GROUPS)).toBeNull();
+      expect(bash(cmd, [...ALL, ...WRITE_GROUPS, ...NET_GROUPS])).toBeNull();
     }
   });
 
-  test('knownGroupNames does not advertise one', () => {
-    expect(knownGroupNames()).not.toContain('net-read');
+  test('net-read carries NO commands at all', () => {
+    // The structural guarantee behind the test above. A future edit adding
+    // even one command to this group turns the bypass test's premise false,
+    // so this fails first and says why.
+    expect(BUILTIN_GROUPS['net-read']?.commands).toEqual([]);
+  });
+
+  test('net-read covers exactly WebFetch and WebSearch', () => {
+    expect(matchGroups('WebFetch', {}, NET_GROUPS)).toBe('net-read:WebFetch');
+    expect(matchGroups('WebSearch', {}, NET_GROUPS)).toBe('net-read:WebSearch');
+    // Not a blanket network grant: Bash is still Bash.
+    expect(bash('echo hi', NET_GROUPS)).toBeNull();
   });
 });
 describe('#960 regression: case-insensitive filesystem', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -1079,3 +1079,72 @@ describe('#880 the shipped defaults do not expose an unauthenticated daemon', ()
     expect(loadConfig(TEST_CONFIG).daemon.bind).toBe('127.0.0.1');
   });
 });
+
+describe('per-agent policy survives the config LOAD path (ADR 0025)', () => {
+  // Review found this untested end to end: `validateAgents`, `resolvePolicy`
+  // and the service were each covered in isolation, but nothing wrote a real
+  // TOML section and asserted it arrived. Deleting the `validateAgents(...)`
+  // call from `loadConfig` left the whole suite green.
+  //
+  // It guards a live coupling, not just wiring: `mergeSection` iterates
+  // `Object.keys(defaults)`, so a key absent from DEFAULT_CONFIG is silently
+  // DROPPED. `agents: {}` in the defaults is the only reason a user's section
+  // is reachable at all — and before this test, removing that line was pinned
+  // solely by a `toEqual` snapshot that anyone deleting it would "fix".
+  test('a real [auto_approve.agents.<type>] section reaches the loaded config', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `[auto_approve]
+approve_groups = ["read-only"]
+
+[auto_approve.agents.Explore]
+approve_groups = ["read-only", "net-read"]
+deny = ["curl"]
+`,
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.agents?.['Explore']?.approve_groups).toEqual([
+      'read-only',
+      'net-read',
+    ]);
+    expect(config.auto_approve.agents?.['Explore']?.deny).toEqual(['curl']);
+    // The base is untouched by the section.
+    expect(config.auto_approve.approve_groups).toEqual(['read-only']);
+  });
+
+  test('an unknown KEY inside a section is rejected at load', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `[auto_approve.agents.Explore]
+approve_group = ["read-only"]
+`,
+    );
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/approve_group/);
+  });
+
+  test('an unknown GROUP name inside a section warns but loads', () => {
+    // Warn, not throw: a throw reaches cli.ts's exit(1), and under the
+    // --install LaunchAgent (KeepAlive.SuccessfulExit=false) that is a
+    // crash-restart loop over a one-character typo. Matches the base path.
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '));
+    };
+    try {
+      fs.writeFileSync(
+        TEST_CONFIG,
+        `[auto_approve.agents.Explore]
+approve_groups = ["net-reed"]
+`,
+      );
+      const config = loadConfig(TEST_CONFIG);
+      expect(config.auto_approve.agents?.['Explore']?.approve_groups).toEqual(['net-reed']);
+    } finally {
+      console.warn = original;
+    }
+    // Because approve_groups REPLACES, this typo silently narrows the agent
+    // below base — which is exactly why it must be reported.
+    expect(warnings.join('\n')).toContain('net-reed');
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -464,6 +464,10 @@ describe('auto_approve config', () => {
   test('defaults are present', () => {
     expect(DEFAULT_CONFIG.auto_approve).toEqual({
       enabled: false,
+      // ADR 0025: empty by default. No shipped config grants any agent type
+      // anything the base does not already grant — a non-empty default here
+      // would be a per-role permission nobody asked for.
+      agents: {},
       // Resolved per platform (#822), so the expectation is too — but derived
       // from `detectLocalLLMPlatform` rather than from `DEFAULT_CONFIG`, which
       // would assert the value against itself and prove nothing.


### PR DESCRIPTION
Four fixes for one measured problem: on a live 0.7.6 machine almost every
subagent permission was escalating and the GPU was not firing.

## What the log actually said

Not the risk ceiling (`decided_by=risk_ceiling` never appears). The
distribution was **664 `approve (0ms)` vs 40 `decided_by=model`**, with
escalations at exactly **`240001ms`** on `WebFetch`/`WebSearch`:

```
[AutoApprove 605f4fc8] WebFetch: escalate (240001ms) - eval queue wait exceeded 240000ms
```

Each eval costs **7-10s**, evals run **serially**, timeout is 240s -- so ~30
clear before the next times out. A timed-out waiter escalates *before*
acquiring a slot, which is why it looks like "the model gave up": hundreds of
escalations, zero GPU.

## 1. net-read + per-agent scoping (ADR 0025)

`WebFetch`/`WebSearch` matched **no group at all**. `net-read` covers them; a
`[auto_approve.agents.<type>]` section scopes it per role -- which matters
because the deterministic layers are the only ones a subagent reaches at hook
time (ADR 0004).

`deny`/`deny_groups` **union** (a section can never weaken a machine-wide
prohibition); `allow`/`approve_groups` **replace** (the motivating case is
giving a role *less*).

**#959's absence test is superseded, not deleted.** A previous net-read was cut
after review found ten bypasses, five of them curl's, and that test was written
so a re-add had to be deliberate. Every bypass was **command-shaped**; this
group ships `commands: []`, tools only. So the test is inverted rather than
removed: curl/wget/gh api must still match nothing, **now including when
net-read is enabled**.

In **no preset and no default**. Not added to `trusted`: that level is chosen
for git mutation, and quietly attaching outbound egress to it is the same
widening ADR 0023 fixed one release ago.

## 2. A leading variable assignment sank covered reads

`S=/tmp/x` matched neither a neutral nor a read prefix, and every segment must
be covered. Agents open scripts by assigning a path, so this was a large share
of the 40 -- pure `ls`/`cat` costing an 8s eval. Now 0ms.

**A segment is inert only when EVERY word is an assignment.** `PATH=/evil ls`
runs ls *and picks which one*. Probed adversarially: that, `LD_PRELOAD=... cat
/etc/passwd`, `FOO=$(...)`, backtick form, `FOO=bar; PATH=/evil ls` and five
more all still refuse. Command substitution is rejected by `hasShellControl`
first; that ordering is load-bearing and pinned by a test.

## 3. Missing read-only utilities

`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du`, `df`. None opens a
file for writing or takes an output-path flag. `mdutil` deliberately absent and
pinned as such.

## 4. Answering on the terminal did not cancel the eval

`onHooklessQuestionGone` is the only evidence remi gets that a permission was
answered in the terminal -- no hook fires, the prompt disappears. It cleared the
card and released the hold but **never cancelled the eval**, so a queued waiter
kept its lane to decide something already answered, then pushed a card for it.
Every survivor delayed every real question behind it.

`cancelEvalForQuestion` already handles the running eval AND splices a queued
waiter; it simply was not wired here. Guarded separately from the release so a
throw in either cannot skip the other (#661 zombie-card shape).

## Verification

Full suite green; biome and all four typecheck targets clean.

**Mutation-verified throughout, and it caught two of my own bad tests:**
- "net-read is in no shipped default" hardcoded `approve_groups` and stayed
  green when net-read was planted into `trusted` -- now reads the presets.
- the cancel-on-answer pin scanned a window wide enough to reach other
  `cancelEvalForQuestion` sites and stayed green when the new call was deleted
  -- now asserts the exact call.

Both were the ADR 0011 row-5 shape in tests defending measured regressions.

Mutations that DO go red: deny-replaces-instead-of-unioning (3), empty
approve_groups treated as absent (1), service ignoring agentType (1), net-read
in trusted (1), in DEFAULT_CONFIG (1), group deleted (2), assignment-prefix
accepted (1), eval-cancel removed (1).

## Not in this PR

`allow` and `approve_groups` do not compose across segments: `uv run ... && ls
-la` has segment 1 covered by allow and segment 2 by read-only and matches
**neither**, because each layer demands the whole command. Real remaining cause,
but a design change that wants its own ADR.

Structural and unaddressed: the queue is serial, a waiter burns the full 240s
before shedding, and a timed-out request costs four minutes to be told "you
decide". net-read removes web calls from that lane; any sufficient fan-out of
unmatched commands reproduces it.
