### PR TITLE
Release 0.7.7

### DIFF
--- a/.context/decisions/0025-agent-scoped-permissions.md
+++ b/.context/decisions/0025-agent-scoped-permissions.md
@@ -7,7 +7,7 @@
 ## Context
 
 A live 0.7.6 session on the owner's machine escalated a burst of subagent
-permissions without the LLM ever running. Traced from `~/.remi/remi.log`, the
+permissions without the LLM ever running. Traced from `~/.remi/daemon.log`, the
 mechanism was not the one the daemon's own docs would suggest:
 
 - The #1024 hook-time deterministic path worked exactly as designed
@@ -38,7 +38,11 @@ Two things are wrong here, and they are separable.
 reaching for a bare tool-name `allow` to get them.
 
 It is **not** in `strict`, `balanced`, or `trusted`, and not in
-`DEFAULT_CONFIG.approve_groups`. Every shipped preset stays entirely local.
+`DEFAULT_CONFIG.approve_groups`. No shipped preset grants **arbitrary-URL
+egress** — stated that way because "the presets are entirely local" would be
+false: `vcs-read` carries fifteen `gh` subcommands that call api.github.com and
+`build-test` has `uv run pytest`, which resolves from PyPI. The line `net-read`
+crosses is not network-vs-local, it is *whose choice the destination is*.
 
 Adding it to `trusted` was considered and rejected. `trusted` is selected for
 git mutation and proved-derived deletion; someone who chose it for those reasons
@@ -105,11 +109,14 @@ it to nobody.
   unchanged here.
 - `deny` remains substring-matched and `approve_groups` whole-command-matched
   (ADR 0010); per-agent scoping inherits both behaviours unchanged.
-- Agent *names* are not validated against anything. There is no registry of
-  agent types to check against, so a typo in `[auto_approve.agents.Explor]`
-  silently never matches. The daemon logs the agent types it has actually seen
-  resolve a policy, which is the only honest mitigation available without
-  inventing a registry.
+- Agent *names* are not validated against anything, and **a typo in a section
+  name is currently undetectable**. There is no registry of agent types to
+  check against, so `[auto_approve.agents.Explor]` silently never matches and
+  NOTHING reports it — not at load, not at evaluation. An earlier draft of this
+  ADR claimed "the daemon logs the agent types it has actually seen resolve a
+  policy"; it does not, and shipping that sentence would have been the ADR 0011
+  failure inside the ADR itself. Group names inside a section ARE validated
+  (they have a registry), which is the half that was closeable.
 
 ## Verification obligation
 

