### PR TITLE
Phase 2: destination-checked redirect, heredoc, and sed -i grants

### DIFF
--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -181,3 +181,26 @@ overall approve rate 2301/3188 = 72.2%.
 - Whether to turn `REMI_HOOK_DEBUG=1` on by default for a capture window (or
   add a dedicated, structure-preserving-only capture flag) so the next
   baseline has a real PermissionRequest corpus on both machines.
+
+## Phase 2 addendum (2026-08-15, same day — after ADR 0026 grants)
+
+The 12-record PreToolUse proxy corpus contains zero Phase-2-shaped commands
+(its two "redirection" misses are for-loops with stderr-discards — Phase 3
+shapes), so corpus coverage is unchanged at 41.7% and the honest measurement
+is direct probes of the #996/#1041 shapes at `trusted`, all verified on this
+branch:
+
+| shape (issue sample) | before | after |
+|---|---|---|
+| `cat > notes.md` / `cat a.txt >> log.txt` | null | `read-only:cat` |
+| `bun test > out.log 2>&1` | null | `build-test:bun test` |
+| `git diff > review.diff` | null | `vcs-read:git diff` |
+| `cat >> src/...test.ts <<'EOF' ... EOF` (#996 sample) | null | `read-only:cat` |
+| `sed -i '' 's/.../.../g' src/lib/api.ts` (#996 sample, BSD) | null | `fs-write:sed -i` |
+| `cat > .env`, and `cat > /tmp/.env` (#1060) | the /tmp form approved at 0ms | null |
+| bash heredoc with destructive body | null | null (pinned invariant) |
+| sed script with a `w /etc/cron.d/evil` command | n/a | null |
+
+Re-measure against a real PermissionRequest corpus (REMI_HOOK_DEBUG capture)
+once one exists; #996's 50%+13% miss buckets are the population these grants
+target.

--- a/.context/decisions/0010-allow-deny-matching-asymmetry.md
+++ b/.context/decisions/0010-allow-deny-matching-asymmetry.md
@@ -28,7 +28,11 @@ correct for both.
 Allow is precise. A Bash command is split on `; && || |`, and every segment must
 either match one of the user's prefixes or be a neutral no-op (`cd`, `pwd`,
 `echo`, `true`, `:`). Any segment carrying shell control (backticks, `$()`,
-redirects, `-exec` and its family) is refused even when a prefix matches. An
+redirects, `-exec` and its family) is refused even when a prefix matches --
+except that, in the GROUP path only, ADR 0026's destination-checked grants may
+delete a specific redirect clause or heredoc whose target was positively
+proven before matching runs; the veto itself is unchanged and still refuses
+whatever no grant proved. An
 entry shaped like a tool name (`Read`, `mcp__*`) matches that **tool** and never
 a Bash command containing the word.
 

--- a/.context/decisions/0026-destination-checked-write-grants.md
+++ b/.context/decisions/0026-destination-checked-write-grants.md
@@ -1,0 +1,110 @@
+# ADR 0026: Write grants for decidable shell shapes, checked by destination
+
+**Status:** accepted
+**Date:** 2026-08-15
+**Owner:** epic #1057 Phase 2 (#996, #1041, #1060)
+
+## Context
+
+Deterministic group coverage was measured at 12.9% of real asked-remi Bash
+traffic (#996), with 63% of the misses being redirection and heredoc shapes
+that `hasShellControl` refuses wholesale — the #536 fix, reaffirmed by ADR
+0010's Decision ("any segment carrying shell control ... is refused even when
+a prefix matches"). At `trusted`, 58% of Bash escalations were file writes
+against a config that already approves file writes through the `Write`/`Edit`
+tools (#1041): `cat > notes.md` escalated to a phone while `Write(notes.md)`
+approved at 0ms. The 4B model then justified many of these escalations with
+factually wrong category claims (#972), because commands that should never
+have reached it did.
+
+The constraint that shaped everything here: this repo's allow path produced
+three P0s in one month (#536, #1031, #1034), every one from logic that tried
+to understand a command more cleverly than a literal match. #1041 states the
+boundary: cover only shapes whose write destination is DECIDABLE at the shell
+layer; never classify interpreter code.
+
+## Decision
+
+The write groups gain coverage for three decidable shapes, each proven by its
+destination and vetoed by ADR 0018's axes; everything else is refused exactly
+as before, and `hasShellControl`, `splitCompoundParts`, and `maskQuotedSpans`
+are byte-for-byte untouched:
+
+1. **Redirect-to-file** (extends the `scratch` precedent): a pre-pass
+   (`sanitizeCommandForRedirectGrants`) deletes a `path`-kind redirect clause
+   before matching when its cwd-resolved target is proven allowed — under a
+   scratch root (`scratch` active, the pre-existing rule), or, with `fs-write`
+   active, a relative path that cannot ascend out of the starting directory
+   (`RelativeCwd`: starts in-tree, composes only relative non-ascending `cd`s,
+   collapses to sticky `null` on any absolute/`~`/`$VAR`/unreliable/dash-reset
+   `cd`). In both grants the resolved target must additionally clear
+   `isSensitiveWritePath` — which the scratch carve-out had silently omitted
+   (#1060: `cat a > /tmp/.env` approved at 0ms; fixed here first, as a
+   narrowing). `opaque` targets are never deleted (#1000); `discard`/`fd-dup`
+   were always permitted. The head command still needs its own coverage —
+   deleting a clause grants nothing by itself.
+2. **Heredoc excision** (`exciseHeredocsForGroups`): `<< WORD` operator and
+   body are excised before compound splitting IF recognition fully succeeds —
+   plain `[A-Za-z0-9_]+` delimiter, single heredoc per line, terminator found,
+   and (for an unquoted delimiter, whose body the shell expands) no `$(`,
+   backtick, or `<(` in the body. Any failure leaves the command byte-for-byte
+   intact, preserving the previous accidental-escalation behavior. The body is
+   inert stdin data; safety rests on a pinned invariant: **no interpreter is
+   in any group's command list**, so `bash <<EOF` / `python3 - <<'PY'` remain
+   uncovered after excision by construction. Adding an interpreter to a group
+   would silently void this — the test suite pins it.
+3. **`sed -i`** as an `fs-write` prefix behind a page-sized script-shape
+   allowlist: every script token must be exactly `s<D>…<D>…<D>[gIp0-9]*` or
+   `y<D>…<D>…<D>` with no `;` — refusing sed's `w`/`W` (arbitrary file write),
+   GNU `s///e` (execute), `r`/`R`, addresses, and braces. `-f`/`--file` is
+   refused by the flag axis; the `-i` backup suffix gets its own
+   `[A-Za-z0-9._-]*` check (a GNU backup suffix containing `/` redirects the
+   backup write). File destinations ride the existing `writeGroupVeto`
+   destination axis.
+
+The grants run in the GROUP path only. The user-allow path
+(`pattern-matcher.ts`) keeps today's behavior: a user allow entry still fails
+on redirects and heredoc bodies. Asymmetry is deliberate — groups carry
+curated veto profiles the allow path does not.
+
+## Consequences
+
+- The redirection (50%) and heredoc (13%) miss buckets from #996 become
+  coverable; `cat > notes.md <<'EOF'` compositions approve at 0ms when the
+  destination proves out. Measured deltas live in
+  `.context/approval-rate-baseline-2026-08.md`'s successor runs.
+- ADR 0010's Decision line is amended by this ADR: shell control is refused
+  *unless a destination-checked grant proved the specific clause*, and the
+  enforcement point moves one step earlier (clause deletion) without touching
+  the veto itself.
+- New standing obligations: (a) never add an interpreter to a group command
+  list (voids the heredoc invariant); (b) any new grant must check
+  `isSensitiveWritePath` on the RESOLVED target — #1060 is the receipt for
+  what omitting it costs; (c) the single-walk rule holds — one cwd walk feeds
+  all grants, because a second walk that disagrees is a bypass (#1000).
+- Known residuals, verified fail-closed: GNU's attached-suffix spelling
+  `sed -i.bak …` matches no prefix (prefix matching requires `sed -i` + space)
+  and still escalates; on BSD/macOS sed, `-i` consumes the next token as a
+  suffix, so a GNU-read command may parse differently under BSD — the
+  divergent reading errors or writes an odd backup name, never a sensitive
+  write or execution. Both stay documented rather than solved.
+
+## Alternatives considered
+
+- **Lift the shell-control veto for covered heads:** rejected — the veto is
+  the #536 fix; the whole point is proving the clause, not trusting the head.
+- **Classify interpreter heredoc bodies (Python AST allowlist):** rejected per
+  #1041's own analysis — an incomplete classifier grants arbitrary code
+  execution while reporting `fs-write`.
+- **Hotfix #1060 to develop separately:** offered; owner chose in-phase
+  (scratch-tree-only blast radius).
+- **Descope `sed -i`:** kept as the standing fallback if the shape rule ever
+  needs to grow past a page; owner chose to include it at this size.
+
+## Receipts
+
+#996 (measurement), #1041 (the decidable-shapes boundary), #1060 (the gap
+this fixes first), #536/#1031/#1034 (why cleverness is rationed), #1000 (the
+opaque/single-walk rules), #1047 (dash reset), ADR 0010, ADR 0018. Probes and
+adversarial cases: `permission-groups.test.ts` blocks tagged #1060/#1041 and
+the heredoc/sed describe blocks.

--- a/.context/decisions/README.md
+++ b/.context/decisions/README.md
@@ -40,6 +40,8 @@ add a row below.
 | [0022](0022-status-bar-never-freezes.md) | Status-bar liveness is bounded by `HEARTBEAT_MS`, never by a human |
 | [0023](0023-artifact-deletion-is-proved-not-judged.md) | (proposed) Deletion approves only when the target is provably derived — amends #956's blanket escalate rule |
 | [0024](0024-loopback-bind-default.md) | The daemon binds loopback by default; off-machine access is opt-in (0023 is claimed by an un-merged branch) |
+| [0025](0025-agent-scoped-permissions.md) | Permissions scope per agent_type: deny unions with base, allow/groups replace it |
+| [0026](0026-destination-checked-write-grants.md) | Write grants for decidable shell shapes (redirects, heredocs, sed -i), proven by destination |
 
 ## By area
 
@@ -47,7 +49,7 @@ Most work touches one of these clusters, and the ADRs in a cluster constrain
 each other — reading one without its siblings is how a "fix" reopens the case
 another one closed.
 
-- **Permission decisions / auto-approve:** 0003, 0010, 0015, 0016, 0017, 0018, 0023
+- **Permission decisions / auto-approve:** 0003, 0010, 0015, 0016, 0017, 0018, 0023, 0025, 0026
 - **Questions + notifications:** 0002, 0004, 0019, 0020, 0021, 0022
 - **Protocol + contracts:** 0012, 0013, 0014, 0006
 - **Sessions + transport:** 0001, 0005, 0009, 0024

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -432,12 +432,22 @@ function classifyScratchAbsolute(token: string): { segments: string[]; rootLen: 
   for (const marker of ['$TMPDIR', '${TMPDIR}']) {
     if (token === marker || token.startsWith(`${marker}/`)) {
       const rest = token.slice(marker.length).replace(/^\//, '');
+      // The $TMPDIR/-PREFIX carve-out is consumed above; the REMAINDER must
+      // contain no FURTHER `$`/`~` anywhere (#1061 -- see the anywhere-check
+      // note on `resolveRelativeTarget` below for the mid-path bypass this
+      // closes). `$TMPDIR/x` and `$TMPDIR/sub/file` stay granted; `$TMPDIR/$FOO`
+      // does not, even though it starts with the trusted marker.
+      if (rest.includes('$') || rest.includes('~')) return null;
       const extra = rest === '' ? [] : rest.split('/');
       const segs = joinScratchSegments(['$TMPDIR'], 1, extra);
       return segs === null ? null : { segments: segs, rootLen: 1 };
     }
   }
   if (token.startsWith('/')) {
+    // Same anywhere-check as the `$TMPDIR` arm above, applied before dot-dot
+    // resolution: a plain `/tmp/...`/`/private/tmp/...` token gets no
+    // trusted-prefix carve-out at all, so ANY `$`/`~` anywhere refuses it.
+    if (token.includes('$') || token.includes('~')) return null;
     const resolved = resolveDotDot(token);
     const segs = resolved.split('/').filter((s) => s !== '');
     if (segs[0] === 'tmp') return { segments: segs, rootLen: 1 };
@@ -464,7 +474,16 @@ function resolveScratchTarget(
 ): { segments: readonly string[]; rootLen: number } | null {
   const absolute = classifyScratchAbsolute(token);
   if (absolute !== null) return absolute;
-  if (token.startsWith('/') || token.startsWith('~') || token.startsWith('$')) return null;
+  if (token.startsWith('/')) return null;
+  // Anywhere-check, not just a leading-character one (#1061). A relative
+  // token composed onto a scratch-rooted cwd may contain NO `$`/`~` at ANY
+  // position: `sub/$FOO`, `sub/${FOO}` and `../$FOO` all named an unresolved
+  // shell expansion mid-path while starting with an ordinary-looking
+  // character, so the old `token.startsWith('~') || token.startsWith('$')`
+  // check (which only inspected the first character) granted them the
+  // instant a `cd` had put the tracked cwd under a scratch root. Probe-
+  // verified: `cd /tmp/$FOO && cat a > x` approved before this fix.
+  if (token.includes('$') || token.includes('~')) return null;
   if (cwd === null) return null;
   const segs = joinScratchSegments(cwd.segments, cwd.rootLen, token.split('/'));
   return segs === null ? null : { segments: segs, rootLen: cwd.rootLen };
@@ -570,12 +589,17 @@ type RelativeCwd = readonly string[] | null;
  * Resolve `token` to its offset from the fs-write start directory given
  * `relCwd`, or null if it cannot be shown to stay inside it.
  *
- * An absolute-shaped token (leading `/`, `~`, or `$`) is refused outright,
- * never composed with `relCwd`: fs-write's grant is for a target IN TREE
- * relative to wherever the command runs, and an absolute path names a
- * location this matcher has no basis to trust regardless of the tracked
- * offset — that is `scratch`'s grant to make, for its own four rooted
- * shapes, not this one's.
+ * An absolute-shaped token (leading `/`) is refused outright, never composed
+ * with `relCwd`: fs-write's grant is for a target IN TREE relative to
+ * wherever the command runs, and an absolute path names a location this
+ * matcher has no basis to trust regardless of the tracked offset — that is
+ * `scratch`'s grant to make, for its own four rooted shapes, not this one's.
+ *
+ * A `~`/`$` ANYWHERE in the token also refuses it, not only when leading
+ * (#1061). The old check only inspected the first character, so `sub/$FOO`
+ * and `sub/${FOO}` — an unresolved shell expansion sitting mid-path — were
+ * composed onto `relCwd` and granted like an ordinary relative path. Probe-
+ * verified: `cat a > sub/$FOO` approved before this fix.
  *
  * Reuses `joinScratchSegments` with `floorLen: 0` — the start directory
  * itself is the floor a composed offset may never pop below, exactly the
@@ -583,7 +607,8 @@ type RelativeCwd = readonly string[] | null;
  * enforces, just with the floor at 0 instead of scratch's root length.
  */
 function resolveRelativeTarget(token: string, relCwd: RelativeCwd): RelativeCwd {
-  if (token.startsWith('/') || token.startsWith('~') || token.startsWith('$')) return null;
+  if (token.startsWith('/')) return null;
+  if (token.includes('$') || token.includes('~')) return null;
   if (relCwd === null) return null;
   return joinScratchSegments(relCwd, 0, token.split('/'));
 }
@@ -690,6 +715,45 @@ interface RedirectGrantCwd {
 }
 
 /**
+ * Mirrors shell-safety.ts's PRIVATE `REDIRECT_CLAUSE_RE` (`/\d*>>?\s*&?\S+/g`)
+ * so this module can find clause OFFSETS without that module exporting one
+ * (ADR 0026: shell-safety.ts stays untouched). Used ONLY to decide whether a
+ * clause is eligible for deletion below; the actual deletion still runs
+ * through `rewriteRedirectClauses`, so a drift between the two patterns could
+ * only ever change which segments this pre-scan is cautious about, never what
+ * gets deleted once a segment passes it.
+ */
+const REDIRECT_CLAUSE_OFFSET_RE = /\d*>>?\s*&?\S+/g;
+
+/**
+ * True if `segment` contains a redirect-clause-shaped match whose start is
+ * NOT preceded by whitespace or the start of the segment — i.e. it is glued
+ * onto the end of a preceding word, the way `2>x` is glued onto `cat` in
+ * `cat2>x`. Bash parses that as the single command name `cat2` (verified:
+ * exit 127), not `cat` followed by a redirect, so deleting the glued clause
+ * (as the grant pass below otherwise would) makes the matcher approve `cat`
+ * while a DIFFERENT command actually runs. A real fd-redirect always has
+ * whitespace, or nothing, before its digit: `cat 2>x`.
+ *
+ * Deliberately NOT the `/(^|\s)(clause)/`-with-a-captured-preceding-char
+ * shape: that alternation requires CONSUMING the preceding character as part
+ * of the match, so on `cat2>x` it never matches the `2>x` substring AT ALL
+ * (the character before it, `t`, is neither whitespace nor start-of-string) —
+ * it does not report the glued clause as "bad", it simply never sees it,
+ * which would make a scan built that way vacuously pass. Finding every
+ * REDIRECT_CLAUSE_RE-shaped match by its own offset, unconditionally, and
+ * then inspecting the character immediately before that offset, is what
+ * actually distinguishes the two shapes.
+ */
+function segmentHasGluedRedirectClause(segment: string): boolean {
+  for (const m of segment.matchAll(REDIRECT_CLAUSE_OFFSET_RE)) {
+    const idx = m.index ?? 0;
+    if (idx > 0 && !/\s/.test(segment[idx - 1] as string)) return true;
+  }
+  return false;
+}
+
+/**
  * Remove every redirect clause in `segment` whose target an ACTIVE grant
  * covers: `scratch`'s absolute-root proof, `fs-write`'s relative-offset
  * proof, or both — a clause deletable by either grant is deleted. REMOVES the
@@ -702,6 +766,13 @@ interface RedirectGrantCwd {
  * `hasShellControl` already permits them — and `opaque` must never be removed,
  * since removing it is exactly how a second operator hidden inside the greedy
  * match would escape the veto that was going to catch it.
+ *
+ * Callers MUST check `segmentHasGluedRedirectClause` first and skip calling
+ * this at all when it is true (see the call site in
+ * `sanitizeCommandForRedirectGrants`) — a glued clause is not modeled here,
+ * because by the time a clause reaches this function's callback there is no
+ * way to recover whether ITS particular match was glued or not: the deletion
+ * has to be refused for the whole segment, before any deletion is attempted.
  */
 function sanitizeSegmentRedirects(
   segment: string,
@@ -787,11 +858,22 @@ function sanitizeCommandForRedirectGrants(
       scratchCwd = unreliable ? null : advanceScratchCwd(scratchCwd, operand);
       relativeCwd = unreliable ? null : advanceRelativeCwd(relativeCwd, operand);
     } else if (trimmed !== '') {
-      text = sanitizeSegmentRedirects(
-        part.text,
-        { scratch: scratchCwd, relative: relativeCwd },
-        grants,
-      );
+      // A glued clause (`cat2>x`) means bash reads a DIFFERENT command name
+      // than the one this matcher is about to judge (#1061). Deleting even a
+      // different, legitimately-spaced clause in the same segment would leave
+      // that glued absorption behind, unexamined, in the command handed to
+      // `matchCoveredCommand` — so ANY glued clause in the segment skips
+      // deletion for the WHOLE segment, leaving `text` as the original
+      // `part.text`. That fails closed exactly like every other unproven
+      // redirect: `hasShellControl` sees the still-present, non-`/dev/null`
+      // clause and vetoes the segment, same as before this grant existed.
+      text = segmentHasGluedRedirectClause(part.text)
+        ? part.text
+        : sanitizeSegmentRedirects(
+            part.text,
+            { scratch: scratchCwd, relative: relativeCwd },
+            grants,
+          );
     }
     rebuilt += i === 0 ? text : `${joinerText(part.joiner)}${text}`;
   }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -342,6 +342,38 @@ function cdEffectIsUnreliable(joiner: CompoundJoiner, nextJoiner: CompoundJoiner
 }
 
 /**
+ * True if a redirect clause targeting `path` may be DELETED rather than left
+ * for `hasShellControl` to veto: the target resolves STRICTLY under a scratch
+ * root, AND is not itself a sensitive destination.
+ *
+ * #1060 + ADR 0018 axis 3. `isStrictlyUnderScratchRoot` alone proves only the
+ * destination-root half of a write-side match (axis 3's "under `/tmp`" half);
+ * it never asked WHAT the target names, so `cat a > /tmp/.env`,
+ * `cat a > /tmp/.git/hooks/pre-commit` and `cat a > /tmp/sub/package.json` all
+ * qualified and had their redirect clause deleted before
+ * `segmentTouchesSensitivePath` — this file's own axis-3 conjunct — ever got a
+ * token to look at: the clause it would have vetoed was gone by the time that
+ * check ran. Same "one proof holds, the other owner's veto never runs" shape
+ * ADR 0018 exists to name for every other write-side match; this is that gap
+ * inside `scratch`'s own redirect carve-out.
+ *
+ * Checked on the RESOLVED path, not the raw token, so a cd-established root
+ * composed with a relative target still lands on the real destination before
+ * the sensitivity check runs — `cd /tmp && cat a > .git/hooks/pre-commit` must
+ * be caught exactly like the absolute spelling.
+ */
+function isGrantedScratchRedirectTarget(path: string, cwd: ScratchCwd): boolean {
+  const resolved = resolveScratchTarget(path, cwd);
+  if (resolved === null || resolved.segments.length <= resolved.rootLen) return false;
+  return !isSensitiveWritePath(scratchSegmentsToPath(resolved.segments));
+}
+
+/** Render resolved scratch-root segments back into a path `isSensitiveWritePath` can read. */
+function scratchSegmentsToPath(segments: readonly string[]): string {
+  return segments[0] === '$TMPDIR' ? segments.join('/') : `/${segments.join('/')}`;
+}
+
+/**
  * Remove every redirect clause in `segment` whose target is a plain path under
  * a scratch root. REMOVES the clause entirely rather than retargeting it to
  * `/dev/null`: a retargeted clause would still leave a token like
@@ -357,7 +389,7 @@ function cdEffectIsUnreliable(joiner: CompoundJoiner, nextJoiner: CompoundJoiner
 function sanitizeSegmentRedirects(segment: string, cwd: ScratchCwd): string {
   return rewriteRedirectClauses(segment, (target, text) => {
     if (target.kind !== 'path') return text;
-    return isStrictlyUnderScratchRoot(target.path, cwd) ? '' : text;
+    return isGrantedScratchRedirectTarget(target.path, cwd) ? '' : text;
   });
 }
 

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -84,6 +84,194 @@ function hasWriteGroupPositionalVeto(segment: string): boolean {
   return false;
 }
 
+// ---------------------------------------------------------------------------
+// `sed -i` under a strict script-shape allowlist (#1057 phase 2, commit 4).
+// Placed here, in `permission-groups.ts` alongside the rest of fs-write's
+// veto plumbing, rather than in `write-flag-safety.ts`: the flag axis there
+// answers "is every FLAG safe", but what a permitted sed SCRIPT is allowed
+// to say is a shape no flag-letter allowlist can express, and it needs to
+// interact with `hasUnsafeWriteFlag`'s call site to normalize `-i`'s attached
+// suffix first (see `normalizeSedInPlaceSuffix`) -- both are decisions this
+// file already owns for every other write prefix (`artifactCleanVeto`,
+// `scratchTargetVeto`).
+// ---------------------------------------------------------------------------
+
+/**
+ * `sed -i` accepts an attached backup suffix with no separator (`-i.bak`).
+ * `write-flag-safety.ts`'s short-option scan checks every alphabetic
+ * character of a `-`-prefixed token as a possible flag letter (by design —
+ * see that module's doc), so an unnormalized `.bak` would need ITS OWN
+ * letters on the safe list, which is not what that list means. Normalizes
+ * every `-i<suffix>` token on a `sed` segment to bare `-i` before handing it
+ * to `hasUnsafeWriteFlag`; every other token, and every non-sed segment,
+ * passes through untouched.
+ *
+ * This is also exactly correct GNU getopt semantics, not a hack: `-i` takes
+ * an OPTIONAL argument, so once it appears, getopt consumes the REST of that
+ * token as its value regardless of what letters are in it — `-in` really is
+ * `-i` with suffix `n`, not `-i -n`. The suffix's own SHAPE (must contain no
+ * path separator or `*`) is verified independently by `sedScriptShapeVeto`,
+ * which sees the original, unnormalized token.
+ */
+function normalizeSedInPlaceSuffix(segment: string): string {
+  if (!/^sed\b/.test(segment)) return segment;
+  return shellWords(segment)
+    .map((w) => (/^-i.+$/.test(w) ? '-i' : w))
+    .join(' ');
+}
+
+/**
+ * Split `text` on UNESCAPED occurrences of the single delimiter character
+ * `d`: a `d` preceded by a backslash is literal and does not split, and the
+ * backslash+`d` pair is kept verbatim in the field (exactly as sed's own
+ * parser would see it — this function only needs to find the field
+ * boundaries, not unescape their contents).
+ */
+function splitOnUnescapedDelimiter(text: string, d: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '\\' && i + 1 < text.length) {
+      current += c + text[i + 1];
+      i++;
+      continue;
+    }
+    if (c === d) {
+      fields.push(current);
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  fields.push(current);
+  return fields;
+}
+
+/**
+ * True if `script` is EXACTLY one `s<D>...<D>...<D>[gIp0-9]*` or
+ * `y<D>...<D>...<D>` sed command — `D` any single non-alphanumeric,
+ * non-backslash delimiter, the three delimited fields containing no
+ * unescaped `D`. Anything else fails closed: an address prefix (`/re/s///`,
+ * `1,5s///`) and a brace block both fail the leading-letter check below (the
+ * first character is not literally `s`/`y`); a trailing side-command
+ * (`w file`, `W`, `e`, `r`, `R`) fails the `y`'s empty-trailer or the `s`'s
+ * `[gIp0-9]*` check; a `;`-chained second command is refused outright,
+ * rather than trusted to the shape checks alone, because it is the one
+ * adversary this function must make trivially auditable: this script
+ * contains no `;`, full stop.
+ */
+function sedScriptShapeOk(script: string): boolean {
+  if (script.includes(';')) return false;
+  const cmd = script[0];
+  if (cmd !== 's' && cmd !== 'y') return false;
+  const d = script[1];
+  if (d === undefined || d === '\\' || /[A-Za-z0-9]/.test(d)) return false;
+  const fields = splitOnUnescapedDelimiter(script.slice(1), d);
+  if (fields.length !== 4) return false;
+  const trailing = fields[3] ?? '';
+  return cmd === 'y' ? trailing === '' : /^[gIp0-9]*$/.test(trailing);
+}
+
+/**
+ * Script-shape veto for a `sed` segment: every script the command would
+ * actually run — the bare positional script, or each `-e`/`--expression`
+ * value — must pass `sedScriptShapeOk`. A `-f`/`--file` script (loaded from
+ * an arbitrary external file) is not modeled here at all, because it is
+ * already refused by the flag axis (`-f`/`--file` are not on `sed`'s safe
+ * list in `write-flag-safety.ts`) before this veto's verdict can matter.
+ *
+ * `-i`'s own backup-suffix VALUE gets a second, independent check here, on
+ * the ORIGINAL (unnormalized) token: a suffix containing `/` or `*` can
+ * redirect GNU sed's backup to an arbitrary path (sed expands `*` to the
+ * target's own name and treats the result as a path), which is a
+ * destination-axis bypass `segmentTouchesSensitivePath` never sees — the
+ * suffix is a flag VALUE, not the command's final file argument.
+ */
+function sedScriptShapeVeto(segment: string): boolean {
+  if (!/^sed\b/.test(segment)) return false;
+  const words = shellWords(segment);
+  const hasScriptFlag = words.some(
+    (w) => w === '-e' || w === '--expression' || w.startsWith('--expression='),
+  );
+  let positionalConsumed = false;
+  for (let i = 1; i < words.length; i++) {
+    const w = words[i] as string;
+    if (w === '') continue;
+    if (w === '-i' || /^-i.+$/.test(w)) {
+      const suffix = w === '-i' ? '' : w.slice(2);
+      if (!/^[A-Za-z0-9._-]*$/.test(suffix)) return true;
+      if (w === '-i' && words[i + 1] === '') i++; // BSD `-i ''`: consume the empty suffix
+      continue;
+    }
+    if (w === '--in-place' || w.startsWith('--in-place=')) {
+      const suffix = w.startsWith('--in-place=') ? w.slice('--in-place='.length) : '';
+      if (!/^[A-Za-z0-9._-]*$/.test(suffix)) return true;
+      continue;
+    }
+    if (w === '-e' || w === '--expression') {
+      const script = words[i + 1];
+      if (script === undefined || !sedScriptShapeOk(script)) return true;
+      i++;
+      continue;
+    }
+    if (w.startsWith('--expression=')) {
+      if (!sedScriptShapeOk(w.slice('--expression='.length))) return true;
+      continue;
+    }
+    // Every other flag this family allows takes no argument; an unrecognized
+    // one is the flag axis's job, not this veto's.
+    if (w.startsWith('-')) continue;
+    // The bare positional script -- only the FIRST such token, and only when
+    // no `-e`/`--expression` supplied one instead; every later positional is
+    // a FILE argument (covered independently by `segmentTouchesSensitivePath`).
+    if (!hasScriptFlag && !positionalConsumed) {
+      positionalConsumed = true;
+      if (!sedScriptShapeOk(w)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Two residuals, DECLARED rather than open bugs, mirroring how `scratch` and
+ * `artifact-clean` document their own honest limits above.
+ *
+ * 1. `matchPrefix` (shell-safety.ts) requires the curated prefix to be
+ *    followed by a literal SPACE (`segment === p || segment.startsWith(p +
+ *    ' ')`), which is exactly right for every OTHER prefix in this file but
+ *    cannot match GNU's ATTACHED `-i` suffix spelling: `sed -i.bak 's/a/b/'
+ *    f` does not start with `sed -i ` (the fifth character after `-i` is
+ *    `.`, not a space), so it never reaches `sedScriptShapeVeto` at all --
+ *    the whole command falls through UNMATCHED. Verified, not assumed:
+ *    `sed -i.bak 's/a/b/' f` returns null under every group. Fixing this
+ *    would mean rewriting the command text before prefix-matching runs (the
+ *    same shape of pre-pass `sanitizeCommandForRedirectGrants` and
+ *    `exciseHeredocsForGroups` use), and doing so safely requires the
+ *    downstream veto to agree on which token is the suffix versus the
+ *    script -- a second, independent walk that must never disagree with the
+ *    first (#1000's law) for a feature already safe on its escalate side.
+ *    Descoped rather than built under time pressure; the fallback is
+ *    unconditionally safe (escalate to the LLM), never unsafe.
+ * 2. This veto's `-i`/`-e` token walk assumes GNU getopt semantics
+ *    throughout (a bare `-i` takes no argument unless one is attached in
+ *    the SAME token; a BSD-style separate, non-empty suffix argument is not
+ *    recognized). Real BSD/macOS sed disagrees: its `-i` MANDATORILY
+ *    consumes the very next token as the backup suffix, so
+ *    `sed -i 's/a/b/' file` -- this file's own first positive example --
+ *    would, on a real BSD sed, use `'s/a/b/'` as the suffix and `file` as
+ *    the (almost certainly invalid) script. This matcher cannot know which
+ *    `sed` a bare `$PATH` lookup will resolve to, and there is no shape
+ *    that reads identically under both getopt conventions once anything
+ *    beyond a bare `-i ''` is involved -- the "BSD/GNU `-i` ambiguity ... at
+ *    the token layer" this feature's design brief named as a legitimate
+ *    stop condition. Accepted rather than solved because it is not a
+ *    SAFETY gap: the divergent (BSD) reading fails closed on its own --
+ *    sed errors out on a bogus script, or at worst writes a confusingly
+ *    named backup -- never a sensitive-destination write or code execution,
+ *    which remains this veto's only chartered property.
+ */
+
 /**
  * Every group that can MUTATE the filesystem, and therefore every group whose
  * matches must clear the sensitive-destination axis (`sensitive-paths.ts`).
@@ -134,9 +322,10 @@ const MUTATING_GROUPS: ReadonlySet<string> = new Set([
  */
 function writeGroupVeto(segment: string): boolean {
   return (
-    hasUnsafeWriteFlag(segment) ||
+    hasUnsafeWriteFlag(normalizeSedInPlaceSuffix(segment)) ||
     hasWriteGroupPositionalVeto(segment) ||
-    segmentTouchesSensitivePath(segment)
+    segmentTouchesSensitivePath(segment) ||
+    sedScriptShapeVeto(segment)
   );
 }
 
@@ -1361,6 +1550,11 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'tee',
       'cp',
       'mv',
+      // #1057 phase 2 commit 4: in-place edits under a strict script-shape
+      // allowlist (`sedScriptShapeVeto`, above) — every script must be a
+      // single, unconditional `s///` or `y///`, so no address prefix, brace
+      // block, or side-command (`w`/`e`/`r`/`R`) can ride through it.
+      'sed -i',
       // `truncate`, `dd`, `shred`, `chmod` and `chown` are deliberately
       // absent at every strictness level (#956). `rm`/`rmdir` are absent
       // from THIS group for a polarity reason (ADR 0023): fs-write's

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -146,34 +146,47 @@ function writeGroupVeto(segment: string): boolean {
 // provably resolves under a scratch root: `/tmp/...`, `/private/tmp/...`
 // (macOS's real path for `/tmp`), `$TMPDIR/...`, `${TMPDIR}/...`.
 //
-// This is deliberately NOT expressed as a stateless `PermissionGroup.
-// segmentVeto` the way `fs-write`/`vcs-write` are. Two things it needs that a
-// pure `(segment) => boolean` cannot express:
+// A second, independent redirect grant lives in this same machinery:
+// `fs-write` (#1041 — 58% of trusted Bash escalations measured were plain
+// file writes). `cat a.txt > notes.md`, `bun test > out.log 2>&1` and
+// `git diff > review.diff` are read-side prefixes owned by OTHER groups
+// (`read-only`, `build-test`, `vcs-read`) whose output redirect targets a
+// RELATIVE, non-ascending, non-sensitive destination — exactly the operation
+// `fs-write` already approves through the `Write` tool. `fs-write` itself
+// never grants an ABSOLUTE target or one reached through an unprovable `cd`;
+// that is scratch's grant to make, not this one's, and the two compose (a
+// clause deletable by either grant is deleted).
 //
-//   - A leading `cd` into a scratch root must make later RELATIVE targets in
-//     the SAME compound command count as scratch-rooted (the owner's real
-//     traffic: `cd /private/tmp/.../scratchpad && <work>`). That is state
-//     carried ACROSS segments, in order, which `matchCoveredCommand`'s
-//     per-segment veto hooks do not thread through.
+// Neither grant is expressed as a stateless `PermissionGroup.segmentVeto` the
+// way `fs-write`/`vcs-write`'s own prefix-matched segments are. Two things
+// they need that a pure `(segment) => boolean` cannot express:
+//
+//   - A leading `cd` must make later RELATIVE targets in the SAME compound
+//     command count as rooted (scratch's real traffic:
+//     `cd /private/tmp/.../scratchpad && <work>`; fs-write's:
+//     `cd sub && cat a > out.txt`). That is state carried ACROSS segments, in
+//     order, which `matchCoveredCommand`'s per-segment veto hooks do not
+//     thread through.
 //   - `hasShellControl` (shell-safety.ts) vetoes ANY non-`/dev/null` output
 //     redirect unconditionally, for every group, and runs before any
-//     group-specific veto gets a look. A scratch-rooted redirect target has
-//     to be recognised BEFORE that check runs, not after.
+//     group-specific veto gets a look. A granted redirect target has to be
+//     recognised BEFORE that check runs, not after.
 //
 // Both are handled here, in `matchGroups` itself, rather than through the
-// `PermissionGroup` interface: `sanitizeCommandForScratch` removes a
-// scratch-granted redirect clause before `matchCoveredCommand` ever sees it,
-// and `scratchTargetVeto` is called directly by `matchGroups`'s own
-// `vetoForMatched` closure, which threads a single `cwd` variable across the
-// whole command the way a segment-by-segment veto function structurally
-// cannot.
+// `PermissionGroup` interface: `sanitizeCommandForRedirectGrants` removes a
+// granted redirect clause before `matchCoveredCommand` ever sees it, tracking
+// BOTH a scratch-rooted cwd and an fs-write relative offset in ONE walk over
+// the command (never two walks that could disagree — #1000's law), and
+// `scratchTargetVeto` is called directly by `matchGroups`'s own
+// `vetoForMatched` closure, which threads that per-segment state the way a
+// segment-by-segment veto function structurally cannot.
 //
 // Honest limits, not solved here, because static analysis cannot cover them:
 //
-//   - A symlink under `/tmp` pointing outside it. Every check in this section
-//     is LEXICAL (path-segment text analysis, like every other guard in this
-//     file); none of them resolve the filesystem, and a symlink's target is
-//     invisible to a lexical check.
+//   - A symlink under `/tmp`, or under the relative start directory, pointing
+//     outside it. Every check in this section is LEXICAL (path-segment text
+//     analysis, like every other guard in this file); none of them resolve
+//     the filesystem, and a symlink's target is invisible to a lexical check.
 //   - `$TMPDIR`'s actual value is never expanded. `$TMPDIR/x` is matched by
 //     SPELLING against the literal token, not by resolving to whatever
 //     directory the shell would actually substitute at runtime.
@@ -281,21 +294,33 @@ function isStrictlyUnderScratchRoot(token: string, cwd: ScratchCwd): boolean {
 }
 
 /**
- * Advance the tracked scratch `cwd` across one trimmed segment. A no-op for
- * anything other than a `cd`. Bare `cd` (goes to `$HOME`) and `cd -`
- * (previous directory, unknowable statically) both reset to null rather than
- * guess.
+ * A `cd`'s parsed operand, or the fact that one could not be extracted —
+ * shared by BOTH cwd walks (`scratch`'s absolute-root tracking and
+ * `fs-write`'s relative-offset tracking) so the two can never derive a
+ * different operand from the same segment, which is exactly the
+ * two-walks-that-must-agree defect #1000 found and fixed once already.
+ * `target: null` covers every case NEITHER walk can resolve: a bare `cd`
+ * (goes to `$HOME`), `cd -` (previous directory), any leading-dash option
+ * (#1047 — `cd` reads it as OPTIONS, not an operand), and any operand shape a
+ * redirect clause could hide inside (`cd ..>/dev/null`).
  */
-function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd {
-  if (trimmedSegment === '') return cwd;
+type CdOperand = { readonly isCd: false } | { readonly isCd: true; readonly target: string | null };
+
+/**
+ * Parse a trimmed, grammar-peeled segment's `cd` operand, if it is a `cd` at
+ * all. Both `advanceScratchCwd` and `advanceRelativeCwd` call this rather
+ * than each re-deriving the operand from the segment text.
+ */
+function extractCdOperand(trimmedSegment: string): CdOperand {
+  if (trimmedSegment === '') return { isCd: false };
   // Strip redirect clauses BEFORE tokenizing. `shellWords('cd ..>/dev/null')`
   // is `['cd', '..>/dev/null']`, and that glued token is neither `..` nor
-  // `../…`, so the ascent was invisible and the tracked cwd became
-  // `<scratch>/..>/dev/null` -- a name that never pops below the root. Real
-  // bash ascends. Chained, `cd /tmp/x && cd ..>/dev/null && cd ..>/dev/null &&
-  // rm -rf etc` reached `rm -rf /etc` at `balanced`, on SHIPPED releases.
+  // `../…`, so the ascent was invisible and a tracked cwd never popped below
+  // the root. Real bash ascends. Chained, `cd /tmp/x && cd ..>/dev/null && cd
+  // ..>/dev/null && rm -rf etc` reached `rm -rf /etc` at `balanced`, on
+  // SHIPPED releases.
   const words = shellWords(rewriteRedirectClauses(trimmedSegment, () => '').trim());
-  if (words[0] !== 'cd') return cwd;
+  if (words[0] !== 'cd') return { isCd: false };
   const target = words[1];
   // POSITIVE allowlist on the operand, not another round of subtracting known
   // -bad spellings. The #1047 fix rejected a leading dash; this found the same
@@ -303,8 +328,11 @@ function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd 
   // `&>` is not even modelled by `rewriteRedirectClauses`. So the rule is now
   // "does this look like a path at all" -- shell metacharacters, whitespace and
   // quotes all disqualify. `$TMPDIR`, `${TMPDIR}`, `~` and `/tmp/x` are the
-  // shapes `resolveScratchTarget` genuinely handles, so they stay in.
-  if (target !== undefined && !/^[A-Za-z0-9._+/@~$:{}-]+$/.test(target)) return null;
+  // shapes `resolveScratchTarget`/`resolveRelativeTarget` genuinely handle, so
+  // they stay in.
+  if (target !== undefined && !/^[A-Za-z0-9._+/@~$:{}-]+$/.test(target)) {
+    return { isCd: true, target: null };
+  }
   // ANY leading dash resets, not just the exact `-` (#1047). `cd` reads a
   // leading-dash token as OPTIONS, so `cd -P` / `cd -L` / `cd --` / `cd -LP`
   // are an option with NO operand -- and a bare `cd` goes to `$HOME`. Testing
@@ -314,9 +342,72 @@ function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd 
   // deleted `~/out`. Verified in bash on darwin: the chain ends in `$HOME`.
   //
   // Resetting to null is the safe direction -- an unknowable cwd means no
-  // relative target can be proved to land under a scratch root.
-  if (target === undefined || target.startsWith('-')) return null;
-  return resolveScratchTarget(target, cwd);
+  // relative target can be proved to land under either tracked root.
+  if (target === undefined || target.startsWith('-')) return { isCd: true, target: null };
+  return { isCd: true, target };
+}
+
+/**
+ * Advance the tracked scratch `cwd` across one `cd` operand. A no-op for a
+ * non-`cd` segment; a null operand (bare `cd`, `cd -`, or an unresolvable
+ * shape — see `extractCdOperand`) resets to null rather than guess.
+ */
+function advanceScratchCwd(cwd: ScratchCwd, operand: CdOperand): ScratchCwd {
+  if (!operand.isCd) return cwd;
+  if (operand.target === null) return null;
+  return resolveScratchTarget(operand.target, cwd);
+}
+
+/**
+ * The tracked relative offset from wherever `fs-write`'s command runs, while
+ * walking a compound command — the same shape of state `ScratchCwd` tracks
+ * for an absolute scratch root, but for a starting directory this matcher
+ * never learns the name of.
+ *
+ * `[]` means "still at the start" — the INITIAL state, which a command with
+ * no `cd` at all never leaves. A non-empty array is a composed, non-ascending
+ * relative path from there (`['sub']` after `cd sub`). `null` means "not
+ * provable relative to the start": an absolute or `$VAR`/`~` cd, an
+ * unreliable one (`|`/`||`), a #1047-shaped dash reset, or a composed offset
+ * that tried to ascend above the start. `null` is STICKY — once the offset
+ * from the start is unprovable, no later RELATIVE `cd` can rebuild it, the
+ * same rule #1000 pins for scratch ("a relative cd after an unreliable one
+ * does not rebuild the root").
+ */
+type RelativeCwd = readonly string[] | null;
+
+/**
+ * Resolve `token` to its offset from the fs-write start directory given
+ * `relCwd`, or null if it cannot be shown to stay inside it.
+ *
+ * An absolute-shaped token (leading `/`, `~`, or `$`) is refused outright,
+ * never composed with `relCwd`: fs-write's grant is for a target IN TREE
+ * relative to wherever the command runs, and an absolute path names a
+ * location this matcher has no basis to trust regardless of the tracked
+ * offset — that is `scratch`'s grant to make, for its own four rooted
+ * shapes, not this one's.
+ *
+ * Reuses `joinScratchSegments` with `floorLen: 0` — the start directory
+ * itself is the floor a composed offset may never pop below, exactly the
+ * same "may not ascend past the root" shape scratch's own walk already
+ * enforces, just with the floor at 0 instead of scratch's root length.
+ */
+function resolveRelativeTarget(token: string, relCwd: RelativeCwd): RelativeCwd {
+  if (token.startsWith('/') || token.startsWith('~') || token.startsWith('$')) return null;
+  if (relCwd === null) return null;
+  return joinScratchSegments(relCwd, 0, token.split('/'));
+}
+
+/**
+ * Advance the tracked fs-write relative offset across one `cd` operand.
+ * Mirrors `advanceScratchCwd` exactly — same operand, same null-on-unknown
+ * handling — composing through `resolveRelativeTarget` instead of
+ * `resolveScratchTarget`.
+ */
+function advanceRelativeCwd(relCwd: RelativeCwd, operand: CdOperand): RelativeCwd {
+  if (!operand.isCd) return relCwd;
+  if (operand.target === null) return null;
+  return resolveRelativeTarget(operand.target, relCwd);
 }
 
 /**
@@ -332,19 +423,21 @@ function advanceScratchCwd(cwd: ScratchCwd, trimmedSegment: string): ScratchCwd 
  *   one FOLLOWED by `|`, since either position makes it a stage.
  *
  * Both directions matter because the consequence is not a missed match but a
- * tracked scratch root that differs from the real one, under which a later
- * relative `rm -rf` is approved against a directory nobody checked. Returning
- * true makes the caller forget the directory rather than guess it, the same
- * fail-closed handling bare `cd` and `cd -` already get.
+ * tracked cwd that differs from the real one, under which a later relative
+ * target is approved against a directory nobody checked. Returning true makes
+ * the caller forget the directory rather than guess it, the same fail-closed
+ * handling bare `cd` and `cd -` already get. Shared by both walks (`scratch`
+ * and `fs-write`'s relative offset): a `cd`'s reliability does not depend on
+ * which grant is asking.
  */
 function cdEffectIsUnreliable(joiner: CompoundJoiner, nextJoiner: CompoundJoiner): boolean {
   return joiner === '|' || joiner === '||' || nextJoiner === '|';
 }
 
 /**
- * True if a redirect clause targeting `path` may be DELETED rather than left
- * for `hasShellControl` to veto: the target resolves STRICTLY under a scratch
- * root, AND is not itself a sensitive destination.
+ * True if a redirect clause targeting `path` may be DELETED under the
+ * `scratch` grant: the target resolves STRICTLY under a scratch root, AND is
+ * not itself a sensitive destination.
  *
  * #1060 + ADR 0018 axis 3. `isStrictlyUnderScratchRoot` alone proves only the
  * destination-root half of a write-side match (axis 3's "under `/tmp`" half);
@@ -374,54 +467,110 @@ function scratchSegmentsToPath(segments: readonly string[]): string {
 }
 
 /**
- * Remove every redirect clause in `segment` whose target is a plain path under
- * a scratch root. REMOVES the clause entirely rather than retargeting it to
- * `/dev/null`: a retargeted clause would still leave a token like
- * `2>/dev/null` sitting in the word list `scratchTargetVeto` scans for
- * positional arguments, which is neither a flag nor a real target and would
- * wrongly fail that scan.
+ * True if a redirect clause targeting `path` may be DELETED under the
+ * `fs-write` grant (#1041): it composes to a RELATIVE, non-ascending offset
+ * from wherever the command runs, and is not a sensitive destination.
+ *
+ * fs-write's own axis-3 destination veto (`isSensitiveWritePath`) is reused
+ * rather than re-derived, checked on the RESOLVED (cwd-composed) path for the
+ * same reason `isGrantedScratchRedirectTarget` does: `cd sub && cat a >
+ * .git/hooks/pre-commit` must be caught exactly like the un-cd'd spelling.
+ * `resolveRelativeTarget` already refuses an absolute-shaped target and an
+ * ascending composition, so an empty (root-itself) result is the only other
+ * non-grant case left to check here.
+ */
+function isGrantedFsWriteRedirectTarget(path: string, relCwd: RelativeCwd): boolean {
+  const resolved = resolveRelativeTarget(path, relCwd);
+  if (resolved === null || resolved.length === 0) return false;
+  return !isSensitiveWritePath(resolved.join('/'));
+}
+
+/** Which redirect grants are active for the current command — gates both the
+ *  pre-pass itself and each individual clause deletion decision. */
+interface RedirectGrants {
+  readonly scratchActive: boolean;
+  readonly fsWriteActive: boolean;
+}
+
+/** The per-segment cwd state both grants read, from ONE walk: the tracked
+ *  scratch root (absolute) and the tracked fs-write offset (relative). */
+interface RedirectGrantCwd {
+  readonly scratch: ScratchCwd;
+  readonly relative: RelativeCwd;
+}
+
+/**
+ * Remove every redirect clause in `segment` whose target an ACTIVE grant
+ * covers: `scratch`'s absolute-root proof, `fs-write`'s relative-offset
+ * proof, or both — a clause deletable by either grant is deleted. REMOVES the
+ * clause entirely rather than retargeting it to `/dev/null`: a retargeted
+ * clause would still leave a token like `2>/dev/null` sitting in the word
+ * list `scratchTargetVeto` scans for positional arguments, which is neither a
+ * flag nor a real target and would wrongly fail that scan.
  *
  * Only a `path` target is ever removed. `discard`/`fd-dup` need no help —
  * `hasShellControl` already permits them — and `opaque` must never be removed,
  * since removing it is exactly how a second operator hidden inside the greedy
  * match would escape the veto that was going to catch it.
  */
-function sanitizeSegmentRedirects(segment: string, cwd: ScratchCwd): string {
+function sanitizeSegmentRedirects(
+  segment: string,
+  cwd: RedirectGrantCwd,
+  grants: RedirectGrants,
+): string {
   return rewriteRedirectClauses(segment, (target, text) => {
     if (target.kind !== 'path') return text;
-    return isGrantedScratchRedirectTarget(target.path, cwd) ? '' : text;
+    if (grants.scratchActive && isGrantedScratchRedirectTarget(target.path, cwd.scratch)) return '';
+    if (grants.fsWriteActive && isGrantedFsWriteRedirectTarget(target.path, cwd.relative))
+      return '';
+    return text;
   });
 }
 
 /**
- * Pre-pass over the WHOLE command, run only when `scratch` is among the
- * requested groups: removes every redirect clause whose target is
- * scratch-rooted, tracking `cd` across segments exactly like the real match
- * that follows will. This has to run BEFORE `matchCoveredCommand`, not
- * alongside it: `hasShellControl` cannot be told "except this one clause", it
- * returns one boolean for the whole segment, so the only way to let a
- * scratch-rooted redirect through it is to remove the clause before that
- * check ever sees it.
+ * Pre-pass over the WHOLE command, run when EITHER grant is active: removes
+ * every redirect clause a granted proof covers, tracking `cd` across segments
+ * exactly like the real match that follows will. This has to run BEFORE
+ * `matchCoveredCommand`, not alongside it: `hasShellControl` cannot be told
+ * "except this one clause", it returns one boolean for the whole segment, so
+ * the only way to let a granted redirect through it is to remove the clause
+ * before that check ever sees it.
+ *
+ * ONE walk over the command produces BOTH tracked states (`scratch` and
+ * `relative`), from the same extracted `cd` operand at each step — never two
+ * separate passes that could disagree, exactly the defect shape #1000 found
+ * and fixed once already. `grants` only gates which state a clause deletion
+ * may CONSULT; both states are always tracked regardless, so enabling
+ * `fs-write` alone never changes what a `scratch`-only caller would have
+ * computed, and vice versa — every existing scratch-only behavior is
+ * bit-identical to before this function was generalized.
  *
  * The rebuilt string keeps each segment's ORIGINAL joining operator. An
  * earlier draft rebuilt with a uniform `&&`, reasoning that
  * `matchCoveredCommand` re-splits via `splitCompound` and never inspects which
  * separator joined two segments. That was true of `matchCoveredCommand` and
- * false of the scratch veto downstream of it, which tracks `cd` across
- * segments and so depends on exactly the operator a uniform `&&` erased:
- * flattening `true | cd /tmp` to `true && cd /tmp` converts a discarded
- * subshell `cd` into one the veto believes moved the shell.
+ * false of the cwd walks downstream of it, which track `cd` across segments
+ * and so depend on exactly the operator a uniform `&&` erased: flattening
+ * `true | cd /tmp` to `true && cd /tmp` converts a discarded subshell `cd`
+ * into one the walk believes moved the shell.
  */
-function sanitizeCommandForScratch(command: string): ScratchSanitized {
+function sanitizeCommandForRedirectGrants(
+  command: string,
+  grants: RedirectGrants,
+): RedirectGrantWalk {
   const parts = splitCompoundParts(command);
-  const cwdBySegment: ScratchCwd[] = [];
-  let cwd: ScratchCwd = null;
+  const stateBySegment: RedirectGrantCwd[] = [];
+  let scratchCwd: ScratchCwd = null;
+  // fs-write's relative offset starts at the INITIAL state — `[]`, not null —
+  // because the grant is available from the very first segment: a command
+  // that never `cd`s at all is exactly as in-tree as one could hope to prove.
+  let relativeCwd: RelativeCwd = [];
   let rebuilt = '';
   for (const [i, part] of parts.entries()) {
-    // The cwd RECORDED for a segment is the one in effect when the shell
+    // The state RECORDED for a segment is the one in effect when the shell
     // reaches it, i.e. before its own effect: a `cd` moves the segments after
     // it, not itself.
-    cwdBySegment.push(cwd);
+    stateBySegment.push({ scratch: scratchCwd, relative: relativeCwd });
     const trimmed = part.text.trim();
     // Detect the `cd` in the PEELED body, not the raw text. Judging raw text
     // here while `matchCoveredCommand` judges the peeled body is what made
@@ -437,26 +586,31 @@ function sanitizeCommandForScratch(command: string): ScratchSanitized {
     if (words[0] === 'cd') {
       // A `cd` that needed grammar peeled off it sits inside a conditional or
       // a loop body, so it runs zero or more times and the shell's directory
-      // afterwards is not knowable from the text. Forget the directory rather
-      // than carry a stale one forward — carrying it forward is what made the
+      // afterwards is not knowable from the text. Forget it rather than carry
+      // a stale one forward — carrying it forward is what made the scratch
       // escape above auto-approve, so here "unknown" must mean null, never
-      // "whatever it was before".
+      // "whatever it was before", for BOTH tracked states.
       const wrappedInGrammar = body !== trimmed;
-      cwd =
-        wrappedInGrammar || cdEffectIsUnreliable(part.joiner, parts[i + 1]?.joiner ?? null)
-          ? null
-          : advanceScratchCwd(cwd, body);
+      const unreliable =
+        wrappedInGrammar || cdEffectIsUnreliable(part.joiner, parts[i + 1]?.joiner ?? null);
+      const operand = extractCdOperand(body);
+      scratchCwd = unreliable ? null : advanceScratchCwd(scratchCwd, operand);
+      relativeCwd = unreliable ? null : advanceRelativeCwd(relativeCwd, operand);
     } else if (trimmed !== '') {
-      text = sanitizeSegmentRedirects(part.text, cwd);
+      text = sanitizeSegmentRedirects(
+        part.text,
+        { scratch: scratchCwd, relative: relativeCwd },
+        grants,
+      );
     }
     rebuilt += i === 0 ? text : `${joinerText(part.joiner)}${text}`;
   }
-  return { command: rebuilt, cwdBySegment };
+  return { command: rebuilt, stateBySegment };
 }
 
 /**
- * A scratch pre-pass result: the rewritten command, plus the tracked scratch
- * directory in effect at each of its compound segments, BY INDEX.
+ * A redirect-grant pre-pass result: the rewritten command, plus BOTH tracked
+ * cwd states in effect at each of its compound segments, BY INDEX.
  *
  * The trajectory is published rather than recomputed downstream because the
  * two used to be computed twice — once here and once by a closure threaded
@@ -464,9 +618,9 @@ function sanitizeCommandForScratch(command: string): ScratchSanitized {
  * agree are exactly the shape that produced the `|`/`||` desync this type
  * exists to prevent recurring. One walk, one answer, read by index.
  */
-interface ScratchSanitized {
+interface RedirectGrantWalk {
   readonly command: string;
-  readonly cwdBySegment: readonly ScratchCwd[];
+  readonly stateBySegment: readonly RedirectGrantCwd[];
 }
 
 /** Render a joiner back into command text, preserving `splitCompoundParts`'s split. */
@@ -488,11 +642,11 @@ function joinerText(joiner: CompoundJoiner): string {
  * escalation, never a wrongly-approved write).
  *
  * Any redirect clause still present in `segment` at this point is exempt by
- * construction: `sanitizeCommandForScratch` already removed every
- * scratch-granted one, and a non-exempt, non-granted clause would have
- * tripped `hasShellControl` before `matchCoveredCommand` ever reached this
- * veto. It is stripped here purely so a leftover token like `2>&1` is not
- * mistaken for a positional target.
+ * construction: `sanitizeCommandForRedirectGrants` already removed every
+ * clause EITHER grant covered (scratch's or fs-write's), and a non-exempt,
+ * non-granted clause would have tripped `hasShellControl` before
+ * `matchCoveredCommand` ever reached this veto. It is stripped here purely so
+ * a leftover token like `2>&1` is not mistaken for a positional target.
  */
 function scratchTargetVeto(segment: string, cwd: ScratchCwd): boolean {
   const stripped = rewriteRedirectClauses(segment, () => '').trim();
@@ -688,8 +842,8 @@ function cdTargetIsPlainDescendant(words: readonly string[]): boolean {
 
 /**
  * Pre-walk for `artifact-clean` (ADR 0023), beside
- * `sanitizeCommandForScratch`: for each compound segment BY INDEX, whether a
- * poisoning `cd` occurred anywhere earlier. A `cd` poisons unless its single
+ * `sanitizeCommandForRedirectGrants`: for each compound segment BY INDEX,
+ * whether a poisoning `cd` occurred anywhere earlier. A `cd` poisons unless its single
  * target is a plain relative descendant; a grammar-wrapped `cd` (`if ...;
  * then cd sub; fi`) poisons regardless of target, because it runs zero or
  * more times and the directory afterwards is unknowable from the text.
@@ -1174,21 +1328,26 @@ export function matchGroups(
   if (toolName === 'Bash') {
     const rawCommand = typeof toolInput['command'] === 'string' ? toolInput['command'].trim() : '';
     if (rawCommand === '') return null;
-    // `scratch` (see the section above `PermissionGroup`) needs a redirect
-    // clause removed BEFORE `hasShellControl` ever sees it, which has to
-    // happen on the whole command ahead of the per-segment machinery below.
-    // Only run the pre-pass when `scratch` was actually requested, so every
-    // OTHER caller (in particular `strict`, which never lists it) gets back
-    // out exactly the string it put in and nothing here can change its
-    // behavior.
+    // `scratch` and `fs-write` (see the section above `PermissionGroup`) each
+    // need a redirect clause removed BEFORE `hasShellControl` ever sees it,
+    // which has to happen on the whole command ahead of the per-segment
+    // machinery below. Only run the pre-pass when at least one of the two
+    // grants was actually requested, so every OTHER caller (in particular
+    // `strict`, which lists neither) gets back out exactly the string it put
+    // in and nothing here can change its behavior.
     const scratchActive = known.includes('scratch');
-    const scratch = scratchActive ? sanitizeCommandForScratch(rawCommand) : null;
-    const command = scratch?.command ?? rawCommand;
+    const fsWriteActive = known.includes('fs-write');
+    const redirectGrants =
+      scratchActive || fsWriteActive
+        ? sanitizeCommandForRedirectGrants(rawCommand, { scratchActive, fsWriteActive })
+        : null;
+    const command = redirectGrants?.command ?? rawCommand;
     // The cd-poison pre-walk for `artifact-clean` (ADR 0023). Like the
-    // scratch pre-pass: run only when the group was actually requested, and
-    // walked over the SAME string `matchCoveredCommand` receives, so the two
-    // agree by segment index (the scratch sanitize preserves segment count
-    // and joiners; it only rewrites redirect clauses inside segments).
+    // redirect-grant pre-pass: run only when the group was actually
+    // requested, and walked over the SAME string `matchCoveredCommand`
+    // receives, so the two agree by segment index (the redirect-grant
+    // sanitize preserves segment count and joiners; it only rewrites redirect
+    // clauses inside segments).
     const artifactPoison = known.includes('artifact-clean')
       ? artifactCleanPoisonWalk(command)
       : null;
@@ -1218,8 +1377,8 @@ export function matchGroups(
     // need per-INDEX state — the tracked scratch directory, the cd-poison
     // flag — which the stateless `PermissionGroup.segmentVeto` signature has
     // no room for). That state is looked up BY SEGMENT INDEX from the single
-    // walk done in each pre-pass, rather than re-tracked by a closure here —
-    // see `ScratchSanitized`.
+    // walk done in the pre-pass, rather than re-tracked by a closure here —
+    // see `RedirectGrantWalk`.
     const vetoedByOwner = (owner: string, segment: string, prefix: string, index: number) => {
       // The sensitive-destination axis is a GLOBAL conjunct, checked before any
       // owner's own proof and never delegated to one. Found by the ADR 0023
@@ -1251,7 +1410,7 @@ export function matchGroups(
       // sensitive path is exactly what `read-only` exists to allow.
       if (MUTATING_GROUPS.has(owner) && segmentTouchesSensitivePath(segment)) return true;
       if (owner === 'scratch') {
-        return scratchTargetVeto(segment, scratch?.cwdBySegment[index] ?? null);
+        return scratchTargetVeto(segment, redirectGrants?.stateBySegment[index]?.scratch ?? null);
       }
       if (owner === 'artifact-clean') {
         return artifactCleanVeto(segment, prefix, artifactPoison?.[index] ?? true);

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -156,10 +156,21 @@ function splitOnUnescapedDelimiter(text: string, d: string): string[] {
  * `1,5s///`) and a brace block both fail the leading-letter check below (the
  * first character is not literally `s`/`y`); a trailing side-command
  * (`w file`, `W`, `e`, `r`, `R`) fails the `y`'s empty-trailer or the `s`'s
- * `[gIp0-9]*` check; a `;`-chained second command is refused outright,
- * rather than trusted to the shape checks alone, because it is the one
- * adversary this function must make trivially auditable: this script
- * contains no `;`, full stop.
+ * `[gIp0-9]*` check.
+ *
+ * The explicit `;`-inclusion check is NOT what catches a `;`-chained second
+ * command appended after the closing delimiter — the field-count and
+ * trailing-class checks already do, on their own: appending `; rm -rf /` (or
+ * any other chained command) after a real `s///`/`y///` script inserts an
+ * extra unescaped delimiter-free field, so `splitOnUnescapedDelimiter` no
+ * longer returns exactly 4 fields and the shape fails regardless. What the
+ * `;` check's own presence UNIQUELY refuses is `;` used AS THE DELIMITER
+ * itself (`s;a;b;g`) — a shape that genuinely passes the field-count and
+ * trailing-class checks on its own (4 fields, trailing `g`) and is refused
+ * ONLY because this line runs first. It is kept, conservative, for a second
+ * reason beyond that one refusal: it makes "this script contains no chained
+ * command" a property auditable by reading ONE line, rather than by trusting
+ * the delimiter-counting math above to have no adversarial case left in it.
  */
 function sedScriptShapeOk(script: string): boolean {
   if (script.includes(';')) return false;
@@ -187,8 +198,31 @@ function sedScriptShapeOk(script: string): boolean {
  * target's own name and treats the result as a path), which is a
  * destination-axis bypass `segmentTouchesSensitivePath` never sees — the
  * suffix is a flag VALUE, not the command's final file argument.
+ *
+ * BOTH branches below that check this suffix (the attached `-i<suffix>` form
+ * and `--in-place=<suffix>`) are UNREACHABLE through the actual group-match
+ * path today, probe-verified: `matchPrefix` (shell-safety.ts) requires the
+ * curated `sed -i` prefix to be followed by a literal SPACE
+ * (`segment.startsWith('sed -i ')`), which neither attached spelling
+ * satisfies — an attached, glob-carrying `-i` suffix quoted directly onto the
+ * flag does not start with `sed -i ` (the character right after `-i` is a
+ * quote, not a space), and `sed --in-place=... ...` does not start with
+ * `sed -i ` at all. Both fall
+ * through UNMATCHED before this function, or any veto, is ever reached — see
+ * the "documented residual" test block and the residuals comment above
+ * `sedScriptShapeVeto`'s call site for the same limit stated from the
+ * `matchPrefix` side. The branches are kept anyway, as defense-in-depth for
+ * the day attached-suffix prefix matching is added (the ADR 0026 residual):
+ * removing them now would silently reopen this exact bypass the moment that
+ * prefix-matching gap closes. Reached directly by calling this exported
+ * function with a crafted segment in tests, since the group path cannot
+ * reach them today.
+ *
+ * Exported for tests ONLY (mirrors `MUTATION_TOKEN`'s convention above): the
+ * two branches this comment describes have no OTHER way to be exercised
+ * while `matchPrefix`'s space requirement stands.
  */
-function sedScriptShapeVeto(segment: string): boolean {
+export function sedScriptShapeVeto(segment: string): boolean {
   if (!/^sed\b/.test(segment)) return false;
   const words = shellWords(segment);
   const hasScriptFlag = words.some(

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -35,6 +35,7 @@ import {
 } from './sensitive-paths.ts';
 import {
   type CompoundJoiner,
+  maskQuotedSpans,
   matchCoveredCommand,
   matchPrefix,
   rewriteRedirectClauses,
@@ -663,6 +664,196 @@ function scratchTargetVeto(segment: string, cwd: ScratchCwd): boolean {
     if (!isStrictlyUnderScratchRoot(word, cwd)) return true;
   }
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// Heredoc excision (#1057 phase 2, commit 3). A pre-pass SIBLING of
+// `sanitizeCommandForRedirectGrants`, run in the `matchGroups` path only --
+// never the user allow-list path in `pattern-matcher.ts`. That asymmetry is
+// deliberate and is documented alongside this in the phase's ADR.
+//
+// Heredocs appear NOWHERE in the decision code before this commit, and what
+// happens today is a coincidence, not a policy. `tee /tmp/x <<EOF` (one
+// physical line, no real newline in the string) approves, because `<<EOF`
+// just sits as an inert extra token nothing looks at. A genuine MULTI-LINE
+// heredoc escalates only by ACCIDENT: `splitCompoundParts` treats an
+// unquoted newline as a command separator exactly like `;`, so the body
+// becomes its own segment(s), and a body line essentially never happens to
+// prefix-match a curated command. That is not a designed safety property --
+// it is two unrelated mechanisms colliding -- and it is what this excision
+// replaces with a deliberate one: give the heredoc body a real disposition
+// instead of an accidental one.
+//
+// The rule, fail-closed at every step: find the heredoc operator (`<<` or
+// `<<-`) on a physical line, read its delimiter WORD (bare, `'quoted'`, or
+// `"quoted"`), and if the WORD is a plain `[A-Za-z0-9_]+` token, look for a
+// LATER line that equals it exactly (leading tabs only, stripped, for
+// `<<-`). Found: the operator, its word, every body line and the terminator
+// line are all removed from the command text. Everything that remains flows
+// through the EXISTING machinery completely unchanged (compound split,
+// redirect grants, `hasShellControl`, group prefix coverage, every veto).
+// Excision itself grants nothing -- it only deletes syntax that was inert to
+// begin with, so whatever coverage decision the remaining text earns is the
+// same decision it would earn had a human deleted the heredoc by hand.
+//
+// ANY of the following aborts excision for the WHOLE command, restoring it
+// byte-for-byte and falling back to today's (safe, if accidental) behavior:
+//
+//   - a second `<<` on the same physical line (`cat <<A <<B`) -- rare, and
+//     stacked heredocs are refused rather than modeled;
+//   - a delimiter that is not a plain word once unquoted (empty, containing
+//     `$`, a backslash, or other punctuation);
+//   - no later line matches the delimiter exactly -- an unterminated
+//     heredoc is exactly today's accidental-escalation shape, so leaving it
+//     alone reproduces it rather than guessing where it ends;
+//   - an UNQUOTED delimiter (`<<EOF`, not `<<'EOF'`/`<<"EOF"`) whose body
+//     contains `$(`, a backtick, or `<(`. An unquoted heredoc body is LIVE:
+//     the shell performs command/process substitution on it BEFORE it is
+//     ever handed to the reading command. Excising it would DELETE that
+//     execution from the text the matcher ever sees --
+//     `cat > x <<EOF` / `$(rm -rf /)` / `EOF` would collapse to `cat > x`,
+//     approve via the fs-write redirect grant, and the shell would still
+//     run `rm -rf /` as a side effect of expanding the body nobody looked
+//     at. A QUOTED delimiter needs no such scan: bash performs no expansion
+//     at all on a quoted-delimiter body, so it is inert by construction.
+//
+// Quote masking is done PER LINE, not once over the whole multi-line
+// command. A heredoc body is literal data and may contain an apostrophe or
+// an unmatched quote character with no bearing on shell grammar at all
+// (`it's done` is valid body text) -- masking the ENTIRE command in one pass
+// would let that single stray quote desync `maskQuotedSpans`'s state for
+// everything after it (an unterminated quote makes that function return its
+// input completely UNMASKED, per its own contract), which could misread a
+// LATER line's real operator as quoted, or vice versa. Per-line masking
+// confines the blast radius of a body line's stray quote to that one line,
+// which is never consulted for operator detection: operators are only
+// looked for on lines a body has not yet started under.
+// ---------------------------------------------------------------------------
+
+/** Characters a heredoc delimiter must be made of, once unquoted. */
+const HEREDOC_WORD_RE = /^[A-Za-z0-9_]+$/;
+
+/** What scanning one physical line for a heredoc operator found. */
+type HeredocOperatorScan =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'multiple' }
+  | { readonly kind: 'invalid' }
+  | {
+      readonly kind: 'found';
+      /** Index in the line where the `<<` starts. */
+      readonly opStart: number;
+      /** Index in the line right after the (possibly quoted) delimiter word. */
+      readonly opEnd: number;
+      readonly dashed: boolean;
+      readonly word: string;
+      readonly quoted: boolean;
+    };
+
+/**
+ * Find a heredoc operator on ONE physical line, quote-masked so a `<<` that
+ * is really inside a quoted argument (`echo "a << b"`) is not mistaken for
+ * one. `<<<` (here-strings) and any longer run of `<` are excluded outright
+ * -- a run of 3+ `<` is never a heredoc operator.
+ *
+ * `kind: 'multiple'` and `kind: 'invalid'` are both reported rather than
+ * silently treating the line as `'none'`, because the caller has to abort
+ * the WHOLE excision on either -- a line this function cannot fully make
+ * sense of must not have its *other* content silently reinterpreted.
+ */
+function scanHeredocOperator(line: string): HeredocOperatorScan {
+  const masked = maskQuotedSpans(line);
+  const starts: number[] = [];
+  for (let i = 0; i < masked.length - 1; i++) {
+    if (masked[i] !== '<' || masked[i + 1] !== '<') continue;
+    if (masked[i - 1] === '<' || masked[i + 2] === '<') continue; // <<< / <<<<
+    starts.push(i);
+  }
+  if (starts.length === 0) return { kind: 'none' };
+  if (starts.length > 1) return { kind: 'multiple' };
+  const opStart = starts[0] as number;
+  let idx = opStart + 2;
+  let dashed = false;
+  if (masked[idx] === '-') {
+    dashed = true;
+    idx++;
+  }
+  while (masked[idx] === ' ' || masked[idx] === '\t') idx++;
+  // From here, read the RAW line (not the masked view): the masked view has
+  // replaced a quoted delimiter's characters, quotes included, with `_`.
+  const quoteChar = line[idx];
+  let word: string;
+  let opEnd: number;
+  if (quoteChar === "'" || quoteChar === '"') {
+    const close = line.indexOf(quoteChar, idx + 1);
+    if (close === -1) return { kind: 'invalid' };
+    word = line.slice(idx + 1, close);
+    opEnd = close + 1;
+  } else {
+    let end = idx;
+    while (end < line.length && !/\s/.test(line[end] ?? '')) end++;
+    word = line.slice(idx, end);
+    opEnd = end;
+  }
+  if (!HEREDOC_WORD_RE.test(word)) return { kind: 'invalid' };
+  return {
+    kind: 'found',
+    opStart,
+    opEnd,
+    dashed,
+    word,
+    quoted: quoteChar === "'" || quoteChar === '"',
+  };
+}
+
+/** True if an UNQUOTED heredoc body carries live substitution the shell
+ *  would execute while expanding it, before the reading command ever runs. */
+function heredocBodyHasLiveSubstitution(bodyLines: readonly string[]): boolean {
+  return bodyLines.some((l) => l.includes('$(') || l.includes('`') || l.includes('<('));
+}
+
+/**
+ * Excise every heredoc this command contains, or return `command` completely
+ * UNCHANGED the instant any single one cannot be proven safe to remove -- see
+ * the section comment above for the full fail-closed rule.
+ *
+ * Run unconditionally in `matchGroups`'s Bash path, before every other
+ * pre-pass and before compound splitting. That is safe rather than a
+ * widening: excision does not grant coverage by itself, it only deletes
+ * syntax that was inert (or, on any abort, leaves the command exactly as it
+ * was), so it can only ever hand the EXISTING machinery a command that means
+ * the same thing with less noise in it -- coverage is still decided entirely
+ * by that machinery, same as if a human had deleted the heredoc by hand.
+ */
+function exciseHeredocsForGroups(command: string): string {
+  if (!command.includes('<<')) return command;
+  const lines = command.split('\n');
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] as string;
+    const op = scanHeredocOperator(line);
+    if (op.kind === 'none') {
+      out.push(line);
+      i++;
+      continue;
+    }
+    if (op.kind === 'multiple' || op.kind === 'invalid') return command;
+    let terminatorAt = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      const raw = lines[j] as string;
+      const candidate = op.dashed ? raw.replace(/^\t+/, '') : raw;
+      if (candidate === op.word) {
+        terminatorAt = j;
+        break;
+      }
+    }
+    if (terminatorAt === -1) return command; // unterminated: fail closed
+    const body = lines.slice(i + 1, terminatorAt);
+    if (!op.quoted && heredocBodyHasLiveSubstitution(body)) return command; // live body: fail closed
+    out.push(line.slice(0, op.opStart) + line.slice(op.opEnd));
+    i = terminatorAt + 1; // skip every body line and the terminator line
+  }
+  return out.join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -1328,20 +1519,30 @@ export function matchGroups(
   if (toolName === 'Bash') {
     const rawCommand = typeof toolInput['command'] === 'string' ? toolInput['command'].trim() : '';
     if (rawCommand === '') return null;
+    // Heredoc excision (#1057 phase 2, commit 3), UNCONDITIONALLY, before
+    // every other pre-pass and before compound splitting -- see the section
+    // above `exciseHeredocsForGroups` for the full rule. Unlike the redirect
+    // grants below, this does not need to be gated on which groups were
+    // requested: excision cannot grant coverage by itself (it only deletes
+    // syntax that was inert, or leaves the command untouched on any
+    // ambiguity), so running it for every caller changes no group's
+    // approvals except by removing noise the rest of this function would
+    // otherwise have judged the accidental (pre-#1057) way.
+    const heredocExcised = exciseHeredocsForGroups(rawCommand);
     // `scratch` and `fs-write` (see the section above `PermissionGroup`) each
     // need a redirect clause removed BEFORE `hasShellControl` ever sees it,
     // which has to happen on the whole command ahead of the per-segment
     // machinery below. Only run the pre-pass when at least one of the two
     // grants was actually requested, so every OTHER caller (in particular
     // `strict`, which lists neither) gets back out exactly the string it put
-    // in and nothing here can change its behavior.
+    // in (heredoc excision aside) and nothing here can change its behavior.
     const scratchActive = known.includes('scratch');
     const fsWriteActive = known.includes('fs-write');
     const redirectGrants =
       scratchActive || fsWriteActive
-        ? sanitizeCommandForRedirectGrants(rawCommand, { scratchActive, fsWriteActive })
+        ? sanitizeCommandForRedirectGrants(heredocExcised, { scratchActive, fsWriteActive })
         : null;
-    const command = redirectGrants?.command ?? rawCommand;
+    const command = redirectGrants?.command ?? heredocExcised;
     // The cd-poison pre-walk for `artifact-clean` (ADR 0023). Like the
     // redirect-grant pre-pass: run only when the group was actually
     // requested, and walked over the SAME string `matchCoveredCommand`

--- a/packages/daemon/src/auto-approve/sensitive-paths.ts
+++ b/packages/daemon/src/auto-approve/sensitive-paths.ts
@@ -160,6 +160,17 @@ const BUILD_SURFACE: readonly string[] = [
   'lefthook.yaml',
   '.pre-commit-config.yaml',
   'vitest.config.ts',
+  'vitest.config.js',
+  'jest.config.js',
+  'jest.config.ts',
+  'webpack.config.js',
+  'webpack.config.ts',
+  'rollup.config.js',
+  'rollup.config.ts',
+  'babel.config.js',
+  '.babelrc',
+  'vite.config.js',
+  'vite.config.ts',
   'bunfig.toml',
 ];
 

--- a/packages/daemon/src/auto-approve/write-flag-safety.ts
+++ b/packages/daemon/src/auto-approve/write-flag-safety.ts
@@ -123,6 +123,33 @@ const FLAG_POLICIES: readonly FlagPolicy[] = [
     dangerousLongFlags: ['output-error'],
   },
   {
+    // sed -i (fs-write, #1057 phase 2 commit 4). This axis only has to keep
+    // `-f`/`--file` (loads a script from an ARBITRARY external file) and
+    // every other unlisted flag off the safe set -- what a permitted script
+    // is actually allowed to SAY (no `w`/`e`/`r`/`R` side-commands, no
+    // address prefix, exactly one `s///` or `y///`) is a shape a flag-letter
+    // allowlist cannot express at all, so it is a SEPARATE veto in
+    // `permission-groups.ts` (`sedScriptShapeVeto`, alongside the fs-write
+    // veto plumbing) layered on top of this one, exactly like ADR 0018's
+    // three independent axes.
+    //
+    // `-i`'s own value is unlike every other flag here: GNU sed accepts an
+    // attached backup suffix with NO separator (`-i.bak`), which is not a
+    // flag CLUSTER at all -- the short-option scan below checks every
+    // alphabetic character of a `-`-prefixed token as a possible flag
+    // letter, so an unnormalized `.bak` would need ITS OWN letters on this
+    // list, which is not what this list means. `permission-groups.ts`
+    // normalizes a `-i<suffix>` token to bare `-i` (and separately verifies
+    // the suffix's own shape) before this family ever sees it -- see
+    // `normalizeSedInPlaceSuffix`. BSD's `-i ''` form needs no such handling:
+    // the empty string is its own token and never starts with `-`, so the
+    // scan below skips it already.
+    family: /^sed\b/,
+    safeShortFlags: 'eEinrsuz',
+    dangerousLongFlags: [], // unused: safeLongFlags governs
+    safeLongFlags: ['in-place', 'expression', 'quiet', 'silent', 'regexp-extended', 'sandbox'],
+  },
+  {
     // rm/rmdir (ADR 0023): consumed only by `artifact-clean`'s veto — no
     // other group lists either prefix through this module (`scratch` covers
     // rm too, but its safety is destination proof, not flag policy). Long

--- a/packages/daemon/tests/auto-approve/guard-chain-replay.test.ts
+++ b/packages/daemon/tests/auto-approve/guard-chain-replay.test.ts
@@ -116,11 +116,16 @@
  *    (`.gitignore`) and NEVER committed by this change or any test here --
  *    the owner reviews `build-hook-corpus.ts`'s stdout report and decides
  *    SEPARATELY whether any reviewed subset is ever fit to commit. When the
- *    fixture is absent (every CI run, and any contributor's machine that has
- *    not generated one), the `describe` block that reads it SKIPS cleanly
- *    (`describe.skip`) with an explanatory `test` that always runs and logs
- *    why -- CI stays green, and a human reading local output sees exactly
- *    why real-corpus coverage did not run. To generate one locally:
+ *    fixture is ABSENT (every CI run, and any contributor's machine that has
+ *    not generated one) OR PRESENT WITH ZERO `PermissionRequest` records
+ *    (exactly what `build-hook-corpus.ts` produces against a
+ *    `~/.remi/hook-diag.jsonl` that has none yet), the `describe` block that
+ *    reads it SKIPS cleanly (`describe.skip`) with an explanatory `test` that
+ *    always runs and logs which of the two cases it hit -- CI stays green,
+ *    and a human reading local output sees exactly why real-corpus coverage
+ *    did not run. Records are loaded once, at module-evaluation time, so this
+ *    gate can be computed from the actual count rather than existence alone.
+ *    To generate one locally:
  *
  *      bun run packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts \
  *        --mode structure-preserving [--input ~/.remi/hook-diag.jsonl]
@@ -602,34 +607,58 @@ describe('guard chain invariants -- hand-written commands (#992, runs in CI)', (
 
 // ---------------------------------------------------------------------------
 // Local-fixture-gated: real commands. SKIPS cleanly when the fixture is
-// absent (every CI run) -- see module doc.
+// absent OR present-but-empty (every CI run, and a fresh `build-hook-corpus`
+// run against a hook-diag with no PermissionRequest records yet) -- see
+// module doc.
+//
+// Loaded ONCE, at module-evaluation time -- not lazily inside a test -- so
+// the describe-gate below can decide whether to run the real-corpus block
+// from the ACTUAL record count, not merely the fixture's existence. Gating on
+// existence alone made a present-but-empty fixture a hard test FAILURE
+// (`records.length > 0` thrown from inside a running `describe`, not a
+// skip): `build-hook-corpus.ts` produces exactly that shape on a machine
+// whose `~/.remi/hook-diag.jsonl` has no `PermissionRequest` entries yet --
+// which is what this machine's fixture is (#1061).
 // ---------------------------------------------------------------------------
 
+const localCorpusRecords: ReplayRecord[] = hasLocalCorpus ? loadLocalCorpusReplayRecords() : [];
+const hasLocalCorpusRecords = localCorpusRecords.length > 0;
+
+const HOW_TO_GENERATE_CORPUS =
+  'bun run packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts --mode structure-preserving [--input ~/.remi/hook-diag.jsonl]';
+
 test('local real-command corpus fixture status', () => {
-  if (hasLocalCorpus) {
+  // Three distinct cases, reported honestly rather than collapsed into a
+  // single boolean: no fixture at all, a fixture with zero PermissionRequest
+  // records (the gate must SKIP, not fail, on this one too), and a fixture
+  // with real records to replay.
+  if (!hasLocalCorpus) {
     console.log(
-      `[guard-chain-replay] Local corpus found at ${LOCAL_CORPUS_PATH} -- real-corpus replay WILL run below.`,
+      `[guard-chain-replay] No local corpus at ${LOCAL_CORPUS_PATH} -- real-corpus replay is SKIPPED. This is expected in CI and on a fresh checkout: this repo never commits captured command data (see this file's module doc and build-hook-corpus.ts). To generate one locally: ${HOW_TO_GENERATE_CORPUS}`,
+    );
+  } else if (!hasLocalCorpusRecords) {
+    console.log(
+      `[guard-chain-replay] Local corpus found at ${LOCAL_CORPUS_PATH} but contains zero PermissionRequest records -- real-corpus replay is SKIPPED. This happens when the machine's own ~/.remi/hook-diag.jsonl has no PermissionRequest entries yet (auto-approve has not parked or rendered a prompt locally). To generate a corpus with records: ${HOW_TO_GENERATE_CORPUS}`,
     );
   } else {
     console.log(
-      `[guard-chain-replay] No local corpus at ${LOCAL_CORPUS_PATH} -- real-corpus replay is SKIPPED. This is expected in CI and on a fresh checkout: this repo never commits captured command data (see this file's module doc and build-hook-corpus.ts). To generate one locally: bun run packages/daemon/tests/hooks/fixtures/build-hook-corpus.ts --mode structure-preserving [--input ~/.remi/hook-diag.jsonl]`,
+      `[guard-chain-replay] Local corpus found at ${LOCAL_CORPUS_PATH} with ${localCorpusRecords.length} PermissionRequest record(s) -- real-corpus replay WILL run below.`,
     );
   }
   // This test only reports status; it must itself always pass so its log
-  // line is never hidden behind a failure.
+  // line is never hidden behind a failure -- and it stays HONEST about which
+  // of the three cases above it actually hit, rather than asserting only the
+  // fixture-existence boolean the way the previous version did.
   expect(typeof hasLocalCorpus).toBe('boolean');
+  expect(typeof hasLocalCorpusRecords).toBe('boolean');
+  expect(hasLocalCorpusRecords ? hasLocalCorpus : true).toBe(true);
 });
 
-const describeRealCorpus = hasLocalCorpus ? describe : describe.skip;
+const describeRealCorpus = hasLocalCorpusRecords ? describe : describe.skip;
 
 describeRealCorpus('guard chain invariants -- real local command corpus (#992, opt-in)', () => {
   test('every invariant holds for every real record x verdict x authority combination', () => {
-    const records = loadLocalCorpusReplayRecords();
-    expect(
-      records.length,
-      'local corpus fixture exists but contains zero PermissionRequest records',
-    ).toBeGreaterThan(0);
-    const report = assertGuardChainInvariants(records);
+    const report = assertGuardChainInvariants(localCorpusRecords);
     logDistribution('real local corpus', report);
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1192,6 +1192,126 @@ describe('#1041: fs-write grants a relative, non-ascending, non-sensitive redire
 });
 
 /**
+ * #1057 phase 2, commit 3: heredoc excision. Heredocs appear NOWHERE in the
+ * decision code before this. Today `tee /tmp/x <<EOF` (one physical line, no
+ * real newline) approves because `<<EOF` just sits as an inert extra token;
+ * a genuine MULTI-LINE heredoc escalates only by ACCIDENT, because
+ * `splitCompoundParts` treats an unquoted newline as a separator and a body
+ * line essentially never happens to prefix-match a curated command. This
+ * block pins the deliberate replacement: excise the operator + body when it
+ * can be proven safe to do so, and fall back to that same accidental (but
+ * safe) behavior the instant it cannot be proven.
+ */
+describe('#1057 phase 2 commit 3: heredoc excision (group path only)', () => {
+  const WRITE_GROUPS_NO_SCRATCH = [...ALL, 'fs-write'];
+  const EVERYTHING = [...ALL, ...WRITE_GROUPS, ...SCRATCH_GROUPS, ...ARTIFACT_GROUPS];
+
+  describe('covered: excision composes with the existing redirect grants', () => {
+    const cases: Array<[string, string, string[], string]> = [
+      [
+        "cat > notes.md <<'EOF'\nhello\nEOF",
+        'quoted delimiter: excised, then the fs-write relative redirect grant deletes "> notes.md"',
+        WRITE_GROUPS_NO_SCRATCH,
+        'read-only:cat',
+      ],
+      [
+        'tee notes.md <<EOF\nplain text\nEOF',
+        'unquoted delimiter, inert body: excised outright, tee itself is the fs-write-owned prefix, no redirect grant needed',
+        WRITE_GROUPS,
+        'fs-write:tee',
+      ],
+    ];
+    for (const [cmd, why, groups, expected] of cases) {
+      test(`${JSON.stringify(cmd)} — ${why}`, () => {
+        expect(bash(cmd, groups)).toBe(expected);
+      });
+    }
+    test("tee /tmp/x <<'EOF'\\nbody\\nEOF — scratch: absolute root grant, unaffected", () => {
+      expect(bash("tee /tmp/x <<'EOF'\nbody\nEOF", SCRATCH_GROUPS)).toBe('scratch:tee');
+    });
+    test('notes.md case actually resolves via fs-write, not just read-only', () => {
+      // Sanity: the fs-write group's own redirect grant is what let this through
+      // -- without it requested, the same command must fall back to null.
+      expect(bash("cat > notes.md <<'EOF'\nhello\nEOF", ALL)).toBeNull();
+    });
+  });
+
+  test("regression guard: today's single-line accidental approval is unaffected", () => {
+    // No real newline in this string at all -- there is no terminator to find,
+    // so excision aborts (unterminated, fails closed) and the command reaches
+    // the existing machinery byte-for-byte, exactly as it did before commit 3.
+    expect(bash('tee /tmp/x <<EOF', WRITE_GROUPS)).toBe('fs-write:tee');
+    // Under `scratch` alone the same string was ALREADY refused before this
+    // commit (`scratchTargetVeto` treats the glued `<<EOF` token as a
+    // non-scratch-rooted positional target) -- unaffected either way.
+    expect(bash('tee /tmp/x <<EOF', SCRATCH_GROUPS)).toBeNull();
+  });
+
+  test("safety invariant: no interpreter is in any group's command list, before or after excision", () => {
+    for (const cmd of [
+      "bash <<'EOF'\nrm -rf /\nEOF",
+      "python3 - <<'PY'\nprint(1)\nPY",
+      'sh <<X\necho hi\nX',
+    ]) {
+      expect(bash(cmd, EVERYTHING)).toBeNull();
+    }
+  });
+
+  describe("MUST NOT excise (falls through to today's accidental, still-safe behavior)", () => {
+    const mustBeNull: Array<[string, string]> = [
+      [
+        'cat > x <<EOF\n$(rm -rf /)\nEOF',
+        'unquoted delimiter, LIVE body: the shell would run $(...) expanding it, so excision must not hide that execution from the matcher',
+      ],
+      [
+        "cat > x <<'EOF'\nbody",
+        'unterminated: no line ever matches the delimiter, so nothing is proven removable',
+      ],
+      [
+        'cat > x <<\'EOF\'\n"EOF"\nrm -rf /',
+        'terminator-inside-quotes spoof with NO real terminator: a quoted lookalike must not count as the delimiter line, so this stays unterminated and falls through',
+      ],
+      [
+        'cat > x <<E$OF\nbody\nE$OF',
+        'delimiter contains $: fails the plain-word shape, so no excision is attempted',
+      ],
+    ];
+    for (const [cmd, why] of mustBeNull) {
+      test(`${JSON.stringify(cmd)} — ${why}`, () => {
+        expect(bash(cmd, WRITE_GROUPS_NO_SCRATCH)).toBeNull();
+      });
+    }
+  });
+
+  test('a quoted lookalike inside the body does not end the heredoc early, when a real terminator follows', () => {
+    // Same body as the spoof case above, but with a genuine trailing bare
+    // `EOF`. The quoted "EOF" line must be skipped as a candidate terminator,
+    // so the WHOLE body -- including the "rm -rf /"-shaped line -- is proven
+    // to be inert heredoc data and excised along with the real terminator,
+    // never examined as a command in its own right.
+    expect(bash('cat > x <<\'EOF\'\n"EOF"\nrm -rf /\nEOF', WRITE_GROUPS_NO_SCRATCH)).toBe(
+      'read-only:cat',
+    );
+  });
+
+  test('<<< here-strings are excluded outright and behave exactly as before', () => {
+    // A run of 3+ `<` is never a heredoc operator, so this command is not
+    // even a candidate for excision -- `exciseHeredocsForGroups` returns it
+    // unchanged, and today's (pre-commit-3) behavior is reproduced exactly.
+    expect(bash('cat <<< "hello"', ALL)).toBe('read-only:cat');
+  });
+
+  test('a body line that looks like a covered command must not leak coverage', () => {
+    // "git status" is BODY, wholly excised along with the operator and the
+    // terminator -- the command's coverage is decided by the `cat` head
+    // alone, which takes no arguments here, so this must equal bare `cat`.
+    const withHeredoc = bash("cat <<'EOF'\ngit status\nEOF", WRITE_GROUPS_NO_SCRATCH);
+    expect(withHeredoc).toBe(bash('cat', WRITE_GROUPS_NO_SCRATCH));
+    expect(withHeredoc).toBe('read-only:cat');
+  });
+});
+
+/**
  * #1001. `deny_groups` was answered by `matchGroups`, the same function that
  * answers the allow question. ADR 0010 says allow matching is PRECISE and deny
  * matching is BROAD; this was the one place a deny question was asked of a

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -6,6 +6,7 @@ import {
   matchGroups,
   matchGroupsBroad,
   matchReadOnlyCommand,
+  sedScriptShapeVeto,
 } from '../../src/auto-approve/permission-groups.ts';
 
 /** The READ groups. Kept as the default for `bash()` so every pre-#959 test
@@ -720,6 +721,21 @@ describe('#959 final pass: every write prefix is covered by a flag policy', () =
   // their flag policy inside `artifactCleanVeto` itself (an exact structural
   // allowlist) -- the probe asserts the same PROPERTY either way: an
   // unclassified flag is refused, wherever the policy lives.
+  //
+  // NOTE for the "sed -i" prefix specifically (review pass, #1061):
+  // `writeGroupVeto` is `hasUnsafeWriteFlag(...) || ... || sedScriptShapeVeto(...)`,
+  // and `hasUnsafeWriteFlag` runs FIRST, so for `sed -i -Zqx target` it is
+  // genuinely the flag axis that produces `null` here -- verified directly:
+  // `hasUnsafeWriteFlag('sed -i -Zqx target')` is `true` on its own, which
+  // short-circuits the `||` before `sedScriptShapeVeto` (which would ALSO
+  // refuse "target" as an invalid script) is ever called. What this specific
+  // generated case does NOT do is isolate which of the cluster's three
+  // letters (`Z`, `q`, `x`) is doing the work -- none of them is individually
+  // on sed's safe list, so a mutation that flipped only ONE of the three to
+  // "safe" would not flip this test's outcome. The dedicated `sed -i -Z
+  // 's/a/b/' f` / `sed -i -w 's/a/b/' f` cases in the "#1057 phase 2 commit
+  // 4" describe block below use a single unsafe letter against an otherwise
+  // VALID script, closing that gap.
   const WRITE_GROUP_NAMES = ['fs-write', 'vcs-write', 'artifact-clean'];
 
   for (const groupName of WRITE_GROUP_NAMES) {
@@ -1292,6 +1308,10 @@ describe('#1057 phase 2 commit 3: heredoc excision (group path only)', () => {
         'cat > x <<E$OF\nbody\nE$OF',
         'delimiter contains $: fails the plain-word shape, so no excision is attempted',
       ],
+      [
+        'cat > a.txt <<EOF\nfirst\nEOF\ncat > b.txt <<BAD!\nsecond\nBAD!',
+        'a VALID first heredoc followed by a second heredoc with an invalid delimiter (BAD! contains a non-word character): excision must abort for the WHOLE command and return it byte-for-byte -- pinning the `return command` path, not a partial reconstruction that keeps the first heredoc already excised',
+      ],
     ];
     for (const [cmd, why] of mustBeNull) {
       test(`${JSON.stringify(cmd)} — ${why}`, () => {
@@ -1366,7 +1386,22 @@ describe('#1057 phase 2 commit 4: sed -i script-shape allowlist', () => {
       ],
       [
         'sed --file=evil.sed -i f',
-        '--file loads an ARBITRARY external script, refused by the flag axis',
+        // #1061 review: relabeled. `matchPrefix` requires the curated prefix
+        // to be followed by a literal space (`sed -i `); this segment does
+        // not even START with that text (it starts `sed --file=`), so it is
+        // refused by PREFIX MISMATCH before `writeGroupVeto`/the flag axis is
+        // ever consulted -- not because `--file` was recognized and rejected.
+        // See `sed -i --file=evil.sed f` below for a spelling that actually
+        // reaches, and is refused by, the flag axis.
+        'refused by PREFIX MISMATCH (does not start with the curated "sed -i " prefix), not the flag axis',
+      ],
+      [
+        'sed -i --file=evil.sed f',
+        // This spelling DOES start with `sed -i `, so it reaches
+        // `writeGroupVeto`, where `--file=evil.sed` fails `hasUnsafeWriteFlag`
+        // ('file' is not in sed's `safeLongFlags`) and that check runs FIRST
+        // in the `||` chain -- genuinely the flag axis, not prefix mismatch.
+        '--file loads an ARBITRARY external script; this spelling reaches and is refused by the flag axis',
       ],
     ];
     for (const [cmd, why] of mustBeNull) {
@@ -1392,20 +1427,73 @@ describe('#1057 phase 2 commit 4: sed -i script-shape allowlist', () => {
     expect(bash("sed -i 's/a/b/' f", ALL)).toBeNull();
   });
 
-  test('the backup-suffix VALUE is checked independently of the destination axis', () => {
-    // A `*` or `/` in an ATTACHED suffix can redirect GNU sed's backup write
-    // to an arbitrary path (sed expands `*` to the target's own name and
-    // treats the result as a path) -- a bypass `segmentTouchesSensitivePath`
-    // cannot see, since the suffix is a flag VALUE, not the final file
-    // argument. Both refused before the script or destination is even reached.
+  test('the backup-suffix VALUE, reached through the FULL group path, is null via PREFIX MISMATCH', () => {
+    // #1061 review: relabeled -- this used to claim the destination-axis
+    // check on the suffix was what refused these. It is not, TODAY: an
+    // attached `-i'...'` (no space before the quote) does not start with the
+    // curated `sed -i ` prefix any more than `sed -i.bak` does (same
+    // `matchPrefix` residual), so `writeGroupVeto` -- and the suffix check
+    // inside `sedScriptShapeVeto` these commands were meant to exercise -- is
+    // never reached at all. Both commands really are null, just for a
+    // different reason than this test's own name used to say. See the
+    // "documented residual" block below for the general case, and the
+    // "backup-suffix VALUE, reached directly" block below for tests that
+    // actually reach and exercise the suffix check.
     expect(bash("sed -i'*/tmp/../../etc/cron.d/evil' 's/a/b/' f", WRITE_GROUPS)).toBeNull();
     expect(bash("sed -i'../../../etc/passwd' 's/a/b/' f", WRITE_GROUPS)).toBeNull();
+  });
+
+  describe('backup-suffix VALUE, reached directly: defense-in-depth for the ADR 0026 residual', () => {
+    // The two branches these tests exercise (permission-groups.ts,
+    // `sedScriptShapeVeto`'s `-i<suffix>` and `--in-place=<suffix>` checks)
+    // are UNREACHABLE through `matchGroups`/`bash()` today for the reason the
+    // test above and the "documented residual" block below both demonstrate:
+    // `matchPrefix` requires a literal space after `sed -i`, which neither
+    // attached spelling has. Calling the exported veto function directly
+    // (mirrors `MUTATION_TOKEN`'s "exported for tests ONLY" convention)
+    // bypasses that prefix-matching layer entirely, so these ARE genuine
+    // direct exercises of the suffix check, kept as defense-in-depth for the
+    // day attached-suffix prefix matching is added.
+    test("-i'<suffix>' containing a path separator and a glob is vetoed", () => {
+      expect(sedScriptShapeVeto("sed -i'*/tmp/../../etc/cron.d/evil' 's/a/b/' f")).toBe(true);
+    });
+    test('--in-place=<suffix> containing an ascent is vetoed', () => {
+      expect(sedScriptShapeVeto("sed --in-place=../../../etc/passwd 's/a/b/' f")).toBe(true);
+    });
+    test('an ordinary attached suffix (no separator or glob) is NOT vetoed by this check', () => {
+      expect(sedScriptShapeVeto("sed -i.bak 's/a/b/' f")).toBe(false);
+    });
   });
 
   test('#959 final pass invariant: sed -i -Zqx is refused by the flag axis', () => {
     // Pinned directly here too (in addition to the machine-checked walk over
     // BUILTIN_GROUPS above): an unclassified flag must be refused.
     expect(bash('sed -i -Zqx target', WRITE_GROUPS)).toBeNull();
+  });
+
+  describe('#1061: the sed FLAG_POLICY, pinned on a VALID script (isolates the flag axis)', () => {
+    // `sed -i -Zqx target` (above, and in the machine-checked walk) bundles
+    // THREE unsafe letters against an INVALID script, so it does not isolate
+    // any one letter, and -- since `hasUnsafeWriteFlag` runs first in
+    // `writeGroupVeto`'s `||` chain and short-circuits -- it never even
+    // reaches `sedScriptShapeVeto` to find out the script was invalid too.
+    // These two use a SINGLE unsafe flag against an otherwise-valid `s///`
+    // script, which is the only shape that actually distinguishes "the flag
+    // axis caught this" from "the script-shape veto would have caught it
+    // anyway".
+    test("sed -i -Z 's/a/b/' f", () =>
+      expect(bash("sed -i -Z 's/a/b/' f", WRITE_GROUPS)).toBeNull());
+    test("sed -i -w 's/a/b/' f", () =>
+      expect(bash("sed -i -w 's/a/b/' f", WRITE_GROUPS)).toBeNull());
+  });
+
+  test("sed -i 's;a;b;g' f — ; used AS THE DELIMITER is refused conservatively", () => {
+    // The `;`-inclusion check's unique observable effect (see
+    // `sedScriptShapeOk`'s doc comment): this script otherwise has exactly 4
+    // fields and a valid trailing class ('g'), so it would PASS the
+    // field-count and trailing-class checks on their own. It is refused only
+    // because `;` is refused outright, regardless of role.
+    expect(bash("sed -i 's;a;b;g' f", WRITE_GROUPS)).toBeNull();
   });
 
   describe('documented residual: matchPrefix cannot see an ATTACHED -i suffix', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1103,6 +1103,95 @@ describe('#1000: a cd whose effect is not guaranteed does not move the tracked r
 });
 
 /**
+ * #1041: 58% of trusted Bash escalations measured on a real machine were
+ * plain file writes -- `cat a.txt > notes.md`, `bun test > out.log 2>&1`,
+ * `git diff > review.diff` -- heads already covered by `read-only`,
+ * `build-test` and `vcs-read`, escalating only because the redirect target
+ * looked like shell control to `hasShellControl`. `fs-write` already approves
+ * exactly this operation through the `Write` tool, so this grant lets it
+ * approve the Bash spelling too: a path-kind redirect clause may be deleted
+ * when its cwd-resolved target is a RELATIVE path that does not ascend out of
+ * the directory the command started in, and is not a sensitive destination.
+ *
+ * `WRITE_GROUPS_NO_SCRATCH` deliberately omits `scratch`, to isolate the
+ * fs-write grant from the pre-existing absolute-root one -- a command that
+ * needs `scratch` to pass here would be pinning the wrong grant.
+ */
+describe('#1041: fs-write grants a relative, non-ascending, non-sensitive redirect', () => {
+  const WRITE_GROUPS_NO_SCRATCH = [...ALL, 'fs-write'];
+
+  describe('covered', () => {
+    const covered: Array<[string, string]> = [
+      ['cat a.txt > notes.md', 'read-only:cat'],
+      ['cat a >> log.txt', 'read-only:cat'],
+      ['bun test > out.log 2>&1', 'build-test:bun test'],
+      ['git diff > review.diff', 'vcs-read:git diff'],
+      ['cd sub && cat a > out.txt', 'read-only:cat'],
+      ['cat a > docs/notes.md', 'read-only:cat'],
+    ];
+    for (const [cmd, expected] of covered) {
+      test(`${JSON.stringify(cmd)} -> ${expected}`, () => {
+        expect(bash(cmd, WRITE_GROUPS_NO_SCRATCH)).toBe(expected);
+      });
+    }
+  });
+
+  describe('MUST NOT cover (falls through to the LLM)', () => {
+    const mustBeNull: Array<[string, string]> = [
+      ['cat a > /etc/hosts', 'absolute target, outside any scratch root'],
+      ['cat a > ~/x', 'home-rooted target'],
+      ['cat a > $HOME/x', '$HOME is absolute-shaped, never composed'],
+      ['cat a > ../escape.txt', 'ascends above the start with no cd at all'],
+      ['cat a > sub/../../escape.txt', 'composes to an ascent above the start'],
+      ['cat a > .env', 'a credential basename'],
+      ['cat a > package.json', 'a build surface'],
+      ['cat a > .git/hooks/pre-commit', 'git hook: code execution on the next commit'],
+      ['cd /opt && cat a > x', 'an absolute cd kills the relative grant, sticky'],
+      ['cd $DIR && cat a > x', 'an unresolvable cd target kills the grant, sticky'],
+      ['cat a > "quoted path.txt"', 'opaque target: quoting is never composed'],
+      ['cat a >| x', 'clobber redirect: opaque target'],
+      ['cat a &> x', 'merge redirect: the residual & still backgrounds'],
+      ['cat a > >(tee x)', 'process substitution: hasShellControl catches <( and >('],
+      ['cat a >/tmp/a>/etc/passwd', 'glued redirect (#1000): opaque target'],
+      ['echo hi > notes.md', 'echo is neutral, so nothing ever matches a prefix'],
+    ];
+    for (const [cmd, why] of mustBeNull) {
+      test(`${JSON.stringify(cmd)} — ${why}`, () => {
+        expect(bash(cmd, WRITE_GROUPS_NO_SCRATCH)).toBeNull();
+      });
+    }
+
+    test('fs-write not in groups: the same redirect stays refused', () => {
+      expect(bash('cat a > notes.md', ALL)).toBeNull();
+    });
+  });
+
+  test('cd composition: a relative cd chain that returns to the start still grants', () => {
+    expect(bash('cd sub && cd .. && cat a > out.txt', WRITE_GROUPS_NO_SCRATCH)).toBe(
+      'read-only:cat',
+    );
+  });
+
+  test('cd composition: ascending past the start kills the grant', () => {
+    expect(bash('cd sub && cd .. && cd .. && cat a > out.txt', WRITE_GROUPS_NO_SCRATCH)).toBeNull();
+  });
+
+  test('the two grants compose: either proof deletes the clause', () => {
+    const BOTH = [...ALL, 'fs-write', 'scratch'];
+    // scratch's own absolute-root grant, unaffected by fs-write being active too.
+    expect(bash('cat a > /tmp/out.txt', BOTH)).toBe('read-only:cat');
+    // fs-write's relative grant, unaffected by scratch being active too.
+    expect(bash('cat a > notes.md', BOTH)).toBe('read-only:cat');
+  });
+
+  test('every existing scratch-only behavior is unaffected by the generalization', () => {
+    expect(bash('rm -rf /tmp/x', SCRATCH_GROUPS)).toBe('scratch:rm');
+    expect(bash('cat file.txt > /tmp/out.txt', ['scratch', 'read-only'])).toBe('read-only:cat');
+    expect(bash('cat file.txt > /etc/passwd', ['scratch', 'read-only'])).toBeNull();
+  });
+});
+
+/**
  * #1001. `deny_groups` was answered by `matchGroups`, the same function that
  * answers the allow question. ADR 0010 says allow matching is PRECISE and deny
  * matching is BROAD; this was the one place a deny question was asked of a

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -894,6 +894,39 @@ describe('scratch: output redirection to a scratch target', () => {
   });
 });
 
+/**
+ * #1060 + ADR 0018 axis 3. The scratch redirect carve-out proved a target
+ * was under a scratch root and stopped there -- it never asked WHAT the
+ * target named, so a redirect INTO `/tmp/.env`, `/tmp/.git/hooks/pre-commit`
+ * or `/tmp/sub/package.json` had its clause deleted before
+ * `segmentTouchesSensitivePath` ever saw the token it exists to veto.
+ * Measured live before the fix: all three approved at 0ms on
+ * `['scratch', 'read-only']`.
+ */
+describe('#1060: a scratch-granted redirect target must not be sensitive', () => {
+  const READ_PLUS_SCRATCH = ['scratch', 'read-only'];
+
+  const sensitiveTargets: Array<[string, string]> = [
+    ['cat a > /tmp/.env', 'a credential basename, inside a scratch root'],
+    ['cat a > /tmp/.git/hooks/pre-commit', 'git hook: code execution on the next commit'],
+    ['cat a > /tmp/sub/package.json', 'build surface, nested under the scratch root'],
+  ];
+
+  for (const [cmd, why] of sensitiveTargets) {
+    test(`${JSON.stringify(cmd)} — ${why}`, () => {
+      expect(bash(cmd, READ_PLUS_SCRATCH)).toBeNull();
+    });
+  }
+
+  test('the fix does not over-narrow: an ordinary scratch redirect still matches', () => {
+    expect(bash('cat a > /tmp/out.txt', READ_PLUS_SCRATCH)).toBe('read-only:cat');
+  });
+
+  test('the fix does not over-narrow: a nested non-sensitive redirect still matches', () => {
+    expect(bash('cat a > /tmp/nested/ok.txt', READ_PLUS_SCRATCH)).toBe('read-only:cat');
+  });
+});
+
 describe('scratch: level membership', () => {
   test('scratch alone does not need fs-write or vcs-write', () => {
     expect(bash('rm -rf /tmp/x', ['scratch'])).toBe('scratch:rm');

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -627,10 +627,27 @@ describe('#960 regression: build surface + the DEFAULT-ON build-test group', () 
     'cp x pyproject.toml',
     'cp x bunfig.toml',
     'mv evil bun.lock',
+    // #1061 additions: jest/webpack/rollup/babel/vite build-surface configs.
+    'cp x jest.config.js',
+    'cp x webpack.config.ts',
+    'cp x rollup.config.js',
+    'cp x babel.config.js',
+    'cp x .babelrc',
+    'cp x vite.config.ts',
   ];
   for (const cmd of mustBeNull) {
     test(JSON.stringify(cmd), () => expect(bash(cmd, WRITE_GROUPS)).toBeNull());
   }
+
+  test('#1061: the redirect-grant path is covered too, not just the direct-argument path', () => {
+    // `jest.config.js` is a read-side redirect TARGET here (`cat` is
+    // read-only, `fs-write` is what would otherwise delete the `>` clause) --
+    // exercising BUILD_SURFACE through `isGrantedFsWriteRedirectTarget`
+    // rather than through `segmentTouchesSensitivePath`'s direct-argument
+    // scan, so a future regression that only re-checks one of the two paths
+    // is caught by this pairing.
+    expect(bash('cat payload > jest.config.js', [...ALL, ...WRITE_GROUPS])).toBeNull();
+  });
 
   test('the mutating tools are guarded too', () => {
     for (const file_path of [

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1312,6 +1312,99 @@ describe('#1057 phase 2 commit 3: heredoc excision (group path only)', () => {
 });
 
 /**
+ * #1057 phase 2, commit 4: `sed -i` under a strict script-shape allowlist.
+ * Every script the command would actually run must be a single, unconditional
+ * `s///` or `y///` -- no address prefix, no brace block, no `w`/`e`/`r`/`R`
+ * side-command, no chained `;`. Destinations still go through the same
+ * `segmentTouchesSensitivePath` axis every other fs-write prefix does.
+ */
+describe('#1057 phase 2 commit 4: sed -i script-shape allowlist', () => {
+  describe('covered', () => {
+    const cases: Array<[string, string]> = [
+      ["sed -i 's/a/b/' file.txt", 'fs-write:sed -i'],
+      ["sed -i 's/a/b/g' f", 'fs-write:sed -i'],
+      ["sed -i -e 's/a/b/' f", 'fs-write:sed -i'],
+      ["sed -i 'y/abc/xyz/' f", 'fs-write:sed -i'],
+      // BSD empty-suffix form: `-i` and the following literal `''` are TWO
+      // tokens, so this still starts with the curated `sed -i ` prefix.
+      ["sed -i '' 's/a/b/' f", 'fs-write:sed -i'],
+    ];
+    for (const [cmd, expected] of cases) {
+      test(cmd, () => expect(bash(cmd, WRITE_GROUPS)).toBe(expected));
+    }
+  });
+
+  describe('MUST NOT cover: named adversaries (falls through to the LLM)', () => {
+    const mustBeNull: Array<[string, string]> = [
+      [
+        "sed -i 's/x/y/w /etc/cron.d/evil' f",
+        'the w side-command writes an ARBITRARY second file, unrelated to the destination axis',
+      ],
+      ["sed -i 's/x/y/e' f", 'the e flag executes the substitution result as a shell command'],
+      ["sed -i '1,5d' f", 'an address-range prefix, not a bare s/// or y///'],
+      ["sed -i '/x/d' f", 'an address-regex prefix, not a bare s/// or y///'],
+      [
+        "sed -i -e 's/a/b/' -e 'e date' f",
+        'a SECOND -e script fails the shape even though the first one passes',
+      ],
+      [
+        'sed --file=evil.sed -i f',
+        '--file loads an ARBITRARY external script, refused by the flag axis',
+      ],
+    ];
+    for (const [cmd, why] of mustBeNull) {
+      test(`${JSON.stringify(cmd)} — ${why}`, () => expect(bash(cmd, WRITE_GROUPS)).toBeNull());
+    }
+  });
+
+  describe('destination axis: still refused regardless of script shape', () => {
+    for (const target of ['.env', 'package.json']) {
+      test(`sed -i 's/a/b/' ${target}`, () =>
+        expect(bash(`sed -i 's/a/b/' ${target}`, WRITE_GROUPS)).toBeNull());
+    }
+  });
+
+  test('read-side SCOPED_VETO is untouched: sed -n with -i still refuses', () => {
+    // Matched via read-only's `sed -n` prefix, not fs-write's `sed -i` --
+    // `hasScopedVeto` (permission-groups.ts) refuses any sed segment
+    // carrying `-i`/`--in-place` regardless of which prefix it matched.
+    expect(bash("sed -n -i 's/a/b/' f", ALL)).toBeNull();
+  });
+
+  test('without fs-write requested, sed -i matches no prefix at all', () => {
+    expect(bash("sed -i 's/a/b/' f", ALL)).toBeNull();
+  });
+
+  test('the backup-suffix VALUE is checked independently of the destination axis', () => {
+    // A `*` or `/` in an ATTACHED suffix can redirect GNU sed's backup write
+    // to an arbitrary path (sed expands `*` to the target's own name and
+    // treats the result as a path) -- a bypass `segmentTouchesSensitivePath`
+    // cannot see, since the suffix is a flag VALUE, not the final file
+    // argument. Both refused before the script or destination is even reached.
+    expect(bash("sed -i'*/tmp/../../etc/cron.d/evil' 's/a/b/' f", WRITE_GROUPS)).toBeNull();
+    expect(bash("sed -i'../../../etc/passwd' 's/a/b/' f", WRITE_GROUPS)).toBeNull();
+  });
+
+  test('#959 final pass invariant: sed -i -Zqx is refused by the flag axis', () => {
+    // Pinned directly here too (in addition to the machine-checked walk over
+    // BUILTIN_GROUPS above): an unclassified flag must be refused.
+    expect(bash('sed -i -Zqx target', WRITE_GROUPS)).toBeNull();
+  });
+
+  describe('documented residual: matchPrefix cannot see an ATTACHED -i suffix', () => {
+    // `matchPrefix` requires a literal space after the curated prefix
+    // (`segment.startsWith('sed -i ')`), which GNU's no-separator spelling
+    // never satisfies -- `sed -i.bak ...` does not start with `sed -i `, so
+    // it never reaches `sedScriptShapeVeto`, or any veto at all: it matches
+    // NO curated prefix and falls through, unconditionally safe (escalate),
+    // never unsafe. See the residuals comment above `sedScriptShapeVeto`.
+    test("sed -i.bak 's/a/b/' f — verified null, not covered", () => {
+      expect(bash("sed -i.bak 's/a/b/' f", WRITE_GROUPS)).toBeNull();
+    });
+  });
+});
+
+/**
  * #1001. `deny_groups` was answered by `matchGroups`, the same function that
  * answers the allow question. ADR 0010 says allow matching is PRECISE and deny
  * matching is BROAD; this was the one place a deny question was asked of a

--- a/packages/daemon/tests/auto-approve/sensitive-paths.test.ts
+++ b/packages/daemon/tests/auto-approve/sensitive-paths.test.ts
@@ -92,6 +92,64 @@ describe('config governing this mechanism', () => {
   });
 });
 
+describe('build surface (#960 review, extended by #1061)', () => {
+  // `build-test` ships enabled by default and reads its behaviour out of
+  // these files -- see BUILD_SURFACE's own module doc in sensitive-paths.ts.
+  // Mirrors every BUILD_SURFACE basename, original and added, none of which
+  // had a direct `isSensitiveWritePath` test before this block: they were
+  // only exercised indirectly through permission-groups.test.ts's higher-
+  // level `bash()` cases.
+  for (const p of [
+    'package.json',
+    'package-lock.json',
+    'bun.lock',
+    'bun.lockb',
+    'pnpm-lock.yaml',
+    'yarn.lock',
+    'tsconfig.json',
+    'biome.json',
+    'biome.jsonc',
+    'makefile',
+    'justfile',
+    'pyproject.toml',
+    'uv.lock',
+    'setup.py',
+    'conftest.py',
+    'cargo.toml',
+    'dockerfile',
+    'lefthook.yml',
+    'lefthook.yaml',
+    '.pre-commit-config.yaml',
+    'vitest.config.ts',
+    'bunfig.toml',
+    // Added (#1061): the missing jest/webpack/rollup/babel/vite forms.
+    'vitest.config.js',
+    'jest.config.js',
+    'jest.config.ts',
+    'webpack.config.js',
+    'webpack.config.ts',
+    'rollup.config.js',
+    'rollup.config.ts',
+    'babel.config.js',
+    '.babelrc',
+    'vite.config.js',
+    'vite.config.ts',
+  ]) {
+    test(`sensitive: ${p}`, () => expect(isSensitiveWritePath(p)).toBe(true));
+    test(`sensitive (nested): /Users/x/project/${p}`, () =>
+      expect(isSensitiveWritePath(`/Users/x/project/${p}`)).toBe(true));
+  }
+
+  test('a file merely NAMED like one is ordinary (over-block boundary)', () => {
+    // Exact-basename matching, not substring: these carry the real basename
+    // as a mere PREFIX or SUFFIX and must be unaffected.
+    expect(isSensitiveWritePath('jest.config.js.example')).toBe(false);
+    expect(isSensitiveWritePath('my-webpack.config.js')).toBe(false);
+    expect(isSensitiveWritePath('vite.config.js.bak')).toBe(false);
+    expect(isSensitiveWritePath('not-a-babelrc.js')).toBe(false);
+  });
+});
+
 describe('.git internals', () => {
   for (const p of ['.git/hooks/pre-commit', '/Users/x/project/.git/config', '~/repo/.git/HEAD']) {
     test(`sensitive: ${p}`, () => expect(isSensitiveWritePath(p)).toBe(true));


### PR DESCRIPTION
## Summary

The write groups gain coverage for the three decidable write shapes that dominate #996's miss classification (redirection 50%, heredoc 13%) and #1041's measurement (58% of trusted Bash escalations are file writes a config already approves via the Write/Edit tools). Design per ADR 0026 (new in this PR): no veto lifting, no interpreter classification — a clause is deleted before matching only when its destination is positively proven, and `hasShellControl`/`splitCompoundParts`/`maskQuotedSpans` are untouched.

- Commit 1 fixes #1060 first: the scratch redirect deletion now requires the resolved target to clear `isSensitiveWritePath` (`cat a > /tmp/.env` no longer approves at 0ms). Narrowing.
- Commit 2 generalizes the scratch pre-pass into `sanitizeCommandForRedirectGrants`: with `fs-write` active, a relative, non-ascending, non-sensitive redirect target is granted (sticky-null RelativeCwd walk shared with scratch — one walk, never two).
- Commit 3 excises heredocs before compound splitting, fail-closed at every step (plain delimiter, single heredoc, terminator found, no live substitution in an unquoted-delimiter body). Interpreters stay uncovered by construction — pinned by test.
- Commit 4 adds `sed -i` to fs-write behind a page-sized script-shape allowlist (`s<D>...<D>...<D>[gIp0-9]*` / `y<D>...`), refusing `w`/`W`/`e`/`r`/`R`, addresses, braces, `;`, and `--file`; the `-i` backup suffix gets its own path-free check. Two documented fail-closed residuals: GNU attached-suffix `sed -i.bak` matches no prefix (still escalates), and BSD `-i` token-consumption divergence.
- Commit 5: ADR 0026, ADR 0010 Decision amendment, decisions README index (adds the missing 0025 row too), and the measurement addendum in `.context/approval-rate-baseline-2026-08.md` — every #996 sample shape now matches at 0ms; every named adversary stays null.

Closes #996. Closes #1041. Closes #1060. Part of epic #1057 (closing keywords fire at the epic-to-develop merge).

## Test plan

- `permission-groups.test.ts` 361 -> 388+ tests; targeted suites (all four shell-safety pinned suites, artifact-clean, sensitive-paths, shell-grammar) 909+ pass, 0 fail
- Adversarial blocks per commit: sensitive /tmp targets, `..`-ascent, `~`/`$HOME`/`$VAR`, quoted/opaque targets, glued clauses (#1000), cd-poisoning, heredoc terminator spoofing, live-substitution bodies, sed `w`/`e` scripts
- biome + typecheck clean