--- a/.context/decisions/0025-agent-scoped-permissions.md
+++ b/.context/decisions/0025-agent-scoped-permissions.md
@@ -1,0 +1,118 @@
+# ADR 0025: Permissions may be scoped per agent type; network egress is never a default
+
+**Status:** accepted
+**Date:** 2026-08-11
+**Owner:** Seyed Yahya Shirazi
+
+## Context
+
+A live 0.7.6 session on the owner's machine escalated a burst of subagent
+permissions without the LLM ever running. Traced from `~/.remi/remi.log`, the
+mechanism was not the one the daemon's own docs would suggest:
+
+- The #1024 hook-time deterministic path worked exactly as designed
+  (`approve-matched group: "read-only:grep"`, `ls`, `cat`, `sed -n`).
+- `WebFetch` and `WebSearch` matched **nothing**. No group lists them —
+  `read-only` is `['Read','Glob','Grep','NotebookRead']` plus shell commands.
+- So every web call from every subagent parked, rendered, and entered the
+  **serial** eval queue.
+- Under a fan-out of five concurrent `general-purpose` agents the queue
+  saturated, and waiters escalated on `queue_timeout` (default 240s) — the
+  `eval queue wait exceeded` branch, which returns before any LLM call.
+
+So the most common operation a research subagent performs took the most
+expensive path available, and under load degraded to "escalate everything"
+while looking like the LLM was broken.
+
+The available workaround was `allow = ["WebFetch", "WebSearch"]` — a bare
+tool-name entry, which ADR 0010 and #1032 both record as the blunt instrument:
+it carries no destination veto at all.
+
+Two things are wrong here, and they are separable.
+
+## Decision
+
+### 1. A `net-read` group exists, and is in no level preset
+
+`net-read` covers `WebFetch` and `WebSearch` as a real group, so users stop
+reaching for a bare tool-name `allow` to get them.
+
+It is **not** in `strict`, `balanced`, or `trusted`, and not in
+`DEFAULT_CONFIG.approve_groups`. Every shipped preset stays entirely local.
+
+Adding it to `trusted` was considered and rejected. `trusted` is selected for
+git mutation and proved-derived deletion; someone who chose it for those reasons
+would silently acquire arbitrary outbound network egress on upgrade. That is
+precisely the failure ADR 0023 fixed in `matchGroups` — a group union quietly
+widening an axis nobody opted into — and repeating it in the level presets a
+release later would be indefensible.
+
+The asymmetry is deliberate and worth stating plainly: **a wrongly-escalated
+web fetch is a nuisance; a wrongly-approved one is an exfiltration channel.**
+`WebFetch` takes an arbitrary URL, subagents are exactly the context no human is
+watching, and a prompt-injected subagent needs only a URL with a query string.
+Opting in is one line; opting out of a default you never noticed is not.
+
+### 2. Permissions may be scoped by `agent_type`
+
+```toml
+[auto_approve.agents.Explore]
+approve_groups = ["read-only", "vcs-read", "net-read"]
+
+[auto_approve.agents.pr-review]
+approve_groups = ["read-only", "vcs-read"]
+allow = ["gh pr view", "gh pr diff"]
+```
+
+`agent_type` is already on the `PermissionRequest` hook input, already logged at
+the decision points, and already used by `precedent.ts` for operation identity.
+Nothing new is trusted: it is Claude Code's own value, the same provenance as
+`agent_id`, which the subagent policy has keyed on since #756.
+
+**Merge semantics, chosen so the safe direction is the monotone one:**
+
+| key | agent section present |
+|---|---|
+| `deny` | **union** with base |
+| `deny_groups` | **union** with base |
+| `allow` | **replaces** base |
+| `approve_groups` | **replaces** base |
+
+Deny unions because a per-agent rule must never be able to *weaken* a
+machine-wide prohibition — an agent section is a place to say "this role is
+narrower", and a reader must be able to trust that adding one cannot remove a
+deny. Allow and approve_groups replace because the entire point is per-role
+scoping: if they merged additively, an agent section could only ever widen, and
+"give the pr-review agent LESS than the base" would be inexpressible — which is
+the case that motivated the feature.
+
+Replacement can widen, when the user writes a wider list. That is their choice,
+made explicitly, and it is visible in one table in one file.
+
+## Consequences
+
+**A per-agent section is the only way to grant `net-read` to just the agents
+that need it.** That is the intended shape: `Explore` and research agents get
+network reads, a `pr-review` agent does not, and the machine-wide default grants
+it to nobody.
+
+**Not closed by this ADR:**
+
+- The serial eval queue itself. Moving web calls to the deterministic layer
+  relieves the measured saturation but does not bound it; a large enough
+  fan-out of genuinely-unmatched operations still queues and still escalates on
+  timeout. The queue is serial to protect the GPU and that trade-off is
+  unchanged here.
+- `deny` remains substring-matched and `approve_groups` whole-command-matched
+  (ADR 0010); per-agent scoping inherits both behaviours unchanged.
+- Agent *names* are not validated against anything. There is no registry of
+  agent types to check against, so a typo in `[auto_approve.agents.Explor]`
+  silently never matches. The daemon logs the agent types it has actually seen
+  resolve a policy, which is the only honest mitigation available without
+  inventing a registry.
+
+## Verification obligation
+
+Per ADR 0011, the claim "a per-agent section cannot weaken a deny" is a security
+claim and must be pinned by a test that fails when the union is changed to a
+replacement — not merely by this document asserting it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,7 @@ from it. One hardcoded default is wrong on one of the two supported targets.
 | Target | `provider` | `model` default | Who runs it |
 |---|---|---|---|
 | macOS Apple Silicon | `yooz` | `YoozLabs/Qwen3.5-4B-qat-lean-4bit-mlx` | remi fetches + supervises the helper (#834) |
-| Linux (any arch) | `llamacpp` | `YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0` | **you**, for now — remi prints the command at boot |
+| Linux (any arch) | `llamacpp` | `YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0` | **you** install `llama-server` once; remi spawns + supervises it (#822) |
 | macOS Intel, Windows | `yooz` (kept deliberately, so the boot warning fires) | (engine's, unused) | nothing; boot says so |
 
 Same trained weights, but **not the same artifact**: QAT was trained against
@@ -291,6 +291,19 @@ differs is everything *around* the weights, and three things bite:
   `/v1`, so it would be requested at `/v1/v1/models`. Every verb but `use`
   refuses with the restart command instead of emitting a 404. Router mode
   (`--models-dir`) is out of scope for all of remi's engine shapes.
+
+**remi supervises `llama-server` but never installs it** (#822 slice 1). It
+spawns it on demand through the same `EngineHost` the engine uses — attach
+first, claim the pidfile before spawning, health-probe `/health` (NOT
+`/v1/llm/status`, which llama.cpp has never served), stop what it started — and
+reports an actionable "install it" reason when the binary is absent. The line is
+drawn there deliberately: the macOS path fetches a **pinned artifact remi
+controls** (#834), while `llama-server` is a third-party binary across an arch
+matrix, so supervising one the user installed is a different trust proposition
+from downloading and executing one. The GGUF is not remi's job either — `-hf`
+makes llama.cpp pull it — which narrows what #822 originally assumed
+("Download is remi's job"). Still open on that issue: acquiring the binary,
+`keep_alive`/idle-stop, and the `escalate_model` design question.
 
 `warmModel()` is engine-only for the same reason, and the `llamacpp` base URL
 already carries `/v1` — calling it there requests `/v1/v1/llm/preload`. Its one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,22 @@ amended #1024 2026-08-08, see [ADR 0004](.context/decisions/0004-pty-as-arbiter-
   sensitive destinations a curated `approve_groups` write group would block. Already true for
   main-context requests; #1024 is the first time it applies with zero chance of a human ever
   seeing the prompt. Tracked as #1032 (not yet decided).
+- **Permissions can be scoped per `agent_type`**
+  ([ADR 0025](.context/decisions/0025-agent-scoped-permissions.md)). Because the deterministic
+  layers are the ONLY ones a subagent reaches at hook time, they are also the only place a
+  per-role grant can live: `[auto_approve.agents.Explore]` with
+  `approve_groups = [..., "net-read"]` lets research agents read the web while nothing else
+  does. `deny`/`deny_groups` UNION with the base (a section can never weaken a machine-wide
+  prohibition — pinned by test); `allow`/`approve_groups` REPLACE it (the motivating case is
+  giving a role LESS). An unmatched agent type falls through to the base, so a typo in a
+  section name silently does nothing — there is no registry to validate against.
+- **`net-read` (WebFetch + WebSearch) is in no preset and no default.** It exists because
+  those tools previously matched *nothing*, so every web call from every subagent parked,
+  rendered and entered the serial eval queue; a measured fan-out of five `general-purpose`
+  agents saturated it and the waiters escalated on `queue_timeout` **without the LLM ever
+  running**. Not added to `trusted`: that level is chosen for git mutation, and quietly
+  attaching outbound egress to it is the same widening ADR 0023 fixed in `matchGroups`.
+  A wrongly-escalated fetch is a nuisance; a wrongly-approved one is an exfil channel.
 
 **Notification channel — APNS push only** (no local notifications for questions):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,26 +60,13 @@ All notable changes to Remi are documented here.
 [ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
-- **A leading variable assignment sank otherwise-covered reads.**
-  `matchCoveredCommand` requires every compound segment covered, and `S=/tmp/x`
-  matched neither a neutral prefix nor a read prefix — so
-  `SCRIPTS_DIR="…"; ls "$SCRIPTS_DIR"; cat "$SCRIPTS_DIR/x.py" | head -100`
-  matched nothing and cost an 8-second LLM eval despite being pure `ls`/`cat`.
-  Agents habitually open a script by assigning a path, which is why
-  agent-written commands escalated so reliably. A segment is now inert when it
-  is **entirely** assignments — and that is the whole safety argument, because
-  an assignment *prefix* is not inert: `PATH=/evil ls` runs `ls` and chooses
-  which one. Command substitution needs no handling here, since
-  `hasShellControl` rejects `$(…)` and backticks first; that ordering is
-  load-bearing and pinned by a test.
 - **`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du` and `df` join
   `read-only`.** None opens a file for writing or takes an output-path flag,
   and `which` resolves a PATH entry rather than running it. `mdutil` — the
   mutating Spotlight sibling — is deliberately absent and pinned as such.
-- **Answering a permission on the terminal now cancels its eval.**
-  `onHooklessQuestionGone` is the only evidence remi gets that a prompt was
-  answered directly in the terminal: no hook fires, the render just disappears.
-  It cleared the card and released the hold but never cancelled the evaluation,
+- **A superseded prompt now cancels its eval.** When
+  `onHooklessQuestionGone` fires, it cleared the card and released the hold but
+  never cancelled the evaluation,
   so a queued waiter kept its place in the **serial** eval lane to decide a
   question a human had already answered — then pushed a card for it. Measured
   on a live 0.7.6 session where evals cost 7–10s each, every such survivor
@@ -87,6 +74,12 @@ All notable changes to Remi are documented here.
   exactly `240001ms` having never reached the model. `cancelEvalForQuestion`
   already handled both the running eval and splicing a queued waiter; it simply
   was not wired to this path.
+  **Scope, stated so it does not read as more than it is:** that callback has
+  exactly one trigger — a confirmed replacement render from the SAME agent
+  (`adoptRenderOwnedQuestion`). A prompt answered in the terminal with no
+  follow-up prompt rendering does NOT fire it, and still burns the full
+  `queue_timeout`. Covering that case needs a second trigger and is not in this
+  release.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Remi are documented here.
 ## [Unreleased]
 
 ### Added
+- **Permissions can be scoped per agent type** ([ADR 0025]). A
+  `[auto_approve.agents.<type>]` section keyed by the hook's `agent_type` lets
+  one role get what another does not:
+  ```toml
+  [auto_approve.agents.Explore]
+  approve_groups = ["read-only", "vcs-read", "net-read"]
+
+  [auto_approve.agents.pr-review]
+  approve_groups = ["read-only", "vcs-read"]
+  allow = ["gh pr view", "gh pr diff"]
+  ```
+  The deterministic layers are the **only** ones a subagent reaches at hook time
+  (the LLM never runs there — [ADR 0004]), so they are also the only place a
+  per-role grant can live. `deny`/`deny_groups` **union** with the base, so a
+  section can never weaken a machine-wide prohibition; `allow`/`approve_groups`
+  **replace** it, because the motivating case is giving a role *less*. An
+  unmatched agent type falls through to the base, which also means a typo in a
+  section name silently does nothing — there is no registry of agent types to
+  validate against, and ADR 0025 records that rather than pretending otherwise.
+- **A `net-read` group** (`WebFetch`, `WebSearch`), in **no** preset and no
+  default. It exists because those tools previously matched *nothing*: every web
+  call from every subagent parked, rendered, and entered the serial eval queue.
+  Measured on a live 0.7.6 session, a fan-out of five concurrent
+  `general-purpose` agents saturated that queue and the waiters escalated on
+  `queue_timeout` **without the LLM ever running** — so the most common thing a
+  research subagent does took the most expensive path available, and under load
+  degraded to "escalate everything" while looking like the model was broken.
+  Deliberately not added to `trusted`: that level is chosen for git mutation and
+  proved-derived deletion, and silently attaching outbound egress to it on
+  upgrade is the same quiet widening ADR 0023 fixed in `matchGroups` one release
+  earlier. A wrongly-escalated fetch is a nuisance; a wrongly-approved one is an
+  exfiltration channel.
 - **remi supervises `llama-server` on Linux** (#822). Auto-approve's local
   backend no longer has to be started by hand: remi spawns it on demand,
   health-probes it, and stops what it started — the same `EngineHost` the macOS
@@ -23,6 +55,9 @@ All notable changes to Remi are documented here.
   The GGUF is not remi's job either — `-hf` pulls it — which narrows what #822
   assumed ("Download is remi's job"). Still open there: acquiring the binary,
   idle-stop, and the `escalate_model` design question.
+
+[ADR 0004]: .context/decisions/0004-pty-as-arbiter-subagent-questions.md
+[ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
 - **The `escalate_model` warning could be silenced for the users it was for**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Remi are documented here.
 
 ## [Unreleased]
 
+### Added
+- **remi supervises `llama-server` on Linux** (#822). Auto-approve's local
+  backend no longer has to be started by hand: remi spawns it on demand,
+  health-probes it, and stops what it started — the same `EngineHost` the macOS
+  engine path already used, so it inherits attach-first, claim-the-pidfile-
+  before-spawning, and the redundant-start race resolution rather than
+  reimplementing them. What differs is only the launch (`-hf`, argv rather than
+  env), the readiness question (`/health`, since llama.cpp has never served
+  `/v1/llm/status`), and how the executable is found.
+  **remi still does not install it** — `brew install llama.cpp`, your distro's
+  package, or a prebuilt binary, once. That line is deliberate: the macOS helper
+  is a pinned artifact remi controls (#834), whereas `llama-server` is a
+  third-party binary across an arch matrix, so supervising one the user
+  installed is a different trust proposition from downloading and executing one.
+  A missing binary now reports how to install it instead of the engine path's
+  generic "no helper available", which implied a download that was never coming.
+  The GGUF is not remi's job either — `-hf` pulls it — which narrows what #822
+  assumed ("Download is remi's job"). Still open there: acquiring the binary,
+  idle-stop, and the `escalate_model` design question.
+
+### Fixed
+- **The `escalate_model` warning could be silenced for the users it was for**
+  (#822). It was nested inside the llamacpp boot warning, which was harmless
+  only while that warning fired on every llamacpp boot. Now that the boot
+  warning fires only for a *missing* binary, the nesting would have hidden the
+  "your second opinion comes from the primary model" notice from exactly the
+  people whose setup works. Lifted out to its own condition. Introduced and
+  fixed within this change; it never shipped.
+
 ## [0.7.6] - 2026-08-11
 
 Closes a P0 that shipped in every release to date: the daemon bound `0.0.0.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ All notable changes to Remi are documented here.
   idle-stop, and the `escalate_model` design question.
 
 ### Fixed
+- **A loopback bind stopped mDNS advertising with no log line at all** (#1051).
+  `startMdnsIfNeeded` collapsed three suppression conditions into one bare
+  `return null`, while every other exit from that function logged something.
+  Before #880 that was nearly harmless because `isLocalhostBind` was false on a
+  stock install; since the bind default moved to loopback it is the path
+  **every** stock install takes. The cost was specific: mDNS does not refuse a
+  discovery attempt, it stops answering, so from the phone's side the daemon
+  does not error — it *vanishes*, and nothing in the daemon's own output
+  contradicts "Remi is broken". Each condition now says which one fired, and
+  only the loopback case — the one the user did not ask for, since it arrived
+  with a changed default — names a remedy. `--no-mdns` and `network.mdns =
+  false` state the fact without nagging. The loopback message names
+  `auth.enabled` alongside `daemon.bind`, because widening the bind while auth
+  stays at `"auto"` (which resolves to `false`) walks straight back into the
+  #880 exposure.
+- **A `typos` false positive that a version bump would have turned into a CI
+  failure.** `ACCEPTs` in `port-discovery.ts` is flagged by typos ≥1.49 but not
+  by the pinned 1.28.4, so the repo was one dependency bump away from a red
+  gate on a comment. Unrelated to the above; called out rather than folded in
+  silently.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,10 @@ All notable changes to Remi are documented here.
   stays at `"auto"` (which resolves to `false`) walks straight back into the
   #880 exposure.
 - **A `typos` false positive that a version bump would have turned into a CI
-  failure.** `ACCEPTs` in `port-discovery.ts` is flagged by typos ≥1.49 but not
-  by the pinned 1.28.4, so the repo was one dependency bump away from a red
-  gate on a comment. Unrelated to the above; called out rather than folded in
+  failure.** A mixed-case word in a `port-discovery.ts` comment is flagged by
+  typos >=1.49 but not by the pinned 1.28.4, so the repo was one dependency
+  bump away from a red gate on a comment. (Spelled around here deliberately:
+  quoting the word verbatim would reintroduce the very hit this describes.) Unrelated to the above; called out rather than folded in
   silently.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,33 @@ All notable changes to Remi are documented here.
 [ADR 0025]: .context/decisions/0025-agent-scoped-permissions.md
 
 ### Fixed
+- **A leading variable assignment sank otherwise-covered reads.**
+  `matchCoveredCommand` requires every compound segment covered, and `S=/tmp/x`
+  matched neither a neutral prefix nor a read prefix — so
+  `SCRIPTS_DIR="…"; ls "$SCRIPTS_DIR"; cat "$SCRIPTS_DIR/x.py" | head -100`
+  matched nothing and cost an 8-second LLM eval despite being pure `ls`/`cat`.
+  Agents habitually open a script by assigning a path, which is why
+  agent-written commands escalated so reliably. A segment is now inert when it
+  is **entirely** assignments — and that is the whole safety argument, because
+  an assignment *prefix* is not inert: `PATH=/evil ls` runs `ls` and chooses
+  which one. Command substitution needs no handling here, since
+  `hasShellControl` rejects `$(…)` and backticks first; that ordering is
+  load-bearing and pinned by a test.
+- **`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du` and `df` join
+  `read-only`.** None opens a file for writing or takes an output-path flag,
+  and `which` resolves a PATH entry rather than running it. `mdutil` — the
+  mutating Spotlight sibling — is deliberately absent and pinned as such.
+- **Answering a permission on the terminal now cancels its eval.**
+  `onHooklessQuestionGone` is the only evidence remi gets that a prompt was
+  answered directly in the terminal: no hook fires, the render just disappears.
+  It cleared the card and released the hold but never cancelled the evaluation,
+  so a queued waiter kept its place in the **serial** eval lane to decide a
+  question a human had already answered — then pushed a card for it. Measured
+  on a live 0.7.6 session where evals cost 7–10s each, every such survivor
+  delayed every real question behind it, and `WebFetch`/`WebSearch` escalated at
+  exactly `240001ms` having never reached the model. `cancelEvalForQuestion`
+  already handled both the running eval and splicing a queued waiter; it simply
+  was not wired to this path.
 - **The `escalate_model` warning could be silenced for the users it was for**
   (#822). It was nested inside the llamacpp boot warning, which was harmless
   only while that warning fired on every llamacpp boot. Now that the boot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.7-dev.3",
+  "version": "0.7.7-dev.4",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.6",
+  "version": "0.7.7-dev.1",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.7-dev.2",
+  "version": "0.7.7-dev.3",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remi",
-  "version": "0.7.7-dev.1",
+  "version": "0.7.7-dev.2",
   "private": true,
   "license": "UNLICENSED",
   "workspaces": ["packages/*"],

--- a/packages/daemon/src/auto-approve/agent-policy.ts
+++ b/packages/daemon/src/auto-approve/agent-policy.ts
@@ -1,0 +1,121 @@
+/**
+ * Per-agent-type policy resolution (ADR 0025).
+ *
+ * `AutoApproveService` holds ONE base policy but serves every agent in the
+ * session. This resolves "what policy applies to THIS request" from the base
+ * plus an optional `[auto_approve.agents.<type>]` section.
+ *
+ * Pure and separate from the service for the usual reason this repo keeps
+ * doing it: the merge asymmetry below is a security contract, and a contract
+ * that can only be tested by standing up a whole service is a contract that
+ * gets tested loosely.
+ */
+
+import type { AgentPolicyOverride } from './types.ts';
+
+/** The four deterministic lists, resolved for one request. */
+export interface ResolvedPolicy {
+  readonly allow: readonly string[];
+  readonly deny: readonly string[];
+  readonly approveGroups: readonly string[];
+  readonly denyGroups: readonly string[];
+}
+
+/**
+ * Resolve the policy for `agentType`.
+ *
+ * `agentType` is undefined for a main-context request, and for any subagent
+ * whose hook did not carry one — both correctly fall through to the base.
+ * An agent type with no section also falls through, which is why a TYPO in a
+ * section name silently does nothing (ADR 0025 records this: there is no
+ * registry of agent types to validate against).
+ *
+ * THE ASYMMETRY IS THE POINT:
+ *
+ * - deny / deny_groups UNION. A per-agent section must never weaken a
+ *   machine-wide prohibition. Adding a section can only ever add denies, so a
+ *   reader can trust that `deny` in the base holds for every agent no matter
+ *   what any section says.
+ * - allow / approve_groups REPLACE when present. Per-role scoping is the whole
+ *   feature; merging additively would make a section able only to widen, and
+ *   the motivating case is "give this role LESS".
+ *
+ * `present` means the key exists, not that it is non-empty: `allow = []` in a
+ * section is a deliberate "this agent gets no allow patterns", and treating it
+ * as absent would silently restore the base's — turning an explicit narrowing
+ * into a widening, which is the one direction this must never fail.
+ */
+export function resolvePolicy(
+  base: ResolvedPolicy,
+  agents: Readonly<Record<string, AgentPolicyOverride>>,
+  agentType: string | undefined,
+): ResolvedPolicy {
+  if (agentType === undefined || agentType.length === 0) return base;
+  const override = agents[agentType];
+  if (override === undefined) return base;
+  return {
+    allow: override.allow ?? base.allow,
+    approveGroups: override.approve_groups ?? base.approveGroups,
+    deny: union(base.deny, override.deny),
+    denyGroups: union(base.denyGroups, override.deny_groups),
+  };
+}
+
+/** Order-preserving union. Base entries keep their positions so a deny's
+ *  reported pattern does not shuffle depending on which agent asked. */
+function union(base: readonly string[], extra: readonly string[] | undefined): readonly string[] {
+  if (extra === undefined || extra.length === 0) return base;
+  const seen = new Set(base);
+  const merged = [...base];
+  for (const e of extra) {
+    if (!seen.has(e)) {
+      seen.add(e);
+      merged.push(e);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Validate the `agents` table shape, throwing with an actionable message.
+ *
+ * Mirrors `validateAutoApprove`'s style: a malformed policy table must fail
+ * loudly at load rather than silently resolve to "no overrides", which would
+ * present as the agent quietly running under the base policy — the exact
+ * class of silent-degradation this epic keeps producing.
+ */
+export function validateAgents(value: unknown, configPath: string): void {
+  if (value === undefined) return;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Invalid auto_approve.agents in ${configPath}: must be a table keyed by agent type. Example:\n  [auto_approve.agents.Explore]\n  approve_groups = ["read-only", "net-read"]`,
+    );
+  }
+  for (const [agentType, section] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof section !== 'object' || section === null || Array.isArray(section)) {
+      throw new Error(
+        `Invalid auto_approve.agents.${agentType} in ${configPath}: must be a table. Example:\n  [auto_approve.agents.${agentType}]\n  approve_groups = ["read-only", "net-read"]`,
+      );
+    }
+    for (const key of ['allow', 'deny', 'approve_groups', 'deny_groups'] as const) {
+      const v = (section as Record<string, unknown>)[key];
+      if (v === undefined) continue;
+      if (!Array.isArray(v) || v.some((e) => typeof e !== 'string')) {
+        throw new Error(
+          `Invalid auto_approve.agents.${agentType}.${key} in ${configPath}: must be an array of strings, got ${JSON.stringify(v)}.`,
+        );
+      }
+    }
+    for (const key of Object.keys(section as Record<string, unknown>)) {
+      if (!['allow', 'deny', 'approve_groups', 'deny_groups'].includes(key)) {
+        // Loud, not ignored. A misspelled `approve_group` would otherwise leave
+        // the agent on the base policy while the config file plainly appears to
+        // grant something -- a doc/behaviour mismatch of exactly the kind
+        // ADR 0011 exists to stop shipping.
+        throw new Error(
+          `Unknown key auto_approve.agents.${agentType}.${key} in ${configPath}. Valid keys: allow, deny, approve_groups, deny_groups.`,
+        );
+      }
+    }
+  }
+}

--- a/packages/daemon/src/auto-approve/agent-policy.ts
+++ b/packages/daemon/src/auto-approve/agent-policy.ts
@@ -11,6 +11,7 @@
  * gets tested loosely.
  */
 
+import { isKnownGroup, knownGroupNames } from './permission-groups.ts';
 import type { AgentPolicyOverride } from './types.ts';
 
 /** The four deterministic lists, resolved for one request. */
@@ -104,6 +105,29 @@ export function validateAgents(value: unknown, configPath: string): void {
         throw new Error(
           `Invalid auto_approve.agents.${agentType}.${key} in ${configPath}: must be an array of strings, got ${JSON.stringify(v)}.`,
         );
+      }
+    }
+    // Group NAMES are checkable and must be checked, unlike agent names (no
+    // registry exists for those -- ADR 0025 records that). Skipping this was
+    // worse than a no-op: because `approve_groups` REPLACES, a typo does not
+    // merely fail to grant the group, it drops the agent's inherited base
+    // grants too. `approve_groups = ["net-reed"]` silently leaves that agent
+    // with less than the base, and the user-visible result is the 240s queue
+    // stall this feature exists to remove. The base path already warns for the
+    // same typo one section up, so the asymmetry was indefensible.
+    //
+    // WARN, not throw, matching the base. A throw reaches `cli.ts`'s exit(1),
+    // and under the `--install` LaunchAgent (`KeepAlive.SuccessfulExit=false`)
+    // that is a crash-restart loop over a one-character typo.
+    for (const key of ['approve_groups', 'deny_groups'] as const) {
+      const groups = (section as Record<string, unknown>)[key];
+      if (!Array.isArray(groups)) continue;
+      for (const g of groups) {
+        if (typeof g === 'string' && !isKnownGroup(g)) {
+          console.warn(
+            `[AutoApprove] Warning: unknown permission group "${g}" in auto_approve.agents.${agentType}.${key} (${configPath}); ignored. Known groups: ${knownGroupNames().join(', ')}.`,
+          );
+        }
       }
     }
     for (const key of Object.keys(section as Record<string, unknown>)) {

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -273,6 +273,10 @@ export interface AutoApproveEvaluator {
      *  `AutoApproveGateDeps.getPrecedent`; the matrix that bounds what a
      *  precedent may authorize lives inside the evaluator, not here. */
     precedent?: PrecedentReader,
+    /** ADR 0025: the hook's `agent_type`, selecting a
+     *  `[auto_approve.agents.<type>]` section for the deterministic layers.
+     *  Undefined = base policy, so every pre-0025 caller is unchanged. */
+    agentType?: string,
   ): Promise<AutoApproveResult>;
   /**
    * Abort an in-flight `evaluate`. With `evalId`, aborts ONLY when that id is the
@@ -312,6 +316,11 @@ export interface AutoApproveEvaluator {
   evaluateDeterministic?(
     toolName: string,
     toolInput: Record<string, unknown>,
+    /** ADR 0025: selects this agent's `[auto_approve.agents.<type>]` section.
+     *  This is the only layer a subagent reaches at hook time, so a per-agent
+     *  grant that did not arrive here would be unreachable for exactly the
+     *  requests it was written for. */
+    agentType?: string,
   ):
     | { decision: 'approve'; reasoning: string }
     | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
@@ -1432,7 +1441,15 @@ export class AutoApproveGate {
     // included) and answers it by PTY inject, or pushes a card the phone can
     // answer. That is the async route this hook response could never take.
     if (isSubagent) {
-      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      // ADR 0025: the agent's own section decides here. This is the ONLY layer
+      // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
+      // without this a per-agent grant would be unreachable for exactly the
+      // requests it was written for.
+      const deterministic = service?.evaluateDeterministic?.(
+        input.tool_name,
+        input.tool_input,
+        input.agent_type,
+      );
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
@@ -2068,6 +2085,10 @@ export class AutoApproveGate {
         true,
         this.authorityForEval(),
         this.precedentForEval(),
+        // ADR 0025: the same agent section that governs the hook-time path must
+        // govern the render-time one, or a parked request would be judged under
+        // a different policy than the one that declined to approve it.
+        input.agent_type,
       );
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] Parked-render eval threw; escalating:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1445,7 +1445,11 @@ export class AutoApproveGate {
       // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
       // without this a per-agent grant would be unreachable for exactly the
       // requests it was written for.
-      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
+      const deterministic = service?.evaluateDeterministic?.(
+        input.tool_name,
+        input.tool_input,
+        input.agent_type,
+      );
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,
@@ -2265,6 +2269,12 @@ export class AutoApproveGate {
     isSubagent: boolean,
     evalId?: number,
   ): Promise<AutoApproveResult | null> {
+    // ADR 0025: the second opinion re-runs `evaluateDeterministic`, so it needs
+    // the SAME agent policy the first eval used. Omitting it resolved to the
+    // BASE policy and silently undid a per-agent narrowing: a `pr-review`
+    // section restricting `approve_groups` is escalated by the first eval, then
+    // deterministically approved at 0ms by this one under the base groups --
+    // and logged as if the heavy model had agreed.
     const escalateModel = this.deps.escalateModel;
     const service = this.deps.service;
     if (!escalateModel || service === null) return null;
@@ -2280,6 +2290,7 @@ export class AutoApproveGate {
         isSubagent,
         this.authorityForEval(),
         this.precedentForEval(),
+        input.agent_type,
       );
     } catch (err) {
       logError(`[AutoApprove ${this.sessionTag}] escalate_model second opinion threw:`, err);

--- a/packages/daemon/src/auto-approve/auto-approve-gate.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-gate.ts
@@ -1445,11 +1445,7 @@ export class AutoApproveGate {
       // a subagent can reach at hook time (the LLM never runs -- ADR 0004), so
       // without this a per-agent grant would be unreachable for exactly the
       // requests it was written for.
-      const deterministic = service?.evaluateDeterministic?.(
-        input.tool_name,
-        input.tool_input,
-        input.agent_type,
-      );
+      const deterministic = service?.evaluateDeterministic?.(input.tool_name, input.tool_input);
       if (deterministic?.decision === 'approve') {
         log(
           `[Hooks] Subagent PermissionRequest answered allow at hook time (deterministic): agent=${input.agent_id?.slice(0, 8)} type=${input.agent_type} tool=${input.tool_name} - ${deterministic.reasoning}`,

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -10,6 +10,7 @@
  */
 
 import { errorToString } from '@remi/shared';
+import { resolvePolicy } from './agent-policy.ts';
 import { reconcileCounterfactual, shouldCounterfactual } from './authority-counterfactual.ts';
 import { enforceAuthorityBoundary } from './authority.ts';
 import { AuthorizationAssessment, matrixDecision } from './authorization-assessment.ts';
@@ -144,6 +145,8 @@ export class AutoApproveService {
   private readonly deny: readonly string[];
   private readonly approveGroups: readonly string[];
   private readonly denyGroups: readonly string[];
+  /** Per-agent-type overrides (ADR 0025). Empty = every agent uses the base. */
+  private readonly agents: Readonly<Record<string, import('./types.ts').AgentPolicyOverride>>;
   private readonly instructions: string;
   /** Strictness preset, threaded into the prompt's default guidelines (#966). */
   private readonly level: AutoApproveLevel;
@@ -266,6 +269,7 @@ export class AutoApproveService {
     this.deny = config.deny;
     this.approveGroups = config.approve_groups;
     this.denyGroups = config.deny_groups;
+    this.agents = config.agents ?? {};
     this.instructions = config.instructions;
     // #966: the LLM handles whatever no group covers, so its DEFAULT
     // GUIDELINES must agree with the level the user chose. Without this the
@@ -666,11 +670,24 @@ export class AutoApproveService {
   evaluateDeterministic(
     toolName: string,
     toolInput: Record<string, unknown>,
+    agentType?: string,
   ):
     | { decision: 'approve'; reasoning: string }
     | { decision: 'deny-covered'; reasoning: string; denySource: DenySource }
     | null {
-    const denyMatch = matchSubstringPattern(toolName, toolInput, this.deny);
+    // ADR 0025. Undefined agentType (main context, or a hook without one)
+    // resolves to the base, so every pre-0025 caller is unchanged.
+    const policy = resolvePolicy(
+      {
+        allow: this.allow,
+        deny: this.deny,
+        approveGroups: this.approveGroups,
+        denyGroups: this.denyGroups,
+      },
+      this.agents,
+      agentType,
+    );
+    const denyMatch = matchSubstringPattern(toolName, toolInput, policy.deny);
     if (denyMatch !== null) {
       return {
         decision: 'deny-covered',
@@ -682,7 +699,7 @@ export class AutoApproveService {
     // command to be covered and is right for the allow question below; asking
     // it a deny question meant `mkdir /tmp/x && ls -la` defeated a
     // `deny_groups = ["fs-write"]` that stopped the bare `mkdir`.
-    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, this.denyGroups);
+    const denyGroupMatch = matchGroupsBroad(toolName, toolInput, policy.denyGroups);
     if (denyGroupMatch !== null) {
       return {
         decision: 'deny-covered',
@@ -690,11 +707,11 @@ export class AutoApproveService {
         denySource: { kind: 'config', pattern: denyGroupMatch },
       };
     }
-    const allowMatch = matchAllowPattern(toolName, toolInput, this.allow);
+    const allowMatch = matchAllowPattern(toolName, toolInput, policy.allow);
     if (allowMatch !== null) {
       return { decision: 'approve', reasoning: `allow-matched pattern: "${allowMatch}"` };
     }
-    const approveGroupMatch = matchGroups(toolName, toolInput, this.approveGroups);
+    const approveGroupMatch = matchGroups(toolName, toolInput, policy.approveGroups);
     if (approveGroupMatch !== null) {
       return { decision: 'approve', reasoning: `approve-matched group: "${approveGroupMatch}"` };
     }
@@ -757,6 +774,13 @@ export class AutoApproveService {
      * omits it behaves exactly as it did pre-#976.
      */
     precedent?: PrecedentReader,
+    /**
+     * The hook's `agent_type` (ADR 0025). Selects a
+     * `[auto_approve.agents.<type>]` section for the deterministic layers.
+     * Undefined = main context, or a subagent hook that carried none; both
+     * resolve to the base policy, so every pre-0025 caller is unchanged.
+     */
+    agentType?: string,
   ): Promise<AutoApproveResult> {
     const start = Date.now();
     // #820: push the idle-unload deadline out. Called at the START so a long
@@ -790,7 +814,7 @@ export class AutoApproveService {
       // Deny/allow/group: checked first, always win, no LLM call. Shared with
       // the gate's subagent hook-time path (#1024) via `evaluateDeterministic`
       // so the two can never drift apart -- see that method's doc.
-      const deterministic = this.evaluateDeterministic(toolName, toolInput);
+      const deterministic = this.evaluateDeterministic(toolName, toolInput, agentType);
       if (deterministic !== null) {
         if (deterministic.decision === 'deny-covered') {
           this.logFn(`${prefix} DENIED ${toolName}: ${deterministic.reasoning} (0ms)`);

--- a/packages/daemon/src/auto-approve/engine-host.ts
+++ b/packages/daemon/src/auto-approve/engine-host.ts
@@ -66,13 +66,60 @@ import { errorToString } from '@remi/shared';
 import { ensureHelperInstalled } from './engine-install.ts';
 import { probeEngine } from './engine-models.ts';
 import { FileEnginePidStore, spawnDetachedEngine } from './engine-process.ts';
+import {
+  LLAMACPP_LOG_FILE,
+  llamaServerArgs,
+  llamaServerMissingHint,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from './llamacpp-backend.ts';
 
 /** How remi relates to the engine on its port. */
 export type EngineOwnership = 'owned' | 'shared';
 
+/**
+ * Which local backend answers on the port (#822). The platform probe decides —
+ * Apple Silicon gets the Yooz engine, Linux gets llama.cpp — and by
+ * construction the two never coexist, so this is a discriminator, not a
+ * preference.
+ *
+ * Everything `EngineHost` does ABOVE the launch is identical for both: attach
+ * first, claim before spawning, resolve the redundant-start race, never reap on
+ * exit. Only the argv, the readiness question and how the executable is
+ * acquired differ, which is why this is a field rather than a subclass.
+ */
+export type EngineBackendKind = 'yooz' | 'llamacpp';
+
+/**
+ * Reachability, which is ALL this class asks of a probe.
+ *
+ * Narrower than `probeEngine`'s return on purpose: `EngineHost` reads only
+ * `.reachable` at every one of its four probe sites and never touches
+ * `.status`. Typing the seam as what it actually uses lets llama.cpp's
+ * `/health` satisfy it without inventing an `EngineStatus` it cannot produce
+ * (#822 — llama-server serves none of the `/v1/llm/*` control plane).
+ * `probeEngine` remains assignable, so nothing on the engine path changes.
+ */
+export type ReachabilityProbe = (
+  baseUrl: string,
+  timeoutMs?: number,
+) => Promise<{ readonly reachable: boolean }>;
+
 export interface EngineHostConfig {
   /** Loopback root, e.g. `http://127.0.0.1:19924`. */
   readonly baseUrl: string;
+  /**
+   * Which backend to launch and probe. Defaults to `yooz` so every existing
+   * construction keeps its behaviour unchanged.
+   */
+  readonly backend?: EngineBackendKind;
+  /**
+   * The model id, needed only by `llamacpp`: llama-server loads one GGUF at
+   * process start (`-hf`), so the id is a LAUNCH argument there rather than a
+   * per-request field. On the engine path the model is chosen per request and
+   * this is ignored.
+   */
+  readonly model?: string | undefined;
   /** `owned` (spawn + supervise) or `shared` (read-only guest). */
   readonly ownership: EngineOwnership;
   /**
@@ -101,11 +148,11 @@ export interface EngineHostDeps {
    * engine survives this process; it returns only the pid because there is no
    * child handle to hold onto afterwards. Tests supply a fake.
    */
-  readonly spawn?: (path: string, env: Record<string, string>) => number;
+  readonly spawn?: (path: string, args: readonly string[], env: Record<string, string>) => number;
   /** Kill a pid. Needed on the failure paths: a helper we started that lost
    *  the race, or never bound, must not be left running. */
   readonly kill?: (pid: number) => void;
-  readonly probe?: typeof probeEngine;
+  readonly probe?: ReachabilityProbe;
   readonly sleep?: (ms: number) => Promise<void>;
   /** Pidfile seam (`~/.remi/engine.pid` in production). */
   readonly pidStore?: PidStore;
@@ -150,7 +197,7 @@ export class EngineHost {
   /** In-flight helper download, so concurrent callers share one fetch. */
   private installInFlight: Promise<string | undefined> | undefined;
   private readonly log: EngineHostDeps['log'];
-  private readonly probe: typeof probeEngine;
+  private readonly probe: ReachabilityProbe;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly spawnFn: EngineHostDeps['spawn'];
   private readonly killFn: (pid: number) => void;
@@ -162,12 +209,34 @@ export class EngineHost {
     deps: EngineHostDeps,
   ) {
     this.log = deps.log;
-    this.probe = deps.probe ?? probeEngine;
+    // Probe by backend: llama.cpp has never served `/v1/llm/status`, so the
+    // engine probe would report a permanently-unreachable server that is in
+    // fact answering evals (#822).
+    this.probe = deps.probe ?? (this.isLlamaCpp ? probeLlamaCpp : probeEngine);
     this.sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
     this.spawnFn = deps.spawn;
     this.killFn = deps.kill ?? ((pid) => process.kill(pid));
     this.pids = deps.pidStore;
-    this.installFn = deps.installHelper ?? (() => ensureHelperInstalled({ log: this.log }));
+    // Acquisition by backend. The engine FETCHES its helper (#834, a pinned
+    // artifact remi controls); llama.cpp only RESOLVES one the user installed.
+    // remi deliberately does not download llama-server -- see the module doc in
+    // llamacpp-backend.ts for why that line is drawn here.
+    this.installFn =
+      deps.installHelper ??
+      (this.isLlamaCpp
+        ? () => Promise.resolve(resolveLlamaServer())
+        : () => ensureHelperInstalled({ log: this.log }));
+  }
+
+  private get isLlamaCpp(): boolean {
+    return this.config.backend === 'llamacpp';
+  }
+
+  /** How this backend is named in logs and reasons. Not cosmetic: "the engine
+   *  did not come up" pointing at a llama-server is the wrong-but-plausible
+   *  description ADR 0011 is about. */
+  private get label(): string {
+    return this.isLlamaCpp ? 'llama-server' : 'engine';
   }
 
   /** True when remi may load/unload/delete models on this engine. The single
@@ -218,6 +287,16 @@ export class EngineHost {
       return { kind: 'unavailable', reason };
     }
 
+    // llama.cpp loads ONE model at process start, so an empty id is not a
+    // degraded launch -- it is `-hf ''`, which fails in the child where the
+    // only trace is a log file nobody is looking at. The engine path cannot hit
+    // this: it picks a model per request, long after startup.
+    if (this.isLlamaCpp && (this.config.model === undefined || this.config.model.length === 0)) {
+      const reason = `cannot start ${this.label}: auto_approve.model is empty and llama.cpp needs the model id at launch (it serves one GGUF per process)`;
+      this.log(`[Engine] ${reason}`);
+      return { kind: 'unavailable', reason };
+    }
+
     // Resolve, then acquire. `engine_path` wins when set -- someone pointing at
     // their own build is making a deliberate choice and must not have it
     // second-guessed by a download. Otherwise use the helper remi has already
@@ -234,7 +313,14 @@ export class EngineHost {
       helperPath = await this.installHelper();
     }
     if (helperPath === undefined || helperPath.length === 0) {
-      const reason = `no engine on ${this.config.baseUrl} and no helper available to start it`;
+      // Name the ACTIONABLE thing. On the engine path "no helper available"
+      // means a download failed and retrying may fix it; on llama.cpp it means
+      // the user has not installed anything, and remi will never install it for
+      // them (#822) -- so the generic wording would leave them waiting for an
+      // acquisition that is never coming.
+      const reason = this.isLlamaCpp
+        ? `no ${this.label} on ${this.config.baseUrl}: ${llamaServerMissingHint()}`
+        : `no engine on ${this.config.baseUrl} and no helper available to start it`;
       this.log(`[Engine] ${reason}`);
       return { kind: 'unavailable', reason };
     }
@@ -293,9 +379,17 @@ export class EngineHost {
    * booting daemon and the two would fight over the port.
    */
   static real(config: EngineHostConfig, log: (msg: string) => void): EngineHost {
+    // Same pidfile for both backends, deliberately: it is a mutual-exclusion
+    // record for "something remi started owns port 19924", and only one backend
+    // can hold that port. Separate records would let a stale engine entry and a
+    // live llama-server entry coexist and both believe they had the claim.
+    const logFile = config.backend === 'llamacpp' ? LLAMACPP_LOG_FILE : undefined;
     return new EngineHost(config, {
       log,
-      spawn: spawnDetachedEngine,
+      spawn:
+        logFile === undefined
+          ? spawnDetachedEngine
+          : (p, args, env) => spawnDetachedEngine(p, args, env, logFile),
       pidStore: new FileEnginePidStore(),
     });
   }
@@ -325,17 +419,8 @@ export class EngineHost {
 
     let pid: number;
     try {
-      const cache = this.config.modelCache;
-      pid = spawnFn(helperPath, {
-        // Headless: no menu-bar UI for a helper nobody looks at.
-        YOOZ_ENGINE_HEADLESS: '1',
-        // remi's reserved port, in every configuration (see the module doc).
-        YOOZ_ENGINE_PORT: String(portOf(this.config.baseUrl)),
-        // Weights location, via the standard HuggingFace variable the engine
-        // already reads. Omitted entirely when unset so the engine keeps its
-        // own default rather than being handed an empty path.
-        ...(cache !== undefined && cache.length > 0 ? { HF_HUB_CACHE: cache } : {}),
-      });
+      const launch = this.buildLaunch();
+      pid = spawnFn(helperPath, launch.args, launch.env);
     } catch (err) {
       // Release the claim we took above, or the next attempt is blocked by a
       // record for a process that never existed.
@@ -389,6 +474,42 @@ export class EngineHost {
     const reason = `engine started (pid ${pid}) but never answered on ${this.config.baseUrl}`;
     this.log(`[Engine] ${reason}`);
     return { kind: 'unavailable', reason };
+  }
+
+  /**
+   * How this backend is launched: argv plus environment.
+   *
+   * The split is not arbitrary. The Yooz engine is configured entirely through
+   * the environment and takes NO arguments (`spawn(helperPath, [], ...)` was
+   * literal before #822); llama.cpp is the mirror image, taking everything on
+   * the command line. Keeping both in one place means the difference is data a
+   * reader can see at once, rather than a branch buried in the spawn path.
+   */
+  private buildLaunch(): { args: string[]; env: Record<string, string> } {
+    const cache = this.config.modelCache;
+    if (this.isLlamaCpp) {
+      return {
+        args: llamaServerArgs(this.config.model ?? '', portOf(this.config.baseUrl)),
+        // `LLAMA_CACHE` is llama.cpp's own download location for `-hf`, NOT
+        // `HF_HUB_CACHE` (which is the Python huggingface_hub variable the Yooz
+        // engine reads). Naming the wrong one would silently ignore a
+        // configured cache and re-download multi-GB weights into the default.
+        env: cache !== undefined && cache.length > 0 ? { LLAMA_CACHE: cache } : {},
+      };
+    }
+    return {
+      args: [],
+      env: {
+        // Headless: no menu-bar UI for a helper nobody looks at.
+        YOOZ_ENGINE_HEADLESS: '1',
+        // remi's reserved port, in every configuration (see the module doc).
+        YOOZ_ENGINE_PORT: String(portOf(this.config.baseUrl)),
+        // Weights location, via the standard HuggingFace variable the engine
+        // already reads. Omitted entirely when unset so the engine keeps its
+        // own default rather than being handed an empty path.
+        ...(cache !== undefined && cache.length > 0 ? { HF_HUB_CACHE: cache } : {}),
+      },
+    };
   }
 
   /**

--- a/packages/daemon/src/auto-approve/engine-process.ts
+++ b/packages/daemon/src/auto-approve/engine-process.ts
@@ -216,14 +216,21 @@ export class FileEnginePidStore implements PidStore {
  */
 export function spawnDetachedEngine(
   helperPath: string,
+  args: readonly string[],
   env: Record<string, string>,
   logFile: string = ENGINE_LOG_FILE,
 ): number {
   fs.mkdirSync(path.dirname(logFile), { recursive: true });
   const logFd = fs.openSync(logFile, 'a');
   try {
-    fs.writeSync(logFd, `\n--- Engine starting at ${new Date().toISOString()} ---\n`);
-    const child = spawn(helperPath, [], {
+    // Name the executable rather than saying "Engine": since #822 this also
+    // launches `llama-server`, and a log banner that calls it the engine is the
+    // kind of wrong-but-plausible description ADR 0011 exists to prevent.
+    fs.writeSync(
+      logFd,
+      `\n--- ${path.basename(helperPath)} starting at ${new Date().toISOString()} ---\n`,
+    );
+    const child = spawn(helperPath, [...args], {
       detached: true,
       stdio: ['ignore', logFd, logFd],
       env: { ...process.env, ...env },

--- a/packages/daemon/src/auto-approve/index.ts
+++ b/packages/daemon/src/auto-approve/index.ts
@@ -13,7 +13,23 @@ export type { AuthorityBoundaryResult } from './authority.ts';
 export { enforceDenyFloor, matchesCatastrophicPattern } from './deny-floor.ts';
 export type { DenyFloorResult } from './deny-floor.ts';
 export { EngineHost } from './engine-host.ts';
-export type { EngineHostState, EngineOwnership, PidStore } from './engine-host.ts';
+export type {
+  EngineBackendKind,
+  EngineHostState,
+  EngineOwnership,
+  PidStore,
+  ReachabilityProbe,
+} from './engine-host.ts';
+// #822: the boot path asks whether a llama-server exists before telling the
+// user anything about it, so both the probe-for-presence and the remedy text
+// are exported here rather than reached for through a deep import.
+export {
+  LLAMACPP_LOG_FILE,
+  llamaServerArgs,
+  llamaServerMissingHint,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from './llamacpp-backend.ts';
 export {
   ENGINE_LOG_FILE,
   ENGINE_PID_FILE,

--- a/packages/daemon/src/auto-approve/llamacpp-backend.ts
+++ b/packages/daemon/src/auto-approve/llamacpp-backend.ts
@@ -1,0 +1,167 @@
+/**
+ * The llama.cpp half of the local-eval backend (#822 Phase B, slice 1).
+ *
+ * `EngineHost` (#818) already owns the hard part — attach-first, claim before
+ * spawning, resolve the redundant-start race, never reap on exit — and none of
+ * that is engine-specific. So llama.cpp reuses the class outright and supplies
+ * only what actually differs: how the process is launched, and how you ask it
+ * whether it is up.
+ *
+ * WHAT REMI DOES NOT DO HERE, deliberately. It does not download or install
+ * `llama-server`. #822's own scope says "remi owns download + process
+ * lifetime", and this module implements the second half only. Supervising a
+ * binary the user installed is a different trust proposition from fetching and
+ * executing a third-party binary across an arch matrix: the macOS path fetches
+ * a PINNED artifact from a release remi controls (#834), which llama.cpp is
+ * not. The install stays a documented step; the nohup does not.
+ *
+ * The GGUF itself is NOT remi's job either, which is a real narrowing of what
+ * #822 assumed ("Download is remi's job. No engine to auto-pull from
+ * HuggingFace"). `-hf` makes llama.cpp pull from HuggingFace on first run, so
+ * the model half of Phase B is already solved by the transport.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+
+const REMI_DIR = path.join(os.homedir(), '.remi');
+
+/** Where a remi-started `llama-server`'s stdout/stderr go. Separate from
+ *  `engine.log` so the two backends' diagnostics never interleave — only one
+ *  can run per machine (the platform probe decides), but a machine that has
+ *  run both over its life should not have to untangle one file. */
+export const LLAMACPP_LOG_FILE = path.join(REMI_DIR, 'llama-server.log');
+
+/** The executable remi looks for. Not configurable by design: `engine_path`
+ *  already exists for "point at my own build", and it is backend-agnostic. */
+export const LLAMA_SERVER_BIN = 'llama-server';
+
+/**
+ * Reachability against `llama-server`.
+ *
+ * Deliberately NOT `probeEngine`: that asks `/v1/llm/status`, which is the Yooz
+ * engine's control plane and something llama.cpp has never served (#822 —
+ * "llama-server has none of /v1/llm/{models,status,preload,unload}"). Pointing
+ * the engine probe at it would report a permanently-unreachable backend that is
+ * in fact answering evals perfectly well.
+ *
+ * `/health` is the right question and it distinguishes the two states that
+ * matter during startup: 503 while the model is still loading, 200 once it can
+ * serve. `waitForReady` polls this, so a cold multi-GB load reads as "not ready
+ * yet" rather than as a failure.
+ *
+ * Never throws, for the same reason `probeEngine` never throws: "nothing is
+ * listening" must be a reportable value, not an exception that escapes into a
+ * silent permanent escalation (#818).
+ */
+export async function probeLlamaCpp(
+  baseUrl: string,
+  timeoutMs = 2_000,
+): Promise<{ readonly reachable: boolean; readonly reason?: string }> {
+  const url = healthUrl(baseUrl);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    // 200 = ready to serve. 503 = alive but still loading the GGUF, which is
+    // NOT reachable for our purposes: dispatching an eval into a loading server
+    // would burn the hook budget waiting. Report it as unreachable-with-reason
+    // so the startup poll keeps waiting instead of giving up.
+    if (res.ok) return { reachable: true };
+    return { reachable: false, reason: `HTTP ${res.status} from ${url}` };
+  } catch (err) {
+    return { reachable: false, reason: errorToString(err) };
+  }
+}
+
+/**
+ * `<origin>/health` from an OpenAI-style base URL.
+ *
+ * The llamacpp base URL carries a `/v1` suffix (`llm-client.ts`'s
+ * `PROVIDER_URLS`) because it is dispatched through the `openai` kind, which
+ * appends `/chat/completions` directly. `/health` is served at the ROOT, not
+ * under `/v1`, so naively joining would request `/v1/health` — the same
+ * `/v1/v1/...` class of bug AGENTS.md already records for `warmModel`.
+ */
+export function healthUrl(baseUrl: string): string {
+  try {
+    return `${new URL(baseUrl).origin}/health`;
+  } catch {
+    // A malformed base URL is a config error that belongs to the caller; the
+    // probe's contract is to report unreachable, not to throw. Returning the
+    // input unchanged makes the fetch fail cleanly with the real reason.
+    return baseUrl;
+  }
+}
+
+/**
+ * argv for `llama-server`.
+ *
+ * `-hf <repo>:<quant>` pulls from HuggingFace on first run and reuses the cache
+ * after. The quant suffix is load-bearing: `-hf` with no tag prefers
+ * `Q4_K_M`/`Q8_0` and the YoozLabs repos publish only `Q4_0`, so a bare repo id
+ * resolves no file (see `defaultModel`).
+ *
+ * `--host` is pinned to loopback and NOT derived from `daemon.bind`. The eval
+ * backend is remi's own sidecar, not a service anyone else may reach: widening
+ * it would hand any host that can reach the port a free LLM, and after #880
+ * that is precisely the class of default this repo just spent a release
+ * closing.
+ */
+export function llamaServerArgs(model: string, port: number, host = '127.0.0.1'): string[] {
+  return ['-hf', model, '--host', host, '--port', String(port)];
+}
+
+/**
+ * Find `llama-server` on PATH.
+ *
+ * Returns the absolute path, or undefined when it is not installed — which
+ * `EngineHost` turns into a reported `unavailable`, never a throw. Scans PATH
+ * by hand rather than shelling out to `which`/`where`: this runs on the boot
+ * path, a subprocess per boot to answer a filesystem question is waste, and the
+ * seam stays synchronous so the caller does not have to be async to ask.
+ */
+export function resolveLlamaServer(
+  env: NodeJS.ProcessEnv = process.env,
+  isExecutable: (p: string) => boolean = defaultIsExecutable,
+): string | undefined {
+  const rawPath = env['PATH'];
+  if (rawPath === undefined || rawPath.length === 0) return undefined;
+  // `delimiter` rather than a literal ':' — Windows uses ';' and, while no
+  // local backend exists there today (`detectLocalLLMPlatform` returns
+  // 'unsupported'), a resolver that silently returns nothing on one platform
+  // for a reason unrelated to the actual question is a trap for whoever adds
+  // that support later.
+  for (const dir of rawPath.split(path.delimiter)) {
+    if (dir.length === 0) continue;
+    const candidate = path.join(dir, LLAMA_SERVER_BIN);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function defaultIsExecutable(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    // A directory can carry the execute bit (it means "traversable"), so the
+    // access check alone would happily return a path that cannot be spawned.
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What to tell a user who has no `llama-server`.
+ *
+ * Shared by the boot path and the host's unavailable reason so the two can
+ * never drift into naming different remedies — the failure mode AGENTS.md
+ * records for `help.ts` still claiming `default: 0.0.0.0` after the default
+ * moved.
+ */
+export function llamaServerMissingHint(): string {
+  return `${LLAMA_SERVER_BIN} is not on PATH, so remi has nothing to supervise. Install it once (remi does not download it, #822): "brew install llama.cpp", your distro's package, or a prebuilt binary from github.com/ggml-org/llama.cpp/releases. remi starts and stops it for you after that.`;
+}

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -860,6 +860,19 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'uniq',
       'jq',
       'ls',
+      // Pure lookups and string operations, added after a live session showed
+      // them sinking otherwise-covered compound reads. None opens a file for
+      // writing, none takes an output-path flag, and none executes what it
+      // finds -- `which` resolves a PATH entry, it does not run it.
+      'which',
+      'basename',
+      'dirname',
+      'realpath',
+      // macOS Spotlight query. Read-only by construction (`mdutil` is the
+      // mutating sibling and is deliberately absent).
+      'mdfind',
+      'du',
+      'df',
     ],
   },
   'vcs-read': {

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -931,6 +931,34 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       // code by design (and may write coverage/report artifacts).
     ],
   },
+  /**
+   * Outbound reads (ADR 0025). In NO level preset and in no shipped default —
+   * every preset stays entirely local, and this one must be asked for by name.
+   *
+   * It exists because `WebFetch`/`WebSearch` previously matched nothing at all,
+   * so every web call from every subagent parked, rendered and entered the
+   * serial eval queue. Measured on a live 0.7.6 session: a fan-out of five
+   * concurrent `general-purpose` agents saturated that queue and the waiters
+   * escalated on `queue_timeout` WITHOUT the LLM ever running. The most common
+   * thing a research subagent does took the most expensive path available.
+   *
+   * Deliberately NOT added to `trusted`: that level is chosen for git mutation
+   * and proved-derived deletion, and someone who selected it for those reasons
+   * would silently gain arbitrary outbound egress on upgrade — the exact
+   * quiet-widening ADR 0023 fixed in `matchGroups` one release earlier.
+   *
+   * The asymmetry that settles it: a wrongly-escalated fetch is a nuisance, a
+   * wrongly-approved one is an exfiltration channel. `WebFetch` takes an
+   * arbitrary URL and a subagent is the context no human is watching.
+   */
+  'net-read': {
+    tools: ['WebFetch', 'WebSearch'],
+    // No commands. `curl`/`wget` are deliberately absent: they are general
+    // process-executing tools whose flags write files (`-o`, `-O`) and whose
+    // output is routinely piped into a shell. Covering them here would smuggle
+    // a write and an exec path into a group whose name promises a read.
+    commands: [],
+  },
   // --- Write-side groups (#959). Opt-in via `approve_groups`; none is on by
   // --- default, so this addition changes no shipped behavior on its own.
   'fs-write': {

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -16,35 +16,41 @@
 /** Benign segments that may appear in a compound command without needing coverage. */
 export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
 
-/**
- * A segment that is ENTIRELY variable assignments, e.g. `S=/tmp/x` or
- * `A=1 B=2`. Such a segment runs no command at all, so it needs no coverage.
+/*
+ * ATTEMPT 5, REVERTED BEFORE MERGE: "a segment whose every word is an
+ * assignment runs no command, so it needs no coverage."
  *
- * Measured cause of escalation: agents habitually open a script by assigning a
- * path, and `SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"` matched NOTHING — because
- * `matchCoveredCommand` requires every segment covered and an assignment
- * matched neither a neutral prefix nor a read prefix. The rest of the command
- * was pure `ls`/`cat`, so an 8-second LLM eval was spent on a read.
+ * It rejected `PATH=/evil ls` (the glued form) and AUTO-APPROVED the
+ * semicolon form, which is strictly worse because a bare assignment persists
+ * for every later segment:
  *
- * EVERY word must be an assignment, and that is the whole safety argument.
- * An assignment PREFIX to a command (`PATH=/evil ls`, `LD_PRELOAD=x cat f`) is
- * not inert: it runs `ls`, and it chooses WHICH `ls`. Accepting a segment that
- * merely STARTS with an assignment would auto-approve exactly that, so the
- * predicate is all-or-nothing and a trailing command disqualifies the segment.
+ *     PATH=/tmp/evil ls     -> escalate            (guarded)
+ *     PATH=/tmp/evil; ls    -> APPROVE read-only:ls  at 0ms
  *
- * Command substitution needs no handling here: `hasShellControl` has already
- * rejected the segment for `$(…)` and backticks before this is reached, so
- * `FOO=$(rm -rf /)` never gets this far. That ordering is load-bearing — this
- * predicate on its own would call it inert.
+ * `splitCompound` splits on `;`/`&&`/`||`/newline, so identical shell
+ * semantics arrive as two segments — an "inert" assignment plus a covered
+ * read. Verified against real bash: both spellings run the attacker's binary
+ * (`PATH`/`HOME` are already exported, so a bare assignment keeps the export
+ * attribute). `export PATH=…; git status` was a second route, since `export`
+ * is peeled by `stripShellGrammar` first. This lands on `read-only`, which is
+ * in EVERY preset including the default, and via #1024 is answered at hook
+ * time for a subagent with no render and no card.
+ *
+ * This is attempt (1) of the post-mortem below, and that post-mortem's
+ * conclusion stands: no property of an assignment inspected IN ISOLATION
+ * separates benign from dangerous, because the danger is what the assignment
+ * does to LATER segments. A correct fix must carry inertness FORWARD — a
+ * pure-assignment segment poisoning every subsequent non-neutral segment, the
+ * way `artifactCleanPoisonWalk` poisons on `cd` — not judge the segment alone.
+ * Name-denylisting (`PATH`/`LD_*`/`BASH_ENV`/…) is item (2) and is rejected
+ * there.
+ *
+ * Do not re-add without the forward-poison walk AND test cases in the `;`,
+ * `&&` and newline spellings. The reverted version's own test block was named
+ * "an assignment PREFIX to a command is NOT inert" and pinned five cases,
+ * every one the glued spelling that already worked — so it passed green while
+ * the hole was open.
  */
-export function isPureAssignment(body: string): boolean {
-  const words = body.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return false;
-  // NAME=..., POSIX name rules. The value may be empty (`FOO=`) and may be
-  // quoted; anything after the first `=` is data, not a command, because a
-  // substitution would already have been vetoed above.
-  return words.every((w) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(w));
-}
 
 /**
  * Shell keywords that PREFIX a real command (#999).
@@ -714,7 +720,7 @@ export function matchCoveredCommand(
     const stripped = stripShellGrammar(seg);
     if (stripped.structural) continue;
     const body = stripped.command;
-    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null || isPureAssignment(body)) {
+    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null) {
       // Neutral segments are vetoed before they can be waved through. Ordering
       // note: `extraVeto` used to run ahead of this neutral check for EVERY
       // segment, so moving it inside is behavior-preserving only because a

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -17,6 +17,36 @@
 export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
 
 /**
+ * A segment that is ENTIRELY variable assignments, e.g. `S=/tmp/x` or
+ * `A=1 B=2`. Such a segment runs no command at all, so it needs no coverage.
+ *
+ * Measured cause of escalation: agents habitually open a script by assigning a
+ * path, and `SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"` matched NOTHING — because
+ * `matchCoveredCommand` requires every segment covered and an assignment
+ * matched neither a neutral prefix nor a read prefix. The rest of the command
+ * was pure `ls`/`cat`, so an 8-second LLM eval was spent on a read.
+ *
+ * EVERY word must be an assignment, and that is the whole safety argument.
+ * An assignment PREFIX to a command (`PATH=/evil ls`, `LD_PRELOAD=x cat f`) is
+ * not inert: it runs `ls`, and it chooses WHICH `ls`. Accepting a segment that
+ * merely STARTS with an assignment would auto-approve exactly that, so the
+ * predicate is all-or-nothing and a trailing command disqualifies the segment.
+ *
+ * Command substitution needs no handling here: `hasShellControl` has already
+ * rejected the segment for `$(…)` and backticks before this is reached, so
+ * `FOO=$(rm -rf /)` never gets this far. That ordering is load-bearing — this
+ * predicate on its own would call it inert.
+ */
+export function isPureAssignment(body: string): boolean {
+  const words = body.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return false;
+  // NAME=..., POSIX name rules. The value may be empty (`FOO=`) and may be
+  // quoted; anything after the first `=` is data, not a command, because a
+  // substitution would already have been vetoed above.
+  return words.every((w) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(w));
+}
+
+/**
  * Shell keywords that PREFIX a real command (#999).
  *
  * Every one of these is followed by a command that actually runs, so the ONLY
@@ -684,7 +714,7 @@ export function matchCoveredCommand(
     const stripped = stripShellGrammar(seg);
     if (stripped.structural) continue;
     const body = stripped.command;
-    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null) {
+    if (matchPrefix(body, NEUTRAL_PREFIXES) !== null || isPureAssignment(body)) {
       // Neutral segments are vetoed before they can be waved through. Ordering
       // note: `extraVeto` used to run ahead of this neutral check for EVERY
       // segment, so moving it inside is behavior-preserving only because a

--- a/packages/daemon/src/auto-approve/types.ts
+++ b/packages/daemon/src/auto-approve/types.ts
@@ -107,6 +107,30 @@ export type MultiChoiceMode = 'skip' | 'evaluate';
  */
 export const DEFAULT_ALWAYS_ESCALATE_TOOLS: readonly string[] = ['AskUserQuestion', 'ExitPlanMode'];
 
+/**
+ * One agent type's policy overrides (ADR 0025).
+ *
+ * Every key optional: a section that sets only `approve_groups` leaves `allow`
+ * and the deny side inheriting the base, so the common case ("this role also
+ * gets net-read") is one line.
+ *
+ * The merge is NOT uniform, and the asymmetry is the security contract:
+ *
+ * - `deny` / `deny_groups` UNION with the base. A per-agent section must never
+ *   be able to weaken a machine-wide prohibition, so adding one cannot remove
+ *   a deny. Pinned by test, per ADR 0025's verification obligation.
+ * - `allow` / `approve_groups` REPLACE the base. Per-role scoping is the point:
+ *   if these merged additively, a section could only ever widen, and "give
+ *   pr-review LESS than the base" — the case that motivated the feature —
+ *   would be inexpressible.
+ */
+export interface AgentPolicyOverride {
+  readonly allow?: readonly string[];
+  readonly deny?: readonly string[];
+  readonly approve_groups?: readonly string[];
+  readonly deny_groups?: readonly string[];
+}
+
 /** Configuration for the auto-approve feature */
 export interface AutoApproveConfig {
   readonly enabled: boolean;
@@ -190,6 +214,29 @@ export interface AutoApproveConfig {
    * Default: empty.
    */
   readonly deny_groups: readonly string[];
+  /**
+   * Per-agent-type policy overrides (ADR 0025), keyed by the hook's
+   * `agent_type` (`Explore`, `general-purpose`, `pr-review`, ...).
+   *
+   * ```toml
+   * [auto_approve.agents.Explore]
+   * approve_groups = ["read-only", "vcs-read", "net-read"]
+   * ```
+   *
+   * Exists because the deterministic layers are the ONLY ones a subagent can
+   * reach at hook time (ADR 0004: an `agent_id`-tagged request never sees the
+   * LLM there), so "let research agents read the web, and nothing else" was
+   * previously inexpressible except as a machine-wide grant.
+   *
+   * Empty object = no overrides; every agent uses the base policy, which is
+   * exactly the pre-ADR-0025 behaviour.
+   *
+   * OPTIONAL rather than required-and-defaulted, deliberately: the service
+   * already reads it as `config.agents ?? {}`, and making it required would
+   * force a meaningless `agents: {}` into every existing construction site
+   * (and every test fixture) to assert something none of them are about.
+   */
+  readonly agents?: Readonly<Record<string, AgentPolicyOverride>>;
   /**
    * Natural-language guidance appended to the LLM system prompt.
    * Lets users steer the LLM for ambiguous cases not covered by allow/deny.

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -192,6 +192,10 @@ import {
 import type { RemiConfig } from './config/index.ts';
 import { ForeignSessionEscalator, HookConfigManager, HookServer } from './hooks/index.ts';
 import type { HookInput, PermissionRequestHookInput, StopHookInput } from './hooks/index.ts';
+// Static, unlike the publisher below it: this is a pure decision with no
+// side effects and nothing to load, so there is nothing for a dynamic import
+// to defer -- and it is needed on the path where mDNS never starts at all.
+import { mdnsSuppression, mdnsSuppressionMessage } from './mdns/advertise-decision.ts';
 import { DeviceTokenStore } from './notifications/device-token-store.ts';
 import type { NotificationDispatcher } from './notifications/notification-dispatcher.ts';
 import { sendPushTrigger } from './notifications/push-client.ts';
@@ -1624,7 +1628,21 @@ const wrapperPtyGate = new PtyQuiescenceGate();
 async function startMdnsIfNeeded(
   logFn: (msg: string) => void,
 ): Promise<import('./mdns/mdns-publisher.ts').MdnsPublisher | null> {
-  if (cliNoMdns || !remiConfig.network.mdns || isLocalhostBind) return null;
+  // #1051: say WHICH condition suppressed it. This used to be a bare
+  // `return null` while every other exit from this function logged, and since
+  // #880 moved the bind default to loopback it became the path every stock
+  // install takes -- so the daemon silently stopped being discoverable and
+  // nothing in its own output said why.
+  const suppression = mdnsSuppression({
+    cliNoMdns,
+    configMdns: remiConfig.network.mdns,
+    isLocalhostBind,
+    bindHost,
+  });
+  if (suppression !== null) {
+    logFn(mdnsSuppressionMessage(suppression));
+    return null;
+  }
   try {
     const { MdnsPublisher } = await import('./mdns/mdns-publisher.ts');
     const publisher = new MdnsPublisher({

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.7-dev.1'; // REMI_COMPILED_VERSION
+      return '0.7.7-dev.2'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.7-dev.1'; // REMI_COMPILED_VERSION
+    return '0.7.7-dev.2'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.6'; // REMI_COMPILED_VERSION
+      return '0.7.7-dev.1'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.6'; // REMI_COMPILED_VERSION
+    return '0.7.7-dev.1'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -1743,6 +1743,29 @@ async function createNewSession(
           `[QuestionPresenceTracker] gate cleanup for superseded ${questionId.slice(0, 8)} threw: ${errorToString(err)}`,
         );
       }
+      // The prompt left the screen, which for a permission answered directly in
+      // the terminal is the ONLY evidence remi gets. Until this call the card
+      // cleared but the EVAL did not: a queued waiter kept its place in the
+      // serial lane and ran (or burned the full `queue_timeout`) to decide a
+      // question a human had already answered — then pushed a card for it.
+      //
+      // Measured on a live 0.7.6 session: evals cost 7-10s each and run one at
+      // a time, so every already-answered survivor delayed every real one
+      // behind it, and WebFetch/WebSearch escalated at exactly 240001ms having
+      // never reached the model.
+      //
+      // Separately guarded from the release above, deliberately: these are two
+      // independent cleanups and a throw in either must not skip the other —
+      // the zombie-card pattern #661 fixed in input-events.ts's answer paths.
+      // `cancelEvalForQuestion` is a no-op when no eval is tracked, so this is
+      // safe to call on every disappearance.
+      try {
+        sessionGateHandles.get(sessionId)?.cancelEvalForQuestion?.(questionId as UUID, reason);
+      } catch (err) {
+        logError(
+          `[QuestionPresenceTracker] eval cancel for gone ${questionId.slice(0, 8)} threw: ${errorToString(err)}`,
+        );
+      }
     },
   });
   // #920: register this session's tracker so the answer handler's

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -134,6 +134,8 @@ import {
   SubagentAlerter,
   alertBody,
   alertTitle,
+  llamaServerMissingHint,
+  resolveLlamaServer,
   resolveProviderUrl,
 } from './auto-approve/index.ts';
 import type { PrecedentStore } from './auto-approve/precedent.ts';
@@ -887,53 +889,68 @@ let autoApproveService: AutoApproveService | null = null;
       logError(
         `[AutoApprove] No local LLM backend exists for ${process.platform}/${process.arch}: the Yooz engine needs Apple Silicon (MLX) and the llama.cpp path is Linux. Auto-approve will escalate every permission until you point auto_approve.provider at a reachable backend (e.g. openrouter, or a custom URL).`,
       );
-    } else if (provider === 'llamacpp') {
-      // Linux resolves to `llamacpp`, but NOTHING installs or supervises a
-      // llama-server yet (#822) -- remi only supervises the engine transport.
-      // Left unsaid, a Linux user enabling auto-approve gets silence and then
-      // every permission escalated, which is precisely the unexplained
-      // degradation #818 was filed to remove, reintroduced on another platform.
-      // The macOS path fetches its own helper (#834); this one cannot yet, so
-      // the honest thing is to say so at boot rather than at the first
-      // permission -- and to say exactly what to run, since the weights and
-      // the transport both already exist. `-hf` pulls from HuggingFace on
-      // first run; the quant suffix is explicit for determinism, not
-      // because a bare id fails (see `defaultModel`).
+    } else if (provider === 'llamacpp' && resolveLlamaServer() === undefined) {
+      // remi SUPERVISES llama-server since #822 (spawn, health-probe, stop) but
+      // deliberately never INSTALLS it -- see llamacpp-backend.ts for where that
+      // line is drawn. So the only remaining boot-time gap is a missing binary,
+      // and it is worth saying here rather than at the first permission: left
+      // unsaid, a Linux user enabling auto-approve gets silence and then every
+      // permission escalated, which is precisely the unexplained degradation
+      // #818 was filed to remove, reintroduced on another platform.
+      //
+      // Nothing is printed when the binary IS present: remi starts it on
+      // demand, so there is no action for the user to take and a warning would
+      // describe a problem that does not exist.
       logError(
-        `[AutoApprove] provider = "llamacpp": remi does not yet download or supervise a llama.cpp server (#822), so start one yourself and auto-approve works:
-    ${llamaServerCommand(model)}
-  Until it answers on ${baseUrl}, every permission escalates. A remote provider (openrouter, a custom URL) also works.`,
+        `[AutoApprove] provider = "llamacpp": ${llamaServerMissingHint()}
+  Until something answers on ${baseUrl}, every permission escalates. A remote provider (openrouter, a custom URL) also works.
+  Once installed, remi runs it for you as: ${llamaServerCommand(model)}`,
       );
-      // llama-server ignores the request's `model` field in single-model mode
-      // (verified against its README), so a configured escalate_model is
-      // answered by whatever GGUF was loaded at process start -- a "second
-      // opinion" from the same weights, reported as if a heavier model had
-      // agreed. Silent, and it makes escalate_model actively misleading rather
-      // than merely absent. #822's own scope calls this out as an open design
-      // question ("one model per process"); until it is decided, say so.
-      if (aaCfg.escalate_model && aaCfg.escalate_model !== model) {
-        logError(
-          `[AutoApprove] escalate_model = "${aaCfg.escalate_model}" has no effect on provider = "llamacpp": llama-server serves the one model it was started with and ignores the requested model id, so the "second opinion" would come from the primary model (#822). There is no per-model base URL in the config, so there is no way to route it elsewhere today (#822 owns that design question) -- leave it empty until then.`,
-        );
-      }
+    }
+
+    // llama-server ignores the request's `model` field in single-model mode
+    // (verified against its README), so a configured escalate_model is
+    // answered by whatever GGUF was loaded at process start -- a "second
+    // opinion" from the same weights, reported as if a heavier model had
+    // agreed. Silent, and it makes escalate_model actively misleading rather
+    // than merely absent. #822's own scope calls this out as an open design
+    // question ("one model per process"); until it is decided, say so.
+    //
+    // Deliberately OUTSIDE the branch above. It used to be nested inside the
+    // llamacpp warning, which was harmless only because that warning fired for
+    // every llamacpp boot. Now that it fires just for a MISSING binary, nesting
+    // would silence this for exactly the users whose setup works -- i.e.
+    // everyone who would actually get the misleading second opinion.
+    if (provider === 'llamacpp' && aaCfg.escalate_model && aaCfg.escalate_model !== model) {
+      logError(
+        `[AutoApprove] escalate_model = "${aaCfg.escalate_model}" has no effect on provider = "llamacpp": llama-server serves the one model it was started with and ignores the requested model id, so the "second opinion" would come from the primary model (#822). There is no per-model base URL in the config, so there is no way to route it elsewhere today (#822 owns that design question) -- leave it empty until then.`,
+      );
     }
 
     // #818: who starts the engine. Only meaningful for the engine transport —
     // an OpenRouter or llama.cpp base URL is not something remi supervises, and
     // handing those an EngineHost would mean spawning a Yooz helper for a
     // provider that never talks to one.
-    const engineHost =
-      provider === 'yooz'
-        ? EngineHost.real(
-            {
-              baseUrl,
-              ownership: aaCfg.engine,
-              helperPath: aaCfg.engine_path,
-              modelCache: aaCfg.model_cache,
-            },
-            writeToLog,
-          )
-        : undefined;
+    // #822: llamacpp is supervised too now. Both are local sidecars remi owns
+    // on its reserved port; what differs is the launch and the readiness probe,
+    // which `EngineHost` takes as configuration. A remote provider (OpenRouter,
+    // a custom URL) is still never supervised -- handing those a host would
+    // mean spawning a local backend for something that never talks to one.
+    const engineHost = localProvider
+      ? EngineHost.real(
+          {
+            baseUrl,
+            backend: provider === 'llamacpp' ? 'llamacpp' : 'yooz',
+            // llama.cpp needs the id at launch (one GGUF per process); the
+            // engine ignores it and selects per request.
+            model,
+            ownership: aaCfg.engine,
+            helperPath: aaCfg.engine_path,
+            modelCache: aaCfg.model_cache,
+          },
+          writeToLog,
+        )
+      : undefined;
 
     autoApproveService = new AutoApproveService(
       {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.7-dev.3'; // REMI_COMPILED_VERSION
+      return '0.7.7-dev.4'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.7-dev.3'; // REMI_COMPILED_VERSION
+    return '0.7.7-dev.4'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,7 +18,7 @@ const REMI_VERSION = (() => {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     if (typeof pkg.version !== 'string') {
       console.error('[remi] package.json missing "version" field');
-      return '0.7.7-dev.2'; // REMI_COMPILED_VERSION
+      return '0.7.7-dev.3'; // REMI_COMPILED_VERSION
     }
     return pkg.version;
   } catch (err) {
@@ -28,7 +28,7 @@ const REMI_VERSION = (() => {
     if (code !== 'ENOENT' && code !== 'MODULE_NOT_FOUND') {
       console.error(`[remi] Failed to read version: ${(err as Error).message}`);
     }
-    return '0.7.7-dev.2'; // REMI_COMPILED_VERSION
+    return '0.7.7-dev.3'; // REMI_COMPILED_VERSION
   }
 })();
 

--- a/packages/daemon/src/config/config.ts
+++ b/packages/daemon/src/config/config.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { DAEMON_BASE_PORT, DAEMON_PORT_RANGE, errorToString } from '@remi/shared';
 import { parse as parseToml } from 'smol-toml';
+import { validateAgents } from '../auto-approve/agent-policy.ts';
 import {
   AUTO_APPROVE_LEVELS,
   DEFAULT_AUTO_APPROVE_LEVEL,
@@ -500,6 +501,9 @@ export const DEFAULT_CONFIG: RemiConfig = {
     // Always escalate these to the user; never auto-decided by the LLM (#572):
     // AskUserQuestion + plan-mode. Extend with custom question-posing tools.
     always_escalate_tools: [...DEFAULT_ALWAYS_ESCALATE_TOOLS],
+    // ADR 0025. Empty = every agent uses the base policy, i.e. exactly the
+    // pre-0025 behaviour. No shipped default grants any agent anything extra.
+    agents: {},
     // Reuse an answer the user already gave THIS SESSION for the identical
     // operation (#976). Session-scoped, in-memory, cleared on rotation -- a
     // durable rule is what `allow` is for. The deny-direction half (an earlier
@@ -624,6 +628,10 @@ export function loadConfig(configPath: string = CONFIG_PATH): RemiConfig {
     const parsed = parseToml(raw) as Record<string, unknown>;
     const merged = deepMerge(DEFAULT_CONFIG, parsed);
     validateAutoApprove(merged.auto_approve, configPath);
+    // ADR 0025. Validated against the MERGED value, which is safe here because
+    // `mergeSection` replaces the `agents` table wholesale rather than deep-
+    // merging it -- a user table never blends with the empty default.
+    validateAgents(merged.auto_approve.agents, configPath);
     // Apply the level preset AFTER merge, but decide from the RAW parsed
     // table (#963). By this point `merged.approve_groups` is populated either
     // way, so it cannot answer "did the user write this?" — reading it here
@@ -1369,6 +1377,26 @@ turn_complete_min_seconds = ${DEFAULT_CONFIG.notifications.turn_complete_min_sec
 # level = "strict"
 # approve_groups = ["read-only", "vcs-read", "build-test"]
 # deny_groups = []
+#
+# "net-read" (WebFetch + WebSearch) is a real group but is in NO preset and no
+# default -- every shipped preset is entirely local. Ask for it by name, and
+# prefer asking per agent (below) over machine-wide: WebFetch takes an
+# arbitrary URL, and a subagent is the context nobody is watching (ADR 0025).
+#
+# Per-agent-type overrides, keyed by the hook's agent_type. This is the only
+# layer a subagent reaches at hook time (the LLM never runs there -- ADR 0004),
+# so it is where "let research agents read the web, and nothing else" belongs.
+#
+#   deny / deny_groups   UNION with the base -- a section can never weaken a
+#                        machine-wide prohibition.
+#   allow / approve_groups   REPLACE the base, so a role can be given LESS.
+#
+# [auto_approve.agents.Explore]
+# approve_groups = ["read-only", "vcs-read", "net-read"]
+#
+# [auto_approve.agents.pr-review]
+# approve_groups = ["read-only", "vcs-read"]
+# allow = ["gh pr view", "gh pr diff"]
 #
 # Natural-language guidance appended to the LLM system prompt:
 # instructions = """

--- a/packages/daemon/src/mdns/advertise-decision.ts
+++ b/packages/daemon/src/mdns/advertise-decision.ts
@@ -1,0 +1,74 @@
+/**
+ * Why mDNS is or is not advertising (#1051).
+ *
+ * `startMdnsIfNeeded` used to collapse three suppression conditions into one
+ * bare `return null`, while every OTHER exit from that function said something
+ * ("Advertising on local network", "Failed to start: ..."). Before #880 that
+ * was nearly harmless, because `isLocalhostBind` was false on a stock install.
+ * Since the bind default moved to loopback it is the path EVERY stock install
+ * takes — so the one unexplained exit became the common one.
+ *
+ * What that costs: mDNS does not refuse a discovery attempt, it stops
+ * answering. From the phone's side the daemon does not error, it VANISHES. The
+ * user's reading is "Remi is broken" or "my network is broken", and nothing in
+ * the daemon's own output contradicts it.
+ *
+ * This module is the decision only — a pure function so it can be tested
+ * without booting a daemon, since the caller in `cli.ts` is module-level
+ * startup code with no seam. The caller owns the sink, which is deliberate:
+ * before the stdout redirect (daemon/serve mode) the terminal is reachable,
+ * after it (wrapper mode) the terminal belongs to Claude's TUI and the log file
+ * is the only honest destination. Both are already passed in as `logFn`.
+ */
+
+/** What is suppressing the advertisement, in the order the caller checks. */
+export type MdnsSuppression =
+  /** `--no-mdns` on the command line. */
+  | { readonly kind: 'cli-flag' }
+  /** `network.mdns = false` in config.toml. */
+  | { readonly kind: 'config' }
+  /** The daemon is bound to loopback, so there is nothing off-machine to find. */
+  | { readonly kind: 'loopback'; readonly bindHost: string };
+
+export interface MdnsAdvertiseInputs {
+  readonly cliNoMdns: boolean;
+  readonly configMdns: boolean;
+  readonly isLocalhostBind: boolean;
+  readonly bindHost: string;
+}
+
+/**
+ * Which condition suppresses advertising, or null when it should advertise.
+ *
+ * Order matches the caller's `||` chain exactly, and that matters: with both
+ * `--no-mdns` and a loopback bind in play, reporting the loopback would hand
+ * the user a remedy (`set daemon.bind`) that their own explicit flag would then
+ * override. Naming the most deliberate cause first is the only ordering that
+ * cannot produce advice which does not work.
+ */
+export function mdnsSuppression(inputs: MdnsAdvertiseInputs): MdnsSuppression | null {
+  if (inputs.cliNoMdns) return { kind: 'cli-flag' };
+  if (!inputs.configMdns) return { kind: 'config' };
+  if (inputs.isLocalhostBind) return { kind: 'loopback', bindHost: inputs.bindHost };
+  return null;
+}
+
+/**
+ * The line to log for a suppression.
+ *
+ * Deliberate suppressions state the fact and stop. The loopback case is the
+ * only one the user did not ask for — it arrived with a changed default — so it
+ * is the only one that names a remedy. #1051 is explicit that the other two
+ * must not nag: someone who passed `--no-mdns` does not need to be told how to
+ * undo it every boot.
+ */
+export function mdnsSuppressionMessage(suppression: MdnsSuppression): string {
+  switch (suppression.kind) {
+    case 'cli-flag':
+      return '[mDNS] Not advertising: --no-mdns was passed.';
+    case 'config':
+      return '[mDNS] Not advertising: network.mdns = false in ~/.remi/config.toml.';
+    case 'loopback':
+      return `[mDNS] Not advertising: bound to ${suppression.bindHost}, so there is nothing to discover off this machine (loopback is the default since #880). Set daemon.bind in ~/.remi/config.toml to advertise on your network — and set auth.enabled = true with it, because "auto" resolves to false on every bind.`;
+  }
+}

--- a/packages/daemon/src/mdns/index.ts
+++ b/packages/daemon/src/mdns/index.ts
@@ -1,4 +1,10 @@
 export { MDNS_SERVICE_TYPE } from './constants.ts';
+export {
+  mdnsSuppression,
+  mdnsSuppressionMessage,
+  type MdnsAdvertiseInputs,
+  type MdnsSuppression,
+} from './advertise-decision.ts';
 export { MdnsPublisher, type MdnsPublisherConfig } from './mdns-publisher.ts';
 export {
   discoverDaemons,

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -1,0 +1,325 @@
+/**
+ * ADR 0025: per-agent-type permission scoping.
+ *
+ * The merge asymmetry here IS the security contract — deny unions, allow
+ * replaces — so the tests that matter are the ones that fail when the
+ * asymmetry is flattened in either direction. ADR 0025 carries an explicit
+ * verification obligation for exactly that, because a document asserting "a
+ * section cannot weaken a deny" is the ADR 0011 failure mode unless a test
+ * fails when it stops being true.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  type ResolvedPolicy,
+  resolvePolicy,
+  validateAgents,
+} from '../../src/auto-approve/agent-policy.ts';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import { AUTO_APPROVE_LEVELS, groupsForLevel } from '../../src/auto-approve/levels.ts';
+import { knownGroupNames } from '../../src/auto-approve/permission-groups.ts';
+import { DEFAULT_CONFIG } from '../../src/config/config.ts';
+
+const BASE: ResolvedPolicy = {
+  allow: ['uv run'],
+  deny: ['rm -rf /'],
+  approveGroups: ['read-only', 'vcs-read'],
+  denyGroups: ['fs-write'],
+};
+
+describe('resolvePolicy falls through to the base', () => {
+  test('main context (no agent type)', () => {
+    expect(resolvePolicy(BASE, {}, undefined)).toEqual(BASE);
+  });
+
+  test('an empty-string agent type', () => {
+    expect(resolvePolicy(BASE, { Explore: { allow: ['x'] } }, '')).toEqual(BASE);
+  });
+
+  test('an agent type with no section', () => {
+    expect(resolvePolicy(BASE, { Explore: { allow: ['x'] } }, 'general-purpose')).toEqual(BASE);
+  });
+
+  test('a MISSPELLED section silently does nothing', () => {
+    // ADR 0025 records this as an accepted consequence: there is no registry of
+    // agent types to validate a name against. Pinned so the behaviour is a
+    // known one rather than a surprise discovered in the field.
+    const resolved = resolvePolicy(BASE, { Explor: { approve_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.approveGroups).toEqual(['read-only', 'vcs-read']);
+  });
+});
+
+describe('deny UNIONS — a section can never weaken a prohibition', () => {
+  test('the base deny survives a section that omits it', () => {
+    // THE obligation from ADR 0025. If `deny` were treated like `allow`
+    // (replace-when-present), a section setting only approve_groups would be
+    // fine, but one setting its own `deny` would silently drop `rm -rf /`.
+    const resolved = resolvePolicy(BASE, { Explore: { deny: ['curl'] } }, 'Explore');
+    expect(resolved.deny).toContain('rm -rf /');
+    expect(resolved.deny).toContain('curl');
+  });
+
+  test('the base deny survives a section with an EMPTY deny', () => {
+    // The adversarial shape: an explicit `deny = []` is the most direct way to
+    // try to clear a machine-wide prohibition for one agent.
+    const resolved = resolvePolicy(BASE, { Explore: { deny: [] } }, 'Explore');
+    expect(resolved.deny).toEqual(['rm -rf /']);
+  });
+
+  test('deny_groups unions the same way', () => {
+    const resolved = resolvePolicy(BASE, { Explore: { deny_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.denyGroups).toEqual(['fs-write', 'net-read']);
+  });
+
+  test('a duplicate deny is not repeated', () => {
+    const resolved = resolvePolicy(BASE, { Explore: { deny: ['rm -rf /'] } }, 'Explore');
+    expect(resolved.deny).toEqual(['rm -rf /']);
+  });
+
+  test('base deny order is preserved, so a reported pattern does not shuffle', () => {
+    const base = { ...BASE, deny: ['a', 'b', 'c'] };
+    const resolved = resolvePolicy(base, { Explore: { deny: ['d'] } }, 'Explore');
+    expect(resolved.deny).toEqual(['a', 'b', 'c', 'd']);
+  });
+});
+
+describe('allow / approve_groups REPLACE — per-role scoping must be able to narrow', () => {
+  test('approve_groups replaces rather than merging', () => {
+    // The motivating case: give this role LESS. If it merged additively, a
+    // section could only ever widen and this would be inexpressible.
+    const resolved = resolvePolicy(
+      BASE,
+      { 'pr-review': { approve_groups: ['read-only'] } },
+      'pr-review',
+    );
+    expect(resolved.approveGroups).toEqual(['read-only']);
+    expect(resolved.approveGroups).not.toContain('vcs-read');
+  });
+
+  test('an EMPTY approve_groups means none, not "inherit the base"', () => {
+    // Treating empty as absent would turn an explicit narrowing into a
+    // widening — the one direction this must never fail.
+    const resolved = resolvePolicy(BASE, { locked: { approve_groups: [] } }, 'locked');
+    expect(resolved.approveGroups).toEqual([]);
+  });
+
+  test('an EMPTY allow means none, not "inherit the base"', () => {
+    const resolved = resolvePolicy(BASE, { locked: { allow: [] } }, 'locked');
+    expect(resolved.allow).toEqual([]);
+  });
+
+  test('a section may also widen, which is the user saying so explicitly', () => {
+    const resolved = resolvePolicy(
+      BASE,
+      { Explore: { approve_groups: ['read-only', 'vcs-read', 'net-read'] } },
+      'Explore',
+    );
+    expect(resolved.approveGroups).toContain('net-read');
+  });
+
+  test('keys not set by the section inherit the base', () => {
+    // The common case is one line: "this role also gets net-read".
+    const resolved = resolvePolicy(BASE, { Explore: { approve_groups: ['net-read'] } }, 'Explore');
+    expect(resolved.allow).toEqual(['uv run']);
+    expect(resolved.deny).toEqual(['rm -rf /']);
+    expect(resolved.denyGroups).toEqual(['fs-write']);
+  });
+
+  test('the base object is never mutated', () => {
+    const snapshot = structuredClone(BASE);
+    resolvePolicy(BASE, { Explore: { deny: ['x'], approve_groups: ['y'] } }, 'Explore');
+    expect(BASE).toEqual(snapshot);
+  });
+});
+
+describe('the real AutoApproveService applies the agent section', () => {
+  // Everything above is a pure function. Without this block, all of it would
+  // stay green if the service never passed `agentType` through -- the feature
+  // would be inert and the suite would not notice. No LLM is involved: these
+  // are deterministic-layer decisions, which is exactly the layer a subagent
+  // reaches at hook time (ADR 0004).
+  function service(agents: Record<string, unknown>) {
+    return new AutoApproveService(
+      {
+        enabled: true,
+        provider: 'yooz',
+        model: 'm',
+        api_key: '',
+        base_url: 'http://127.0.0.1:19924',
+        timeout: 30,
+        log_decisions: false,
+        allow: [],
+        deny: [],
+        subagent_alert: [],
+        approve_groups: ['read-only'],
+        level: 'strict',
+        deny_groups: [],
+        instructions: '',
+        multichoice: 'skip',
+        multichoice_model: '',
+        escalate_model: '',
+        escalate_timeout: 0,
+        queue_timeout: 240,
+        cache_idle: 0,
+        keep_alive: 0,
+        engine: 'owned' as const,
+        engine_path: '',
+        model_cache: '',
+        disable_thinking: false,
+        always_escalate_tools: [],
+        session_precedent: true,
+        hold_timeout: 0,
+        push_hold_timeout: 0,
+        delivery_confirm_timeout: 0,
+        hold_unconfirmed_timeout: 0,
+        agents,
+      } as never,
+      () => {},
+    );
+  }
+
+  const NET_AGENTS = { Explore: { approve_groups: ['read-only', 'net-read'] } };
+
+  test('WebFetch is approved for the agent granted net-read', () => {
+    const d = service(NET_AGENTS).evaluateDeterministic(
+      'WebFetch',
+      { url: 'https://x' },
+      'Explore',
+    );
+    expect(d?.decision).toBe('approve');
+    expect(d?.reasoning).toContain('net-read');
+  });
+
+  test('the SAME call is not approved for an agent without the section', () => {
+    // The whole point of scoping: general-purpose does not inherit Explore's
+    // grant. This is the measured case -- a WebFetch with no match parks,
+    // renders, and enters the serial queue.
+    const d = service(NET_AGENTS).evaluateDeterministic(
+      'WebFetch',
+      { url: 'https://x' },
+      'general-purpose',
+    );
+    expect(d).toBeNull();
+  });
+
+  test('and not for the main context either', () => {
+    expect(service(NET_AGENTS).evaluateDeterministic('WebFetch', { url: 'https://x' })).toBeNull();
+  });
+
+  test('with no agent section, WebFetch matches nothing', () => {
+    expect(
+      service({}).evaluateDeterministic('WebFetch', { url: 'https://x' }, 'Explore'),
+    ).toBeNull();
+  });
+
+  test('a base deny still wins inside an agent that was granted the group', () => {
+    const svc = new AutoApproveService(
+      {
+        enabled: true,
+        provider: 'yooz',
+        model: 'm',
+        api_key: '',
+        base_url: 'http://127.0.0.1:19924',
+        timeout: 30,
+        log_decisions: false,
+        allow: [],
+        deny: ['WebFetch'],
+        subagent_alert: [],
+        approve_groups: ['read-only'],
+        level: 'strict',
+        deny_groups: [],
+        instructions: '',
+        multichoice: 'skip',
+        multichoice_model: '',
+        escalate_model: '',
+        escalate_timeout: 0,
+        queue_timeout: 240,
+        cache_idle: 0,
+        keep_alive: 0,
+        engine: 'owned' as const,
+        engine_path: '',
+        model_cache: '',
+        disable_thinking: false,
+        always_escalate_tools: [],
+        session_precedent: true,
+        hold_timeout: 0,
+        push_hold_timeout: 0,
+        delivery_confirm_timeout: 0,
+        hold_unconfirmed_timeout: 0,
+        agents: NET_AGENTS,
+      } as never,
+      () => {},
+    );
+    const d = svc.evaluateDeterministic('WebFetch', { url: 'https://x' }, 'Explore');
+    expect(d?.decision).toBe('deny-covered');
+  });
+});
+
+describe('net-read is in no shipped default (ADR 0025)', () => {
+  // Written after a mutation exposed the first version of this claim as
+  // untestable: it hardcoded `approve_groups` and so could not fail when
+  // net-read was added to a LEVEL preset. Reading the presets themselves is
+  // the only form of this assertion that can fail on what it claims.
+  test('no level preset grants net-read', () => {
+    for (const level of AUTO_APPROVE_LEVELS) {
+      expect(groupsForLevel(level)).not.toContain('net-read');
+    }
+  });
+
+  test('the shipped approve_groups default does not grant net-read', () => {
+    expect(DEFAULT_CONFIG.auto_approve.approve_groups).not.toContain('net-read');
+  });
+
+  test('net-read IS a real, known group — absent from presets, not missing', () => {
+    // Without this, deleting the group entirely would also satisfy the two
+    // assertions above, and "opt-in" would silently become "unavailable".
+    expect(knownGroupNames()).toContain('net-read');
+  });
+});
+
+describe('validateAgents', () => {
+  test('undefined is fine (no table)', () => {
+    expect(() => validateAgents(undefined, '/c.toml')).not.toThrow();
+  });
+
+  test('an empty table is fine', () => {
+    expect(() => validateAgents({}, '/c.toml')).not.toThrow();
+  });
+
+  test('a valid table passes', () => {
+    expect(() =>
+      validateAgents({ Explore: { approve_groups: ['read-only'], deny: ['curl'] } }, '/c.toml'),
+    ).not.toThrow();
+  });
+
+  test('an array instead of a table throws', () => {
+    expect(() => validateAgents([], '/c.toml')).toThrow(/must be a table/);
+  });
+
+  test('a non-table section throws, naming the agent', () => {
+    expect(() => validateAgents({ Explore: 'read-only' }, '/c.toml')).toThrow(
+      /agents\.Explore.*must be a table/s,
+    );
+  });
+
+  test('a non-array list throws, naming the key', () => {
+    expect(() => validateAgents({ Explore: { approve_groups: 'read-only' } }, '/c.toml')).toThrow(
+      /agents\.Explore\.approve_groups/,
+    );
+  });
+
+  test('a non-string element throws', () => {
+    expect(() => validateAgents({ Explore: { deny: ['ok', 3] } }, '/c.toml')).toThrow(
+      /agents\.Explore\.deny/,
+    );
+  });
+
+  test('a MISSPELLED key throws instead of being ignored', () => {
+    // `approve_group` (singular) would otherwise leave the agent on the base
+    // policy while the config file plainly appears to grant something — a
+    // config/behaviour mismatch of exactly the kind ADR 0011 exists to stop.
+    expect(() => validateAgents({ Explore: { approve_group: ['read-only'] } }, '/c.toml')).toThrow(
+      /Unknown key.*approve_group/s,
+    );
+  });
+});

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -134,13 +134,56 @@ describe('allow / approve_groups REPLACE — per-role scoping must be able to na
   });
 });
 
+/** A real service with only `agents` varying. Module-scope so both the
+ *  deterministic and the async-evaluate describes drive the SAME construction. */
+function svcWithAgents(agents: Record<string, unknown>) {
+  return new AutoApproveService(
+    {
+      enabled: true,
+      provider: 'yooz',
+      model: 'm',
+      api_key: '',
+      base_url: 'http://127.0.0.1:19924',
+      timeout: 30,
+      log_decisions: false,
+      allow: [],
+      deny: [],
+      subagent_alert: [],
+      approve_groups: ['read-only'],
+      level: 'strict',
+      deny_groups: [],
+      instructions: '',
+      multichoice: 'skip',
+      multichoice_model: '',
+      escalate_model: '',
+      escalate_timeout: 0,
+      queue_timeout: 240,
+      cache_idle: 0,
+      keep_alive: 0,
+      engine: 'owned' as const,
+      engine_path: '',
+      model_cache: '',
+      disable_thinking: false,
+      always_escalate_tools: [],
+      session_precedent: true,
+      hold_timeout: 0,
+      push_hold_timeout: 0,
+      delivery_confirm_timeout: 0,
+      hold_unconfirmed_timeout: 0,
+      agents,
+    } as never,
+    () => {},
+  );
+}
+
 describe('the real AutoApproveService applies the agent section', () => {
   // Everything above is a pure function. Without this block, all of it would
   // stay green if the service never passed `agentType` through -- the feature
   // would be inert and the suite would not notice. No LLM is involved: these
   // are deterministic-layer decisions, which is exactly the layer a subagent
   // reaches at hook time (ADR 0004).
-  function service(agents: Record<string, unknown>) {
+  const service = svcWithAgents;
+  function _unusedService(agents: Record<string, unknown>) {
     return new AutoApproveService(
       {
         enabled: true,
@@ -349,13 +392,15 @@ describe('the gate actually threads agent_type to every evaluation site', () => 
     expect(gate.slice(i, i + 200)).toContain('input.agent_type');
   });
 
-  test('all three evaluation sites pass it', () => {
-    // hook-time deterministic, parked-render evaluate, escalate_model second
-    // opinion. The third was missed in the first draft and re-ran the
-    // deterministic layers under the BASE policy, silently undoing a per-agent
-    // narrowing — so the count, not just the presence, is the assertion.
-    const sites = gate.split('input.agent_type,').length - 1;
-    expect(sites).toBe(3);
+  test('the parked-render evaluate receives agent_type', () => {
+    // Its own bounded assertion, not a whole-file count. A count of 3 was the
+    // first draft and had a proven false negative: delete this site and add any
+    // unrelated fourth occurrence and the count still reads 3. This was the one
+    // of the three sites left unguarded by that version.
+    const i = gate.indexOf('arbitrateParkedRender(');
+    expect(i).toBeGreaterThan(-1);
+    const body = gate.slice(i, gate.indexOf('\n  }', i));
+    expect(body).toContain('input.agent_type,');
   });
 
   test('runSecondOpinion specifically forwards it', () => {
@@ -363,5 +408,59 @@ describe('the gate actually threads agent_type to every evaluation site', () => 
     expect(i).toBeGreaterThan(-1);
     const body = gate.slice(i, gate.indexOf('\n  }', i));
     expect(body).toContain('input.agent_type,');
+  });
+});
+
+describe('the async evaluate() path also honours the agent policy', () => {
+  // Criticality-8 gap found by review: deleting the `agentType` argument from
+  // `evaluate()`'s internal `evaluateDeterministic` call left the ENTIRE suite
+  // green. That is the async path — parked-render arbitration, the second
+  // opinion, main-context evals — so a per-agent narrowing silently reverted to
+  // base policy on every non-hook-time decision. Same class as the
+  // `runSecondOpinion` bug one layer up, and equally invisible.
+  //
+  // Driven through the real `evaluate()`, which short-circuits on a
+  // deterministic match and never reaches the network, so no engine is needed.
+  const NET_AGENTS = { Explore: { approve_groups: ['read-only', 'net-read'] } };
+
+  test('an agent-granted group approves through evaluate(), not just evaluateDeterministic()', async () => {
+    const svc = svcWithAgents(NET_AGENTS);
+    const r = await svc.evaluate(
+      'WebFetch',
+      { url: 'https://x' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      'Explore',
+    );
+    expect(r.decision).toBe('approve');
+    expect(r.durationMs).toBe(0);
+    expect(r.reasoning).toContain('net-read');
+  });
+
+  test('and an agent WITHOUT the section does not get it', async () => {
+    // Without a network call this cannot reach a decision, so assert the thing
+    // that distinguishes: it did NOT short-circuit to a 0ms deterministic
+    // approve the way the granted agent did.
+    const svc = svcWithAgents(NET_AGENTS);
+    const r = await svc.evaluate(
+      'WebFetch',
+      { url: 'https://x' },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      undefined,
+      undefined,
+      'general-purpose',
+    );
+    expect(r.decision === 'approve' && r.durationMs === 0).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/agent-policy.test.ts
+++ b/packages/daemon/tests/auto-approve/agent-policy.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   type ResolvedPolicy,
   resolvePolicy,
@@ -321,5 +323,45 @@ describe('validateAgents', () => {
     expect(() => validateAgents({ Explore: { approve_group: ['read-only'] } }, '/c.toml')).toThrow(
       /Unknown key.*approve_group/s,
     );
+  });
+});
+
+describe('the gate actually threads agent_type to every evaluation site', () => {
+  // Proven necessary by incident, not by imagination: during this PR's review a
+  // mutation removed `input.agent_type` from the hook-time
+  // `evaluateDeterministic` call and the ENTIRE suite stayed green, because
+  // every test above calls the service directly. The feature was inert on the
+  // path that matters most (ADR 0004: the hook-time deterministic layer is the
+  // only one a subagent reaches) and nothing said so.
+  //
+  // A behavioural test cannot reach these: `AutoApproveGate`'s call sites are
+  // reached only through a live hook dispatch. So this pins the three sites by
+  // source, which is the same shape `cancel.test.ts` uses and has the same
+  // limitation — it proves the argument is passed, not that it is honoured.
+  const gate = fs.readFileSync(
+    path.join(import.meta.dir, '..', '..', 'src', 'auto-approve', 'auto-approve-gate.ts'),
+    'utf8',
+  );
+
+  test('hook-time evaluateDeterministic receives agent_type', () => {
+    const i = gate.indexOf('evaluateDeterministic?.(');
+    expect(i).toBeGreaterThan(-1);
+    expect(gate.slice(i, i + 200)).toContain('input.agent_type');
+  });
+
+  test('all three evaluation sites pass it', () => {
+    // hook-time deterministic, parked-render evaluate, escalate_model second
+    // opinion. The third was missed in the first draft and re-ran the
+    // deterministic layers under the BASE policy, silently undoing a per-agent
+    // narrowing — so the count, not just the presence, is the assertion.
+    const sites = gate.split('input.agent_type,').length - 1;
+    expect(sites).toBe(3);
+  });
+
+  test('runSecondOpinion specifically forwards it', () => {
+    const i = gate.indexOf('private async runSecondOpinion(');
+    expect(i).toBeGreaterThan(-1);
+    const body = gate.slice(i, gate.indexOf('\n  }', i));
+    expect(body).toContain('input.agent_type,');
   });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 
@@ -277,5 +279,33 @@ describe('AutoApproveService.cancel()', () => {
     // Reasoning should NOT include 'Hard kill' or 'Cancelled' — the leak
     // would surface as one of those.
     expect(second.reasoning).not.toMatch(/hard kill|cancelled/i);
+  });
+});
+
+describe('a prompt leaving the screen cancels its eval (terminal-answered permissions)', () => {
+  // `onHooklessQuestionGone` is the ONLY evidence remi gets that a permission
+  // was answered directly in the terminal: no hook fires, the prompt simply
+  // disappears. It cleared the card and released the hold, but did NOT cancel
+  // the eval -- so a queued waiter kept its place in the serial lane and ran,
+  // or burned the full queue_timeout, to decide something a human had already
+  // answered, then pushed a card for it.
+  //
+  // Measured on a live 0.7.6 session: 7-10s per eval, run one at a time, with
+  // WebFetch/WebSearch escalating at exactly 240001ms having never reached the
+  // model. Every already-answered survivor delayed every real question behind
+  // it.
+  const cli = fs.readFileSync(path.join(import.meta.dir, '..', '..', 'src', 'cli.ts'), 'utf8');
+
+  test('the disappearance handler cancels the eval', () => {
+    // A behavioural test cannot reach this: the wiring lives in module-level
+    // startup code in cli.ts with no seam. Without this pin, the queued-waiter
+    // cancel below stays green while nothing calls it -- the ADR 0011 row-5
+    // shape, in a fix for a measured production stall.
+    // Asserted on the EXACT call, not on a window around the handler: the
+    // first version of this pin scanned 3000 chars from the handler and so
+    // reached input-events.ts's own `cancelEvalForQuestion` call sites, which
+    // meant deleting this one left it green. Verified by mutation.
+    expect(cli).toContain('onHooklessQuestionGone:');
+    expect(cli).toContain('cancelEvalForQuestion?.(questionId as UUID, reason)');
   });
 });

--- a/packages/daemon/tests/auto-approve/cancel.test.ts
+++ b/packages/daemon/tests/auto-approve/cancel.test.ts
@@ -305,7 +305,12 @@ describe('a prompt leaving the screen cancels its eval (terminal-answered permis
     // first version of this pin scanned 3000 chars from the handler and so
     // reached input-events.ts's own `cancelEvalForQuestion` call sites, which
     // meant deleting this one left it green. Verified by mutation.
-    expect(cli).toContain('onHooklessQuestionGone:');
-    expect(cli).toContain('cancelEvalForQuestion?.(questionId as UUID, reason)');
+    // Bounded to the handler BODY, not the whole file. A whole-file
+    // `toContain` stayed green when the call was deleted from the handler and
+    // the same string added to a never-called function -- verified by mutation.
+    const i = cli.indexOf('onHooklessQuestionGone:');
+    expect(i).toBeGreaterThan(-1);
+    const handler = cli.slice(i, cli.indexOf('\n  });', i));
+    expect(handler).toContain('cancelEvalForQuestion');
   });
 });

--- a/packages/daemon/tests/auto-approve/engine-host.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-host.test.ts
@@ -38,7 +38,11 @@ function host(
 ) {
   const logs: string[] = [];
   const killed: number[] = [];
-  const spawnCalls: Array<{ path: string; env: Record<string, string> }> = [];
+  const spawnCalls: Array<{
+    path: string;
+    args: readonly string[];
+    env: Record<string, string>;
+  }> = [];
   const probes = opts.probes ?? [UNREACHABLE];
   let probeIndex = 0;
   const h = new EngineHost(
@@ -54,8 +58,8 @@ function host(
       log: (m) => logs.push(m),
       sleep: async () => {},
       probe: async () => probes[Math.min(probeIndex++, probes.length - 1)] as EngineProbe,
-      spawn: (path, env) => {
-        spawnCalls.push({ path, env });
+      spawn: (path, args, env) => {
+        spawnCalls.push({ path, args, env });
         if (opts.spawnThrows) throw new Error(opts.spawnThrows);
         return opts.spawnPid ?? 4242;
       },

--- a/packages/daemon/tests/auto-approve/engine-process.test.ts
+++ b/packages/daemon/tests/auto-approve/engine-process.test.ts
@@ -170,7 +170,7 @@ describe('spawnDetachedEngine', () => {
   const SLEEP = '/bin/sleep';
 
   test('starts a real process and returns its pid', () => {
-    const pid = spawnDetachedEngine(SLEEP, { YOOZ_ENGINE_PORT: '19924' }, LOG_FILE);
+    const pid = spawnDetachedEngine(SLEEP, [], { YOOZ_ENGINE_PORT: '19924' }, LOG_FILE);
     try {
       expect(pid).toBeGreaterThan(0);
       // Signal 0: alive without delivering anything.
@@ -189,15 +189,18 @@ describe('spawnDetachedEngine', () => {
     // A silent failure would leave a record for a process that never existed,
     // blocking every later attempt.
     const missing = path.join(TEST_DIR, 'no-such-helper');
-    expect(() => spawnDetachedEngine(missing, {}, LOG_FILE)).toThrow();
+    expect(() => spawnDetachedEngine(missing, [], {}, LOG_FILE)).toThrow();
   });
 
   test('writes a start banner to the log file', () => {
     // The helper's own diagnostics are the only evidence available when it
     // starts but never binds, so the log has to exist and be appended to.
-    const pid = spawnDetachedEngine(SLEEP, {}, LOG_FILE);
+    const pid = spawnDetachedEngine(SLEEP, [], {}, LOG_FILE);
     try {
-      expect(fs.readFileSync(LOG_FILE, 'utf8')).toContain('Engine starting at');
+      // Names the EXECUTABLE, not "Engine" (#822): the same function now also
+      // launches llama-server, and a banner calling that the engine is the
+      // wrong-but-plausible description ADR 0011 exists to prevent.
+      expect(fs.readFileSync(LOG_FILE, 'utf8')).toContain('sleep starting at');
     } finally {
       try {
         process.kill(pid);
@@ -213,7 +216,7 @@ describe('spawnDetachedEngine', () => {
     const before = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
     const pids: number[] = [];
     try {
-      for (let i = 0; i < 12; i++) pids.push(spawnDetachedEngine(SLEEP, {}, LOG_FILE));
+      for (let i = 0; i < 12; i++) pids.push(spawnDetachedEngine(SLEEP, [], {}, LOG_FILE));
       const after = process.report?.getReport() as { openFileDescriptors?: unknown[] } | undefined;
       const beforeCount = before?.openFileDescriptors?.length;
       const afterCount = after?.openFileDescriptors?.length;

--- a/packages/daemon/tests/auto-approve/llamacpp-backend.test.ts
+++ b/packages/daemon/tests/auto-approve/llamacpp-backend.test.ts
@@ -1,0 +1,404 @@
+/**
+ * #822 slice 1: remi supervises `llama-server` instead of making the user run
+ * it under nohup.
+ *
+ * Everything here drives the REAL thing it names — a real HTTP server for the
+ * probe, real files with real permission bits for PATH resolution. The probe
+ * tests in particular would be worthless against a stubbed `fetch`: the bug
+ * this module exists to avoid is requesting `/v1/health` instead of `/health`,
+ * and only a server that actually 404s the wrong path can catch it.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  EngineHost,
+  type EngineHostConfig,
+  type PidStore,
+} from '../../src/auto-approve/engine-host.ts';
+import { spawnDetachedEngine } from '../../src/auto-approve/engine-process.ts';
+import {
+  healthUrl,
+  llamaServerArgs,
+  probeLlamaCpp,
+  resolveLlamaServer,
+} from '../../src/auto-approve/llamacpp-backend.ts';
+
+const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'remi-llamacpp-'));
+afterAll(() => {
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('healthUrl', () => {
+  test('drops the /v1 suffix the llamacpp base URL carries', () => {
+    // The regression this pins: `llamacpp`'s base URL ends in /v1 (it is
+    // dispatched through the openai kind), but /health is served at the ROOT.
+    // Naively joining yields /v1/health -- the same /v1/v1 class of bug
+    // AGENTS.md already records for warmModel.
+    expect(healthUrl('http://127.0.0.1:19924/v1')).toBe('http://127.0.0.1:19924/health');
+  });
+
+  test('works on a root base URL too', () => {
+    expect(healthUrl('http://127.0.0.1:19924')).toBe('http://127.0.0.1:19924/health');
+  });
+
+  test('a malformed base URL is returned as-is rather than throwing', () => {
+    // The probe's contract is to REPORT unreachable, never to throw: an
+    // exception escaping here becomes a silent permanent escalation (#818).
+    expect(healthUrl('not a url')).toBe('not a url');
+  });
+});
+
+describe('llamaServerArgs', () => {
+  test('passes the model to -hf with its quant suffix intact', () => {
+    const args = llamaServerArgs('YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0', 19924);
+    // The suffix is load-bearing: -hf with no tag prefers Q4_K_M/Q8_0 and the
+    // YoozLabs repos publish only Q4_0, so a stripped tag resolves no file.
+    expect(args).toEqual([
+      '-hf',
+      'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '19924',
+    ]);
+  });
+
+  test('binds loopback, never the daemon bind address', () => {
+    // The eval backend is remi's own sidecar. Widening it would hand any host
+    // that can reach the port a free LLM -- the exact class of default #880
+    // spent a release closing.
+    expect(llamaServerArgs('m', 19924)).toContain('127.0.0.1');
+    expect(llamaServerArgs('m', 19924)).not.toContain('0.0.0.0');
+  });
+});
+
+describe('resolveLlamaServer', () => {
+  const binDir = path.join(TEST_DIR, 'bin');
+  const emptyDir = path.join(TEST_DIR, 'empty');
+
+  beforeAll(() => {
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(emptyDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'llama-server'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  });
+
+  test('finds an executable llama-server on PATH', () => {
+    const found = resolveLlamaServer({ PATH: `${emptyDir}${path.delimiter}${binDir}` });
+    expect(found).toBe(path.join(binDir, 'llama-server'));
+  });
+
+  test('returns undefined when it is not installed', () => {
+    // This is what turns into the actionable "install it" reason rather than a
+    // throw: remi never installs llama-server, so the user must be told.
+    expect(resolveLlamaServer({ PATH: emptyDir })).toBeUndefined();
+  });
+
+  test('returns undefined when PATH is unset', () => {
+    expect(resolveLlamaServer({})).toBeUndefined();
+  });
+
+  test('a non-executable file of the right name is not accepted', () => {
+    const noExecDir = path.join(TEST_DIR, 'noexec');
+    fs.mkdirSync(noExecDir, { recursive: true });
+    fs.writeFileSync(path.join(noExecDir, 'llama-server'), 'not executable', { mode: 0o644 });
+    expect(resolveLlamaServer({ PATH: noExecDir })).toBeUndefined();
+  });
+
+  test('a DIRECTORY named llama-server is not accepted', () => {
+    // Directories carry the execute bit (it means "traversable"), so an
+    // access(X_OK) check alone would happily return a path that cannot be
+    // spawned -- and the failure would surface as a spawn error at boot.
+    const dirTrap = path.join(TEST_DIR, 'dirtrap');
+    fs.mkdirSync(path.join(dirTrap, 'llama-server'), { recursive: true });
+    expect(resolveLlamaServer({ PATH: dirTrap })).toBeUndefined();
+  });
+});
+
+describe('probeLlamaCpp against a real server', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let base: string;
+  /** Flipped per test to drive the two states that matter at startup. */
+  let health: { status: number } = { status: 200 };
+  /** Every path the probe requested, so a wrong URL is provable, not assumed. */
+  let requested: string[] = [];
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        requested.push(url.pathname);
+        // Only /health answers. Anything else 404s, which is what makes the
+        // "/v1/health would be wrong" assertion real rather than decorative.
+        if (url.pathname === '/health') return new Response('', { status: health.status });
+        return new Response('not found', { status: 404 });
+      },
+    });
+    base = `http://127.0.0.1:${server.port}/v1`;
+  });
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  test('200 on /health is reachable, and /health is the path actually requested', async () => {
+    requested = [];
+    health = { status: 200 };
+    const probe = await probeLlamaCpp(base);
+    expect(probe.reachable).toBe(true);
+    expect(requested).toEqual(['/health']);
+    expect(requested).not.toContain('/v1/health');
+  });
+
+  test('503 while the GGUF loads is NOT reachable', async () => {
+    // llama-server answers 503 until the model is loaded. Treating that as
+    // reachable would dispatch an eval into a server that cannot serve it and
+    // burn the hook budget waiting.
+    health = { status: 503 };
+    const probe = await probeLlamaCpp(base);
+    expect(probe.reachable).toBe(false);
+    expect(probe.reason).toContain('503');
+  });
+
+  test('a closed port is unreachable with a reason, never a throw', async () => {
+    // Port 1 on loopback: nothing listens, and the probe must turn that into a
+    // value. An exception here is the silent-escalation failure of #818.
+    const probe = await probeLlamaCpp('http://127.0.0.1:1/v1', 500);
+    expect(probe.reachable).toBe(false);
+    expect(probe.reason).toBeDefined();
+  });
+});
+
+/** A real in-memory PidStore with production semantics. */
+function pidStore(): PidStore & { current: number | null } {
+  const store = {
+    current: null as number | null,
+    read: () => store.current,
+    claim: (pid: number) => {
+      if (store.current !== null) return false;
+      store.current = pid;
+      return true;
+    },
+    release: (pid: number) => {
+      if (store.current === pid) store.current = null;
+    },
+  };
+  return store;
+}
+
+function llamaHost(
+  over: Partial<EngineHostConfig> = {},
+  opts: { reachable?: boolean[]; installed?: string | undefined } = {},
+) {
+  const logs: string[] = [];
+  const spawnCalls: Array<{
+    path: string;
+    args: readonly string[];
+    env: Record<string, string>;
+  }> = [];
+  const reach = opts.reachable ?? [false, true];
+  let i = 0;
+  const h = new EngineHost(
+    {
+      baseUrl: 'http://127.0.0.1:19924/v1',
+      backend: 'llamacpp',
+      model: 'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      ownership: 'owned',
+      startupTimeoutMs: 500,
+      probeIntervalMs: 50,
+      ...over,
+    },
+    {
+      log: (m) => logs.push(m),
+      sleep: async () => {},
+      probe: async () => ({ reachable: reach[Math.min(i++, reach.length - 1)] ?? false }),
+      spawn: (p, args, env) => {
+        spawnCalls.push({ path: p, args, env });
+        return 5150;
+      },
+      kill: () => {},
+      // Keep the test off the developer's real PATH: whether this machine
+      // happens to have llama-server installed must not decide the outcome.
+      installHelper: async () => ('installed' in opts ? opts.installed : '/usr/bin/llama-server'),
+      pidStore: pidStore(),
+    },
+  );
+  return { h, logs, spawnCalls };
+}
+
+describe('EngineHost with backend = llamacpp', () => {
+  test('spawns llama-server with -hf and the reserved port', async () => {
+    const { h, spawnCalls } = llamaHost();
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('spawned');
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.path).toBe('/usr/bin/llama-server');
+    expect(spawnCalls[0]?.args).toEqual([
+      '-hf',
+      'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '19924',
+    ]);
+  });
+
+  test('passes NO YOOZ_ENGINE_* environment to llama-server', async () => {
+    // Those variables configure the Yooz engine and mean nothing here.
+    // Setting them anyway would be a misleading description in the process
+    // table and in the log.
+    const { h, spawnCalls } = llamaHost();
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.env).toEqual({});
+  });
+
+  test('a model cache goes to LLAMA_CACHE, not HF_HUB_CACHE', async () => {
+    // HF_HUB_CACHE is the Python huggingface_hub variable the ENGINE reads.
+    // Naming it here would silently ignore the configured cache and
+    // re-download multi-GB weights into llama.cpp's default.
+    const { h, spawnCalls } = llamaHost({ modelCache: '/models' });
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.env).toEqual({ LLAMA_CACHE: '/models' });
+    expect(spawnCalls[0]?.env['HF_HUB_CACHE']).toBeUndefined();
+  });
+
+  test('attaches to a llama-server already running, without spawning', async () => {
+    const { h, spawnCalls } = llamaHost({}, { reachable: [true] });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('attached');
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test('a missing binary reports how to install it, and never spawns', async () => {
+    const { h, logs, spawnCalls } = llamaHost({}, { installed: undefined });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('unavailable');
+    if (state.kind !== 'unavailable') throw new Error('unreachable');
+    // The generic engine wording ("no helper available") would imply a
+    // download that is never coming: remi does not install llama-server.
+    expect(state.reason).toContain('not on PATH');
+    expect(state.reason).toContain('brew install llama.cpp');
+    expect(spawnCalls).toHaveLength(0);
+    expect(logs.join('\n')).toContain('not on PATH');
+  });
+
+  test('an empty model is refused before anything is spawned', async () => {
+    // llama.cpp loads ONE model at process start, so an empty id is `-hf ''`,
+    // which fails inside the child where the only trace is a log file nobody
+    // is reading.
+    const { h, spawnCalls } = llamaHost({ model: '' });
+    const state = await h.ensureRunning();
+    expect(state.kind).toBe('unavailable');
+    if (state.kind !== 'unavailable') throw new Error('unreachable');
+    expect(state.reason).toContain('auto_approve.model is empty');
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test('END TO END: really spawns a server that binds the port it was told', async () => {
+    // The unit tests above inject `spawn`, so none of them exercises
+    // `spawnDetachedEngine` with argv -- the very thing #822 widened. A stand-in
+    // "llama-server" makes the whole chain real: EngineHost builds the argv,
+    // the production detached spawn passes it, the child PARSES --port and
+    // binds it, and the production /health probe finds it.
+    //
+    // The port is the assertion. A child that binds a port it was not told
+    // about never answers, so this cannot pass on a wrong or dropped argv --
+    // which an `expect(args).toEqual([...])` against a fake spawn can.
+    const port = 18000 + (Math.floor(process.uptime() * 1000) % 900);
+    const argvLog = path.join(TEST_DIR, 'argv.json');
+    const serverTs = path.join(TEST_DIR, 'fake-llama-server.ts');
+    fs.writeFileSync(
+      serverTs,
+      `const argv = process.argv.slice(2);
+require('node:fs').writeFileSync(${JSON.stringify(argvLog)}, JSON.stringify(argv));
+const port = Number(argv[argv.indexOf('--port') + 1]);
+const host = argv[argv.indexOf('--host') + 1];
+Bun.serve({ port, hostname: host, fetch(req) {
+  return new URL(req.url).pathname === '/health'
+    ? new Response('', { status: 200 })
+    : new Response('no', { status: 404 });
+} });
+await new Promise(() => {});
+`,
+    );
+    const binDir = path.join(TEST_DIR, 'realbin');
+    fs.mkdirSync(binDir, { recursive: true });
+    const fakeBin = path.join(binDir, 'llama-server');
+    fs.writeFileSync(fakeBin, `#!/bin/sh\nexec ${process.execPath} ${serverTs} "$@"\n`, {
+      mode: 0o755,
+    });
+
+    const logs: string[] = [];
+    // The PRODUCTION spawn and the PRODUCTION probe (both defaulted), with only
+    // the pidfile and log file redirected: `EngineHost.real` would otherwise
+    // claim the developer's real ~/.remi/engine.pid and fight a running daemon.
+    const testLog = path.join(TEST_DIR, 'llama-server.log');
+    const real = new EngineHost(
+      {
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        backend: 'llamacpp',
+        model: 'YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0',
+        ownership: 'owned',
+        helperPath: fakeBin,
+        startupTimeoutMs: 15_000,
+        probeIntervalMs: 200,
+      },
+      {
+        log: (m) => logs.push(m),
+        pidStore: pidStore(),
+        spawn: (p, args, env) => spawnDetachedEngine(p, args, env, testLog),
+      },
+    );
+
+    try {
+      const state = await real.ensureRunning();
+      expect(state.kind).toBe('spawned');
+      // It answered on /health, through the real probe, at the real port.
+      expect(await real.probeOnce()).toBe(true);
+      // And it was launched with the model on -hf.
+      const argv = JSON.parse(fs.readFileSync(argvLog, 'utf8')) as string[];
+      expect(argv).toContain('-hf');
+      expect(argv[argv.indexOf('-hf') + 1]).toBe('YoozLabs/Qwen3.5-4B-qat-GGUF:Q4_0');
+    } finally {
+      real.stopStartedEngine();
+    }
+  }, 30_000);
+
+  test('the engine path is unchanged: no args, YOOZ_ENGINE_* env', async () => {
+    // The two-sided half of this change. Widening the spawn seam must not have
+    // altered what the engine is launched with.
+    const spawnCalls: Array<{ args: readonly string[]; env: Record<string, string> }> = [];
+    const h = new EngineHost(
+      {
+        baseUrl: 'http://127.0.0.1:19924',
+        ownership: 'owned',
+        helperPath: '/Applications/Yooz.app/Contents/MacOS/Yooz',
+        startupTimeoutMs: 500,
+        probeIntervalMs: 50,
+      },
+      {
+        log: () => {},
+        sleep: async () => {},
+        probe: (() => {
+          let n = 0;
+          return async () => ({ reachable: n++ > 0 });
+        })(),
+        spawn: (_p, args, env) => {
+          spawnCalls.push({ args, env });
+          return 4242;
+        },
+        kill: () => {},
+        installHelper: async () => undefined,
+        pidStore: pidStore(),
+      },
+    );
+    await h.ensureRunning();
+    expect(spawnCalls[0]?.args).toEqual([]);
+    expect(spawnCalls[0]?.env).toEqual({
+      YOOZ_ENGINE_HEADLESS: '1',
+      YOOZ_ENGINE_PORT: '19924',
+    });
+  });
+});

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1217,3 +1217,75 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
     );
   });
 });
+
+describe('a pure variable-assignment segment is inert (measured escalation cause)', () => {
+  // Agents habitually open a script by assigning a path, and that one segment
+  // matched neither a neutral prefix nor a read prefix -- sinking commands that
+  // were otherwise pure `ls`/`cat` into an 8-second LLM eval. Taken verbatim
+  // from a live 0.7.6 session.
+  test('the reported figure-qa command', () => {
+    const cmd =
+      'SCRIPTS_DIR="/Users/y/.claude/figure-qa-scripts"\n' +
+      'ls "$SCRIPTS_DIR/examples" 2>/dev/null\n' +
+      'cat "$SCRIPTS_DIR/check_raster.py" | head -100';
+    expect(bash(cmd)).toBe('read-only:ls');
+  });
+
+  test('semicolon form', () => {
+    expect(bash('SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"')).toBe('read-only:ls');
+    expect(bash('S=/tmp/x; grep -o "a" $S')).toBe('read-only:grep');
+  });
+
+  test('multiple assignments in one segment', () => {
+    expect(bash('A=1 B=2; ls')).toBe('read-only:ls');
+  });
+
+  test('assignments alone are still not "a read"', () => {
+    // Same rule every neutral segment obeys: a command that runs nothing is
+    // not a read, so it must not be approved on its own.
+    expect(bash('S=/tmp/x')).toBeNull();
+  });
+});
+
+describe('an assignment PREFIX to a command is NOT inert', () => {
+  // The whole safety argument for the rule above. `PATH=/evil ls` runs `ls`
+  // AND chooses which one; accepting a segment that merely STARTS with an
+  // assignment would auto-approve exactly that.
+  const mustBeNull = [
+    'PATH=/evil ls',
+    'LD_PRELOAD=/evil.so cat /etc/passwd',
+    'PATH=/evil ls && cat x',
+    'FOO=bar cat /etc/shadow',
+    'FOO=bar; PATH=/evil ls',
+  ];
+  for (const cmd of mustBeNull) {
+    test(cmd, () => expect(bash(cmd)).toBeNull());
+  }
+
+  test('command substitution in the value is refused before the assignment rule is reached', () => {
+    // `hasShellControl` rejects `$(...)`/backticks first. That ordering is
+    // load-bearing: the assignment predicate alone would call these inert.
+    const R = ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('');
+    expect(bash(`FOO=$(${R})`)).toBeNull();
+    expect(bash(`FOO=\`${R}\``)).toBeNull();
+  });
+});
+
+describe('read-only utilities added after the live-session measurement', () => {
+  const cases: Array<[string, string]> = [
+    ['which inkscape rsvg-convert', 'read-only:which'],
+    ['basename /a/b/c.txt', 'read-only:basename'],
+    ['dirname /a/b/c.txt', 'read-only:dirname'],
+    ['realpath ./x', 'read-only:realpath'],
+    ['mdfind "kMDItemFSName == \'X.app\'" 2>/dev/null | head -3', 'read-only:mdfind'],
+    ['du -sh node_modules', 'read-only:du'],
+    ['df -h', 'read-only:df'],
+  ];
+  for (const [cmd, expected] of cases) {
+    test(cmd, () => expect(bash(cmd)).toBe(expected));
+  }
+
+  test('the mutating Spotlight sibling is deliberately absent', () => {
+    expect(bash('mdutil -E /')).toBeNull();
+  });
+});

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1218,59 +1218,6 @@ describe('#1001 matchGroupsBroad: a stop rule matches ANY segment', () => {
   });
 });
 
-describe('a pure variable-assignment segment is inert (measured escalation cause)', () => {
-  // Agents habitually open a script by assigning a path, and that one segment
-  // matched neither a neutral prefix nor a read prefix -- sinking commands that
-  // were otherwise pure `ls`/`cat` into an 8-second LLM eval. Taken verbatim
-  // from a live 0.7.6 session.
-  test('the reported figure-qa command', () => {
-    const cmd =
-      'SCRIPTS_DIR="/Users/y/.claude/figure-qa-scripts"\n' +
-      'ls "$SCRIPTS_DIR/examples" 2>/dev/null\n' +
-      'cat "$SCRIPTS_DIR/check_raster.py" | head -100';
-    expect(bash(cmd)).toBe('read-only:ls');
-  });
-
-  test('semicolon form', () => {
-    expect(bash('SCRIPTS_DIR="/a/b"; ls "$SCRIPTS_DIR"')).toBe('read-only:ls');
-    expect(bash('S=/tmp/x; grep -o "a" $S')).toBe('read-only:grep');
-  });
-
-  test('multiple assignments in one segment', () => {
-    expect(bash('A=1 B=2; ls')).toBe('read-only:ls');
-  });
-
-  test('assignments alone are still not "a read"', () => {
-    // Same rule every neutral segment obeys: a command that runs nothing is
-    // not a read, so it must not be approved on its own.
-    expect(bash('S=/tmp/x')).toBeNull();
-  });
-});
-
-describe('an assignment PREFIX to a command is NOT inert', () => {
-  // The whole safety argument for the rule above. `PATH=/evil ls` runs `ls`
-  // AND chooses which one; accepting a segment that merely STARTS with an
-  // assignment would auto-approve exactly that.
-  const mustBeNull = [
-    'PATH=/evil ls',
-    'LD_PRELOAD=/evil.so cat /etc/passwd',
-    'PATH=/evil ls && cat x',
-    'FOO=bar cat /etc/shadow',
-    'FOO=bar; PATH=/evil ls',
-  ];
-  for (const cmd of mustBeNull) {
-    test(cmd, () => expect(bash(cmd)).toBeNull());
-  }
-
-  test('command substitution in the value is refused before the assignment rule is reached', () => {
-    // `hasShellControl` rejects `$(...)`/backticks first. That ordering is
-    // load-bearing: the assignment predicate alone would call these inert.
-    const R = ['r', 'm', ' ', '-', 'r', 'f', ' ', '/'].join('');
-    expect(bash(`FOO=$(${R})`)).toBeNull();
-    expect(bash(`FOO=\`${R}\``)).toBeNull();
-  });
-});
-
 describe('read-only utilities added after the live-session measurement', () => {
   const cases: Array<[string, string]> = [
     ['which inkscape rsvg-convert', 'read-only:which'],

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -558,8 +558,11 @@ describe('#959 superseded by ADR 0025: net-read ships, but TOOLS ONLY', () => {
   test('net-read covers exactly WebFetch and WebSearch', () => {
     expect(matchGroups('WebFetch', {}, NET_GROUPS)).toBe('net-read:WebFetch');
     expect(matchGroups('WebSearch', {}, NET_GROUPS)).toBe('net-read:WebSearch');
-    // Not a blanket network grant: Bash is still Bash.
-    expect(bash('echo hi', NET_GROUPS)).toBeNull();
+    // NOT asserted here: "Bash is still Bash". That reads like a guard and is
+    // vacuous -- `matchGroups` never consults a group's `tools` list for Bash
+    // (it routes through the command machinery), so the assertion holds for any
+    // possible `tools` content, including `tools: ['Bash']`. The live defence is
+    // `commands: []`, pinned directly by the test above.
   });
 });
 describe('#960 regression: case-insensitive filesystem', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -14,8 +14,9 @@ import {
 const ALL = ['read-only', 'vcs-read', 'build-test'];
 
 /** The write-side groups added in #959. Never enabled by default.
- *  `net-read` was designed alongside these and CUT before merge -- see the
- *  `no network group` block for what that absence must keep looking like. */
+ *  `net-read` was designed alongside these and CUT before merge; it is back as
+ *  of ADR 0025 but TOOLS ONLY, which is the distinction that permitted the
+ *  re-add -- see the '#959 superseded' block. */
 const WRITE_GROUPS = ['fs-write', 'vcs-write'];
 
 /** The scratch group (#994 follow-up). Never enabled by default. */
@@ -25,6 +26,11 @@ const SCRATCH_GROUPS = ['scratch'];
  *  corpus lives in artifact-clean.test.ts. */
 const ARTIFACT_GROUPS = ['artifact-clean'];
 
+/** The net-read group (ADR 0025). TOOLS ONLY, and in no level preset -- see
+ *  the '#959 superseded' block below for why the distinction is the whole
+ *  reason it was allowed back. */
+const NET_GROUPS = ['net-read'];
+
 /** Convenience: match a Bash command against the named groups. */
 function bash(command: string, groups: readonly string[] = ALL): string | null {
   return matchGroups('Bash', { command }, groups);
@@ -32,7 +38,13 @@ function bash(command: string, groups: readonly string[] = ALL): string | null {
 
 describe('permission-groups: known groups', () => {
   test('isKnownGroup', () => {
-    for (const name of [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS]) {
+    for (const name of [
+      ...ALL,
+      ...WRITE_GROUPS,
+      ...SCRATCH_GROUPS,
+      ...ARTIFACT_GROUPS,
+      ...NET_GROUPS,
+    ]) {
       expect(isKnownGroup(name)).toBe(true);
     }
     expect(isKnownGroup('bogus')).toBe(false);
@@ -41,7 +53,7 @@ describe('permission-groups: known groups', () => {
 
   test('knownGroupNames lists exactly the built-ins', () => {
     expect(knownGroupNames().sort()).toEqual(
-      [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS].sort(),
+      [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS, ...NET_GROUPS].sort(),
     );
   });
 });
@@ -504,11 +516,24 @@ describe('#960 regression: long-option abbreviation', () => {
   });
 });
 
-describe('#959: no network group ships', () => {
-  // `net-read` was cut after three review rounds found ten bypasses, five of
-  // them curl's. These assert the ABSENCE is real, so a future re-add has to
-  // delete a test rather than silently widen coverage.
-  test('curl, wget and gh api are covered by nothing', () => {
+describe('#959 superseded by ADR 0025: net-read ships, but TOOLS ONLY', () => {
+  // #959 cut `net-read` after three review rounds found ten bypasses, five of
+  // them curl's, and left a test asserting the absence so that any re-add had
+  // to be deliberate rather than a silent widening. This is that deliberate
+  // re-add, and the distinction that permits it is narrow and load-bearing:
+  //
+  //   #959's net-read covered COMMANDS (curl, wget, gh api). Every bypass it
+  //   died of was command-shaped -- curl's `-o`/`-O` write files, its output
+  //   is routinely piped into a shell, and `gh api` reaches mutating verbs.
+  //
+  //   ADR 0025's net-read covers TOOLS ONLY (`WebFetch`, `WebSearch`) and
+  //   ships `commands: []`. None of those five bypasses has a path back,
+  //   which the first test below proves rather than asserts.
+  //
+  // So the absence test is not deleted, it is INVERTED in the only direction
+  // that was ever the point: the commands must still be covered by nothing,
+  // now including when net-read itself is enabled.
+  test('curl, wget and gh api are covered by nothing — even with net-read on', () => {
     for (const cmd of [
       'curl https://example.com/data.json',
       'curl -sSL https://api.github.com/repos/o/r',
@@ -517,11 +542,24 @@ describe('#959: no network group ships', () => {
     ]) {
       expect(bash(cmd, WRITE_GROUPS)).toBeNull();
       expect(bash(cmd, [...ALL, ...WRITE_GROUPS])).toBeNull();
+      // The new coverage: enabling net-read must not resurrect #959's bypasses.
+      expect(bash(cmd, NET_GROUPS)).toBeNull();
+      expect(bash(cmd, [...ALL, ...WRITE_GROUPS, ...NET_GROUPS])).toBeNull();
     }
   });
 
-  test('knownGroupNames does not advertise one', () => {
-    expect(knownGroupNames()).not.toContain('net-read');
+  test('net-read carries NO commands at all', () => {
+    // The structural guarantee behind the test above. A future edit adding
+    // even one command to this group turns the bypass test's premise false,
+    // so this fails first and says why.
+    expect(BUILTIN_GROUPS['net-read']?.commands).toEqual([]);
+  });
+
+  test('net-read covers exactly WebFetch and WebSearch', () => {
+    expect(matchGroups('WebFetch', {}, NET_GROUPS)).toBe('net-read:WebFetch');
+    expect(matchGroups('WebSearch', {}, NET_GROUPS)).toBe('net-read:WebSearch');
+    // Not a blanket network grant: Bash is still Bash.
+    expect(bash('echo hi', NET_GROUPS)).toBeNull();
   });
 });
 describe('#960 regression: case-insensitive filesystem', () => {

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -1079,3 +1079,72 @@ describe('#880 the shipped defaults do not expose an unauthenticated daemon', ()
     expect(loadConfig(TEST_CONFIG).daemon.bind).toBe('127.0.0.1');
   });
 });
+
+describe('per-agent policy survives the config LOAD path (ADR 0025)', () => {
+  // Review found this untested end to end: `validateAgents`, `resolvePolicy`
+  // and the service were each covered in isolation, but nothing wrote a real
+  // TOML section and asserted it arrived. Deleting the `validateAgents(...)`
+  // call from `loadConfig` left the whole suite green.
+  //
+  // It guards a live coupling, not just wiring: `mergeSection` iterates
+  // `Object.keys(defaults)`, so a key absent from DEFAULT_CONFIG is silently
+  // DROPPED. `agents: {}` in the defaults is the only reason a user's section
+  // is reachable at all — and before this test, removing that line was pinned
+  // solely by a `toEqual` snapshot that anyone deleting it would "fix".
+  test('a real [auto_approve.agents.<type>] section reaches the loaded config', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `[auto_approve]
+approve_groups = ["read-only"]
+
+[auto_approve.agents.Explore]
+approve_groups = ["read-only", "net-read"]
+deny = ["curl"]
+`,
+    );
+    const config = loadConfig(TEST_CONFIG);
+    expect(config.auto_approve.agents?.['Explore']?.approve_groups).toEqual([
+      'read-only',
+      'net-read',
+    ]);
+    expect(config.auto_approve.agents?.['Explore']?.deny).toEqual(['curl']);
+    // The base is untouched by the section.
+    expect(config.auto_approve.approve_groups).toEqual(['read-only']);
+  });
+
+  test('an unknown KEY inside a section is rejected at load', () => {
+    fs.writeFileSync(
+      TEST_CONFIG,
+      `[auto_approve.agents.Explore]
+approve_group = ["read-only"]
+`,
+    );
+    expect(() => loadConfig(TEST_CONFIG)).toThrow(/approve_group/);
+  });
+
+  test('an unknown GROUP name inside a section warns but loads', () => {
+    // Warn, not throw: a throw reaches cli.ts's exit(1), and under the
+    // --install LaunchAgent (KeepAlive.SuccessfulExit=false) that is a
+    // crash-restart loop over a one-character typo. Matches the base path.
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(' '));
+    };
+    try {
+      fs.writeFileSync(
+        TEST_CONFIG,
+        `[auto_approve.agents.Explore]
+approve_groups = ["net-reed"]
+`,
+      );
+      const config = loadConfig(TEST_CONFIG);
+      expect(config.auto_approve.agents?.['Explore']?.approve_groups).toEqual(['net-reed']);
+    } finally {
+      console.warn = original;
+    }
+    // Because approve_groups REPLACES, this typo silently narrows the agent
+    // below base — which is exactly why it must be reported.
+    expect(warnings.join('\n')).toContain('net-reed');
+  });
+});

--- a/packages/daemon/tests/config.test.ts
+++ b/packages/daemon/tests/config.test.ts
@@ -464,6 +464,10 @@ describe('auto_approve config', () => {
   test('defaults are present', () => {
     expect(DEFAULT_CONFIG.auto_approve).toEqual({
       enabled: false,
+      // ADR 0025: empty by default. No shipped config grants any agent type
+      // anything the base does not already grant — a non-empty default here
+      // would be a per-role permission nobody asked for.
+      agents: {},
       // Resolved per platform (#822), so the expectation is too — but derived
       // from `detectLocalLLMPlatform` rather than from `DEFAULT_CONFIG`, which
       // would assert the value against itself and prove nothing.

--- a/packages/daemon/tests/mdns/advertise-decision.test.ts
+++ b/packages/daemon/tests/mdns/advertise-decision.test.ts
@@ -1,0 +1,129 @@
+/**
+ * #1051: a loopback bind stopped mDNS advertising with no log line at all.
+ *
+ * These test the DECISION, which is the part that can be tested — the caller is
+ * module-level startup code in cli.ts with no seam. What they cannot prove is
+ * that cli.ts calls it; that is pinned separately by asserting the bare
+ * `return null` is gone from the source.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  type MdnsAdvertiseInputs,
+  mdnsSuppression,
+  mdnsSuppressionMessage,
+} from '../../src/mdns/advertise-decision.ts';
+
+describe('cli.ts actually uses the decision', () => {
+  // Everything below tests a pure function. Without this, all of it would stay
+  // green if someone restored the bare `return null` in cli.ts -- a suite that
+  // passes while the bug is back is the ADR 0011 row-5 anti-pattern, and this
+  // file is defending a user-visible regression that shipped once already.
+  const cli = fs.readFileSync(path.join(import.meta.dir, '..', '..', 'src', 'cli.ts'), 'utf8');
+
+  test('the silent suppression return is gone', () => {
+    expect(cli).not.toContain('|| isLocalhostBind) return null;');
+  });
+
+  test('the suppression path logs the decision', () => {
+    expect(cli).toContain('mdnsSuppression(');
+    expect(cli).toContain('logFn(mdnsSuppressionMessage(');
+  });
+});
+
+/** Advertising: network bind, mDNS on, no flag. */
+const ADVERTISING: MdnsAdvertiseInputs = {
+  cliNoMdns: false,
+  configMdns: true,
+  isLocalhostBind: false,
+  bindHost: '0.0.0.0',
+};
+
+describe('mdnsSuppression', () => {
+  test('a network bind with mDNS enabled advertises', () => {
+    expect(mdnsSuppression(ADVERTISING)).toBeNull();
+  });
+
+  test('a loopback bind suppresses, carrying the host', () => {
+    // The case #880 made universal: every stock install takes this path now.
+    const s = mdnsSuppression({ ...ADVERTISING, isLocalhostBind: true, bindHost: '127.0.0.1' });
+    expect(s).toEqual({ kind: 'loopback', bindHost: '127.0.0.1' });
+  });
+
+  test('--no-mdns suppresses', () => {
+    expect(mdnsSuppression({ ...ADVERTISING, cliNoMdns: true })).toEqual({ kind: 'cli-flag' });
+  });
+
+  test('network.mdns = false suppresses', () => {
+    expect(mdnsSuppression({ ...ADVERTISING, configMdns: false })).toEqual({ kind: 'config' });
+  });
+
+  test('the CLI flag is reported ahead of a loopback bind', () => {
+    // Precedence is not cosmetic. Reporting 'loopback' here would tell the user
+    // to set daemon.bind -- advice their own --no-mdns would then override, so
+    // they would follow it and still see nothing.
+    const s = mdnsSuppression({ ...ADVERTISING, cliNoMdns: true, isLocalhostBind: true });
+    expect(s).toEqual({ kind: 'cli-flag' });
+  });
+
+  test('config is reported ahead of a loopback bind', () => {
+    const s = mdnsSuppression({ ...ADVERTISING, configMdns: false, isLocalhostBind: true });
+    expect(s).toEqual({ kind: 'config' });
+  });
+
+  test('the CLI flag outranks a config that also disables it', () => {
+    const s = mdnsSuppression({ ...ADVERTISING, cliNoMdns: true, configMdns: false });
+    expect(s).toEqual({ kind: 'cli-flag' });
+  });
+});
+
+describe('mdnsSuppressionMessage', () => {
+  test('the loopback message names the remedy AND the auth trap', () => {
+    const msg = mdnsSuppressionMessage({ kind: 'loopback', bindHost: '127.0.0.1' });
+    expect(msg).toContain('127.0.0.1');
+    expect(msg).toContain('daemon.bind');
+    // Naming bind alone would walk the user into the #880 exposure: "auto"
+    // resolves to false on every bind, so a widened bind with default auth is
+    // the unauthenticated LAN path 0.7.6 just closed.
+    expect(msg).toContain('auth.enabled');
+  });
+
+  test('deliberate suppressions state the fact without prescribing a remedy', () => {
+    // #1051 is explicit that these must not nag: someone who passed --no-mdns
+    // does not need to be told how to undo it on every boot.
+    for (const s of [{ kind: 'cli-flag' } as const, { kind: 'config' } as const]) {
+      const msg = mdnsSuppressionMessage(s);
+      expect(msg).toContain('Not advertising');
+      expect(msg).not.toContain('daemon.bind');
+      expect(msg).not.toContain('auth.enabled');
+    }
+  });
+
+  test('every suppression produces a non-empty [mDNS] line', () => {
+    // The whole point of #1051: no suppression path may be silent. A new kind
+    // added without a message would fail here rather than reintroduce the bug.
+    const all = [
+      { kind: 'cli-flag' } as const,
+      { kind: 'config' } as const,
+      { kind: 'loopback', bindHost: '127.0.0.1' } as const,
+    ];
+    for (const s of all) {
+      const msg = mdnsSuppressionMessage(s);
+      expect(msg.startsWith('[mDNS]')).toBe(true);
+      expect(msg.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('each suppression says something DIFFERENT', () => {
+    // Three conditions behind one message would be the same defect in a new
+    // costume: the user still could not tell which one fired.
+    const msgs = [
+      mdnsSuppressionMessage({ kind: 'cli-flag' }),
+      mdnsSuppressionMessage({ kind: 'config' }),
+      mdnsSuppressionMessage({ kind: 'loopback', bindHost: '127.0.0.1' }),
+    ];
+    expect(new Set(msgs).size).toBe(3);
+  });
+});

--- a/packages/web/src/lib/port-discovery.ts
+++ b/packages/web/src/lib/port-discovery.ts
@@ -31,7 +31,7 @@ export const DEFAULT_PORT_RANGE = DAEMON_PORT_RANGE;
  *
  * Budget: a healthy LAN daemon answers `/auth-info` in single-digit ms; an
  * unreachable host returns ECONNREFUSED in microseconds. The interesting
- * case is a host that ACCEPTs the TCP connection but never responds (broken
+ * case is a host that ACCEPTS the TCP connection but never responds (broken
  * proxy, half-dead daemon). 1500 ms gives enough slack for slow VPN paths
  * while keeping the worst-case scan under ~2 s before the modal surfaces an
  * error.


### PR DESCRIPTION
Release 0.7.7. Promotes `develop` (18 commits, three PRs) to `main`.

Merging tags `v0.7.7` and publishes to npm, GitHub releases and Homebrew.

## What ships

| PR | What |
|---|---|
| #1053 | remi supervises `llama-server` on Linux (#822) |
| #1054 | mDNS says why it is not advertising (#1051) |
| #1055 | `net-read` + per-agent permission scoping (ADR 0025), matcher gaps, eval-cancel |

## Why this release exists

A live 0.7.6 machine was escalating almost every subagent permission with the
GPU never firing. The log said why: **664 `approve (0ms)` vs 40
`decided_by=model`**, with escalations at exactly **`240001ms`** on
`WebFetch`/`WebSearch` — `eval queue wait exceeded`. Evals cost 7-10s, run
**serially**, and time out at 240s, so a waiter that ages out escalates
*before* acquiring a slot. That is why it looked like the model had given up.

`WebFetch`/`WebSearch` matched **no group at all**, so every web call from every
subagent took that path. `net-read` plus per-agent scoping is the fix; the
matcher additions (`which`, `basename`, `dirname`, `realpath`, `mdfind`, `du`,
`df`) remove more of the same traffic.

## Verified WITHOUT GitHub Actions

**Actions has been down since 22:39** — no runs on any branch, and close/reopen
did not wake it. So the gates were reproduced locally in Docker at the versions
CI pins, not the host's: **bun 1.3.11** (CI's `BUN_VERSION`, not the local
1.3.14) and **typos 1.28.4** (not the local 1.49). Clean clone, writable, git
present — the shape PR #1042 recorded a bare `oven/bun` image as failing to
provide.

| Gate | develop (baseline) | this head |
|---|---|---|
| install | PASS | PASS |
| Spelling | PASS | PASS |
| Lint | PASS | PASS |
| Type Check (4 targets) | PASS | PASS |
| Coverage >=60% | PASS | **PASS (91.39%)** |
| Test | 5921 pass / 37 fail | 5983 pass / 37 fail |

The 37 are `WebSocketServer` (15) and `question_snapshot` (5) — port-binding
tests, Docker-networking artifacts. **Not asserted from resemblance:** the same
container ran `develop`, and `comm` over the sorted failure sets is empty in
both directions. **Zero regressions**, 62 more passing tests.

What this does NOT reproduce is GitHub's network environment, which is exactly
where those 37 live. Green here plus a matching baseline is good evidence, not
the same evidence as the real gate.

## This branch burned three safety nets, and that is on the record

Stated plainly because a release note that hides it is the ADR 0011 failure:

1. **A P0 PATH-poisoning bypass shipped into the branch and was reverted before
   merge.** `PATH=/evil; ls` approved at 0ms on the *default* preset, while the
   guarded `PATH=/evil ls` correctly escalated — the semicolon form is worse,
   since a bare assignment persists for later segments. The test defending that
   exact property pinned five cases, every one the glued spelling that already
   worked. Reverted with the reasoning recorded at the call site for attempt 6.
2. **A commit was pushed whose diff contradicted its message.** Mutation-testing
   agents ran against a shared working tree; one probe was captured by a commit
   and two of that commit's own edits were wiped, leaving `agent_type` dropped
   from the hook-time call — the feature inert on the one path subagents reach.
   Restored and pinned.
3. **Six review lenses found four more tests that could not fail on their own
   names**, two of which were written earlier in the same session to close
   gaps found earlier in the same session.

Every one was caught by review, not by authoring. The mutation evidence for the
fixes is in #1055.

## Known open, carried forward

- The eval queue is **serial**; a waiter burns the full `queue_timeout` before
  shedding, and `cancelStale('Stop')` drains main-context waiters wholesale.
  `net-read` removes web calls from that lane but any sufficient fan-out of
  unmatched commands reproduces the stall.
- `allow` and `approve_groups` do not compose across segments: `uv run … && ls
  -la` has segment 1 covered by `allow`, segment 2 by `read-only`, and matches
  **neither**.
- A variable-assignment segment still sinks an otherwise-covered read (the
  reverted fix); a correct one must carry inertness forward across segments.
- A mistyped `[auto_approve.agents.<name>]` section is undetectable — no
  registry. Group names inside a section now warn.
- Relay plaintext in rotating-code mode (#881); `require_local_auth` (#869);
  bare tool-name `allow` carrying no destination veto (#1032).
