### PR TITLE
Veto input redirect from /dev/tcp and /dev/udp (#1063)

### DIFF
--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -213,18 +213,6 @@ const INPUT_REDIRECT_PATH_RE = /^[A-Za-z0-9_./~-]+$/;
 const NETWORK_DEV_PATH_RE = /^\/dev\/(tcp|udp)\//;
 
 /**
- * A single input-redirect operator and its target, for `hasShellControl`'s
- * network-device egress check (#1063). Matches an optional leading fd number
- * and one `<`, capturing the following target word. The lookbehind excludes
- * the trailing `<` of `<<`/`<<<` (heredoc / here-string — neither opens a
- * socket), and the lookahead excludes `<(` (process substitution, refused
- * earlier). Deliberately scans anywhere (no whitespace anchor) so `cat</dev/...`
- * without a space is still caught; the target is then filtered by
- * `NETWORK_DEV_PATH_RE`, so an ordinary `< file` never triggers.
- */
-const INPUT_REDIRECT_TARGET_RE = /(?<!<)\d*<(?![<(])\s*(\S+)/g;
-
-/**
  * One input-redirect clause inside a peeled residue: `< PATH` or `<<< WORD`
  * (a here-string). `<<<` is tried before the single-`<` alternative so a
  * here-string is never misread as a file redirect whose target happens to
@@ -752,12 +740,41 @@ export function hasShellControl(segment: string): boolean {
   // invisible here ON PURPOSE (they read, they neither run nor write, so
   // `grep x < f` stays approvable). This narrows that only for the two device
   // prefixes bash gives socket semantics; every other `< target` is untouched.
-  // `<<`/`<<<` (heredoc / here-string) do NOT open a socket and are excluded
-  // by the lookbehind/lookahead; `<(` (process substitution) already vetoed.
-  for (const match of masked.matchAll(INPUT_REDIRECT_TARGET_RE)) {
-    if (NETWORK_DEV_PATH_RE.test(match[1] ?? '')) {
-      return true;
+  //
+  // Checked against the QUOTE-REMOVED tokens (`shellWords`), NOT the masked
+  // text: `NETWORK_DEV_PATH_RE` matches a literal prefix, and masking rewrites
+  // a quoted target to `_`, so `< "/dev/tcp/h/p"` / `< /dev/"tcp"/h/p` /
+  // `< /d\ev/tcp/h/p` each defeated a masked-text scan while bash still opened
+  // the socket. `shellWords` recovers the real target the program receives --
+  // the module's own law (see its doc): match what runs, not the raw text.
+  if (hasNetworkDeviceInputRedirect(segment)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True if `segment` redirects input from a bash network device
+ * (`/dev/tcp/...` or `/dev/udp/...`) -- an outbound socket open. Scans the
+ * `shellWords` tokenization so quoting/escaping of the target cannot hide it
+ * (#1063). Two operator shapes: a standalone `<`/`N<` token whose NEXT token
+ * is the device, and a glued `cmd</dev/tcp/...` token (no space). Heredoc
+ * (`<<`)/here-string (`<<<`) tokens open no socket and are skipped; process
+ * substitution (`<(`) is already refused by `hasShellControl`'s substitution
+ * check before this runs.
+ */
+function hasNetworkDeviceInputRedirect(segment: string): boolean {
+  const tokens = shellWords(segment);
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i] ?? '';
+    // Standalone redirect operator: the device is the following token.
+    if (t === '<' || /^\d+<$/.test(t)) {
+      if (NETWORK_DEV_PATH_RE.test(tokens[i + 1] ?? '')) return true;
+      continue;
     }
+    // Glued form `cmd</dev/tcp/...` (quote-removed, so no space in the token).
+    const glued = /(?<!<)\d*<(?![<(])(\S+)$/.exec(t);
+    if (glued && NETWORK_DEV_PATH_RE.test(glued[1] ?? '')) return true;
   }
   return false;
 }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -741,13 +741,9 @@ export function hasShellControl(segment: string): boolean {
   // `grep x < f` stays approvable). This narrows that only for the two device
   // prefixes bash gives socket semantics; every other `< target` is untouched.
   //
-  // Checked against the QUOTE-REMOVED tokens (`shellWords`), NOT the masked
-  // text: `NETWORK_DEV_PATH_RE` matches a literal prefix, and masking rewrites
-  // a quoted target to `_`, so `< "/dev/tcp/h/p"` / `< /dev/"tcp"/h/p` /
-  // `< /d\ev/tcp/h/p` each defeated a masked-text scan while bash still opened
-  // the socket. `shellWords` recovers the real target the program receives --
-  // the module's own law (see its doc): match what runs, not the raw text.
-  if (hasNetworkDeviceInputRedirect(segment)) {
+  // Operator position from `masked`, target content dequoted from raw -- see
+  // the helper's doc for why neither view alone is sound.
+  if (hasNetworkDeviceInputRedirect(segment, masked)) {
     return true;
   }
   // An input redirect whose target uses ANSI-C `$'...'` quoting cannot be
@@ -770,52 +766,47 @@ export function hasShellControl(segment: string): boolean {
 }
 
 /**
- * Every single-`<` input-redirect target glued inside one whitespace-free
- * token. A `<` that is NOT part of `<<`/`<<<` (heredoc / here-string, which
- * open no socket) nor `<(` (process substitution, refused upstream), with the
- * target being the run of non-`<`, non-space chars after it. Global so a token
- * carrying MORE THAN ONE redirect (`/dev/null</dev/null</dev/tcp/h/p`) yields
- * EACH target, not just the first -- a greedy first-capture missed the second
- * `<` and approved the socket behind a benign first target (#1063 re-review).
- * A `<` immediately followed by a space captures the empty string, so a
- * quoted literal whose `<` is spaced from the device (`'< /dev/tcp/x is bad'`)
- * does not read as a redirect here.
- */
-const GLUED_INPUT_REDIRECT_RE = /(?<!<)<(?!<)([^<\s]*)/g;
-
-/**
  * True if `segment` redirects input from a bash network device
- * (`/dev/tcp/...` or `/dev/udp/...`) -- an outbound socket open. Scans the
- * `shellWords` tokenization so quoting/escaping of the target cannot hide it
- * (#1063): a standalone `<`/`N<` operator token whose NEXT token is the
- * device, or one or more `<`-glued targets inside a single token.
+ * (`/dev/tcp/...` or `/dev/udp/...`) -- an outbound socket open (#1063).
  *
- * Accepted over-refusal (ADR 0010, err broad in the deny direction): once
- * `shellWords` has removed the quotes, a space-less quoted literal that
- * happens to contain `x</dev/tcp/y` is indistinguishable from a real glued
- * redirect, so it vetoes. That is a niche nuisance escalation; the reverse
- * (a masked-text scan that let `< "/dev/tcp/..."` through) was a live egress.
+ * Operator POSITION is decided from the MASKED view, target CONTENT from the
+ * raw text. This split is the whole design, learned over five re-reviews:
+ *
+ * - Masked (`maskQuotedSpans`, length-preserving so indices align with raw) is
+ *   the only view that locates operators correctly. A `<` that is quoted or
+ *   backslash-escaped (`'x<'`, `\<`) is a LITERAL argument, not an operator,
+ *   and masking rewrites it to `_` -- so it can neither be mistaken for an
+ *   operator nor GLUE onto the real one. A `shellWords`-token scan failed here:
+ *   quote-removal concatenated `'x<'<` into the token `x<<`, which the
+ *   heredoc-exclusion then skipped, opening the socket unseen.
+ * - Raw (dequoted) is the only view with the real target. Masking rewrites a
+ *   quoted target (`< "/dev/tcp/h/p"`) to `_`, which no anchored device regex
+ *   can match, while bash still opens it.
+ *
+ * A `<` that is part of `<<`/`<<<` (heredoc/here-string, no socket), `<(`
+ * (process substitution, refused earlier), `<&` (fd dup, not a path), or `<>`
+ * (read-write, carries a `>` the output-redirect check already vetoes) is not
+ * an input-file operator. The target is the word after it, up to the next
+ * whitespace or `<` (a second glued redirect is its own operator, found in its
+ * own pass); its raw slice is dequoted of `'`/`"`/`\` before the device test.
+ * ANSI-C `$'...'` targets are handled separately in `hasShellControl` (this
+ * simple dequote cannot decode `\xNN`), by a fail-closed rule.
  */
-function hasNetworkDeviceInputRedirect(segment: string): boolean {
-  const tokens = shellWords(segment);
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i] ?? '';
-    // A token ENDING in a single `<` is a stdin-redirect operator whose target
-    // is the NEXT token -- bare `<`, an fd `N<`, and (bash treats `<` glued to
-    // the tail of any word as a fresh operator) `foo<`, `file<`, `{fd}<`. The
-    // lookbehind excludes `<<`/`<<<` (heredoc / here-string), whose next token
-    // is a delimiter/word bash never opens as a path. Recognizing only bare
-    // `<`/`N<` here let `cat foo< /dev/tcp/h/p` open a socket unseen (#1063
-    // third re-review).
-    if (/(?<!<)<$/.test(t) && NETWORK_DEV_PATH_RE.test(tokens[i + 1] ?? '')) {
-      return true;
-    }
-    // Also one or more `<`-glued targets WITHIN this (quote-removed) token. Not
-    // an `else`: a token can carry both (`foo<bar</dev/tcp/h/p` -- a glued
-    // target AND a trailing operator), so both are checked.
-    for (const m of t.matchAll(GLUED_INPUT_REDIRECT_RE)) {
-      if (NETWORK_DEV_PATH_RE.test(m[1] ?? '')) return true;
-    }
+function hasNetworkDeviceInputRedirect(segment: string, masked: string): boolean {
+  for (let i = 0; i < masked.length; i++) {
+    if (masked[i] !== '<') continue;
+    const prev = masked[i - 1];
+    const next = masked[i + 1];
+    if (prev === '<' || next === '<' || next === '(' || next === '&' || next === '>') continue;
+    // Skip whitespace after the operator, then take the target word up to the
+    // next whitespace or `<`.
+    let j = i + 1;
+    while (j < masked.length && (masked[j] === ' ' || masked[j] === '\t')) j++;
+    let k = j;
+    while (k < masked.length && masked[k] !== ' ' && masked[k] !== '\t' && masked[k] !== '<') k++;
+    if (k === j) continue;
+    const dequoted = segment.slice(j, k).replace(/['"\\]/g, '');
+    if (NETWORK_DEV_PATH_RE.test(dequoted)) return true;
   }
   return false;
 }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -754,14 +754,31 @@ export function hasShellControl(segment: string): boolean {
 }
 
 /**
+ * Every single-`<` input-redirect target glued inside one whitespace-free
+ * token. A `<` that is NOT part of `<<`/`<<<` (heredoc / here-string, which
+ * open no socket) nor `<(` (process substitution, refused upstream), with the
+ * target being the run of non-`<`, non-space chars after it. Global so a token
+ * carrying MORE THAN ONE redirect (`/dev/null</dev/null</dev/tcp/h/p`) yields
+ * EACH target, not just the first -- a greedy first-capture missed the second
+ * `<` and approved the socket behind a benign first target (#1063 re-review).
+ * A `<` immediately followed by a space captures the empty string, so a
+ * quoted literal whose `<` is spaced from the device (`'< /dev/tcp/x is bad'`)
+ * does not read as a redirect here.
+ */
+const GLUED_INPUT_REDIRECT_RE = /(?<!<)<(?!<)([^<\s]*)/g;
+
+/**
  * True if `segment` redirects input from a bash network device
  * (`/dev/tcp/...` or `/dev/udp/...`) -- an outbound socket open. Scans the
  * `shellWords` tokenization so quoting/escaping of the target cannot hide it
- * (#1063). Two operator shapes: a standalone `<`/`N<` token whose NEXT token
- * is the device, and a glued `cmd</dev/tcp/...` token (no space). Heredoc
- * (`<<`)/here-string (`<<<`) tokens open no socket and are skipped; process
- * substitution (`<(`) is already refused by `hasShellControl`'s substitution
- * check before this runs.
+ * (#1063): a standalone `<`/`N<` operator token whose NEXT token is the
+ * device, or one or more `<`-glued targets inside a single token.
+ *
+ * Accepted over-refusal (ADR 0010, err broad in the deny direction): once
+ * `shellWords` has removed the quotes, a space-less quoted literal that
+ * happens to contain `x</dev/tcp/y` is indistinguishable from a real glued
+ * redirect, so it vetoes. That is a niche nuisance escalation; the reverse
+ * (a masked-text scan that let `< "/dev/tcp/..."` through) was a live egress.
  */
 function hasNetworkDeviceInputRedirect(segment: string): boolean {
   const tokens = shellWords(segment);
@@ -772,9 +789,10 @@ function hasNetworkDeviceInputRedirect(segment: string): boolean {
       if (NETWORK_DEV_PATH_RE.test(tokens[i + 1] ?? '')) return true;
       continue;
     }
-    // Glued form `cmd</dev/tcp/...` (quote-removed, so no space in the token).
-    const glued = /(?<!<)\d*<(?![<(])(\S+)$/.exec(t);
-    if (glued && NETWORK_DEV_PATH_RE.test(glued[1] ?? '')) return true;
+    // One or more `<`-glued targets inside this (quote-removed) token.
+    for (const m of t.matchAll(GLUED_INPUT_REDIRECT_RE)) {
+      if (NETWORK_DEV_PATH_RE.test(m[1] ?? '')) return true;
+    }
   }
   return false;
 }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -746,20 +746,20 @@ export function hasShellControl(segment: string): boolean {
   if (hasNetworkDeviceInputRedirect(segment, masked)) {
     return true;
   }
-  // An input redirect whose target uses ANSI-C `$'...'` quoting cannot be
-  // vetted by the device check above: `shellWords` UNDER-decodes `$'...'`
-  // (`\x2f` -> `x2f`, `\x74` -> `x74`), so `< $'\x2fdev\x2ftcp\x2fhost\x2fport'`
-  // reads as a benign token while bash decodes it to a real socket path (#1063
-  // fourth re-review). shellWords' under-decode is safe for the flag/positional
-  // vetoes it was built for (a hidden flag can only get longer, never shrink
-  // into a safe-looking one) but NOT for a `^`-anchored prefix membership test,
-  // where under-decoding corrupts the `/dev/tcp/` prefix. Rather than reimplement
-  // bash's ANSI-C decoder, fail closed: an input-redirect operator (detected on
-  // the MASKED text so a quoted `<` does not count) together with any `$'` span
-  // in the raw segment is refused. Over-refuses the rare `grep $'\t' < f` shape
-  // (ANSI-C arg + unrelated file redirect) toward escalate, never toward a
-  // silent socket -- the safe direction (ADR 0010).
-  if (/(?<!<)<(?![<(])/.test(masked) && segment.includes("$'")) {
+  // An input-redirect target built with a DOLLAR-QUOTE -- ANSI-C `$'...'` or
+  // locale `$"..."` -- cannot be vetted by the device check above, whose
+  // dequote (`replace(/['"\\]/g,'')`) leaves a stray `$` (`$'\x2fdev...'` ->
+  // `$/dev...`, `$"/dev/tcp/h/p"` -> `$/dev/tcp/h/p`), so the anchored device
+  // regex misses while bash decodes to a real socket path (#1063 fourth/fifth
+  // re-reviews). Rather than reimplement bash's `$'...'` decoder, fail closed:
+  // an input-redirect operator (detected on the MASKED text so a QUOTED `<`
+  // does not count) together with any `$'`/`$"` dollar-quote in the raw segment
+  // is refused. Over-refuses the rare `grep $'\t' < f` shape (a dollar-quoted
+  // arg + an unrelated file redirect) toward escalate, never toward a silent
+  // socket -- the safe direction (ADR 0010). A bare `$VAR` target stays the
+  // documented residual (it needs an ambient env value the command text cannot
+  // set without a separate, escalating assignment segment).
+  if (/(?<!<)<(?![<(])/.test(masked) && /\$['"]/.test(segment)) {
     return true;
   }
   return false;

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -741,25 +741,10 @@ export function hasShellControl(segment: string): boolean {
   // `grep x < f` stays approvable). This narrows that only for the two device
   // prefixes bash gives socket semantics; every other `< target` is untouched.
   //
-  // Operator position from `masked`, target content dequoted from raw -- see
-  // the helper's doc for why neither view alone is sound.
+  // Operator position from `masked`, target content from raw -- see the
+  // helper's doc for why neither view alone is sound, and why a `$` in the
+  // target fails closed.
   if (hasNetworkDeviceInputRedirect(segment, masked)) {
-    return true;
-  }
-  // An input-redirect target built with a DOLLAR-QUOTE -- ANSI-C `$'...'` or
-  // locale `$"..."` -- cannot be vetted by the device check above, whose
-  // dequote (`replace(/['"\\]/g,'')`) leaves a stray `$` (`$'\x2fdev...'` ->
-  // `$/dev...`, `$"/dev/tcp/h/p"` -> `$/dev/tcp/h/p`), so the anchored device
-  // regex misses while bash decodes to a real socket path (#1063 fourth/fifth
-  // re-reviews). Rather than reimplement bash's `$'...'` decoder, fail closed:
-  // an input-redirect operator (detected on the MASKED text so a QUOTED `<`
-  // does not count) together with any `$'`/`$"` dollar-quote in the raw segment
-  // is refused. Over-refuses the rare `grep $'\t' < f` shape (a dollar-quoted
-  // arg + an unrelated file redirect) toward escalate, never toward a silent
-  // socket -- the safe direction (ADR 0010). A bare `$VAR` target stays the
-  // documented residual (it needs an ambient env value the command text cannot
-  // set without a separate, escalating assignment segment).
-  if (/(?<!<)<(?![<(])/.test(masked) && /\$['"]/.test(segment)) {
     return true;
   }
   return false;
@@ -788,9 +773,21 @@ export function hasShellControl(segment: string): boolean {
  * (read-write, carries a `>` the output-redirect check already vetoes) is not
  * an input-file operator. The target is the word after it, up to the next
  * whitespace or `<` (a second glued redirect is its own operator, found in its
- * own pass); its raw slice is dequoted of `'`/`"`/`\` before the device test.
- * ANSI-C `$'...'` targets are handled separately in `hasShellControl` (this
- * simple dequote cannot decode `\xNN`), by a fail-closed rule.
+ * own pass).
+ *
+ * A target containing `$` FAILS CLOSED. bash processes a redirect target through
+ * quote removal AND expansion (parameter `$x`/`${x}`, ANSI-C `$'\xNN'`, locale
+ * `$"..."`, arithmetic `$((...))`), any of which can materialize `/dev/tcp/...`
+ * from a literal that does not contain it -- `$x/dev/tcp/h/p`, `/dev/t${x}cp/h/p`
+ * (empty `x`), `$'\x2fdev\x2ftcp...'` all open the socket. Five re-reviews chased
+ * these one transformation at a time; the general truth is that a `$`-bearing
+ * target is not statically resolvable, so it is refused (ADR 0010, err broad in
+ * the deny direction). This over-refuses an ordinary variable target like
+ * `< $LOG` / `< $HOME/notes.txt` toward escalate -- accepted; a `<`-redirect
+ * from a variable path is uncommon, and the reverse was a live egress. A target
+ * with NO `$` is a static literal: dequote `'`/`"`/`\` and match the device
+ * prefix (command substitution `$(...)`/backtick and process substitution `<(`
+ * are already refused by `hasShellControl` before this runs).
  */
 function hasNetworkDeviceInputRedirect(segment: string, masked: string): boolean {
   for (let i = 0; i < masked.length; i++) {
@@ -805,7 +802,10 @@ function hasNetworkDeviceInputRedirect(segment: string, masked: string): boolean
     let k = j;
     while (k < masked.length && masked[k] !== ' ' && masked[k] !== '\t' && masked[k] !== '<') k++;
     if (k === j) continue;
-    const dequoted = segment.slice(j, k).replace(/['"\\]/g, '');
+    const rawTarget = segment.slice(j, k);
+    // Any expansion in the target is unresolvable -> refuse (see doc).
+    if (rawTarget.includes('$')) return true;
+    const dequoted = rawTarget.replace(/['"\\]/g, '');
     if (NETWORK_DEV_PATH_RE.test(dequoted)) return true;
   }
   return false;

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -775,19 +775,24 @@ export function hasShellControl(segment: string): boolean {
  * whitespace or `<` (a second glued redirect is its own operator, found in its
  * own pass).
  *
- * A target containing `$` FAILS CLOSED. bash processes a redirect target through
- * quote removal AND expansion (parameter `$x`/`${x}`, ANSI-C `$'\xNN'`, locale
- * `$"..."`, arithmetic `$((...))`), any of which can materialize `/dev/tcp/...`
- * from a literal that does not contain it -- `$x/dev/tcp/h/p`, `/dev/t${x}cp/h/p`
- * (empty `x`), `$'\x2fdev\x2ftcp...'` all open the socket. Five re-reviews chased
- * these one transformation at a time; the general truth is that a `$`-bearing
- * target is not statically resolvable, so it is refused (ADR 0010, err broad in
- * the deny direction). This over-refuses an ordinary variable target like
- * `< $LOG` / `< $HOME/notes.txt` toward escalate -- accepted; a `<`-redirect
- * from a variable path is uncommon, and the reverse was a live egress. A target
- * with NO `$` is a static literal: dequote `'`/`"`/`\` and match the device
- * prefix (command substitution `$(...)`/backtick and process substitution `<(`
- * are already refused by `hasShellControl` before this runs).
+ * A target that is not a STATIC LITERAL fails closed. bash processes a redirect
+ * target through brace expansion, tilde, parameter/arithmetic/command expansion,
+ * quote removal, then globbing -- and several of those can materialize
+ * `/dev/tcp/...` from a literal that does not contain the substring: `$x/dev/tcp`
+ * and `/dev/t${x}cp` (empty `x`), `$'\x2fdev\x2ftcp...'`, and the brace RANGE
+ * `/dev/tc{p..p}/...` (collapses to `/dev/tcp/...`, no `$` needed). Six
+ * re-reviews chased these one transformation at a time; the durable rule is to
+ * refuse anything not statically resolvable rather than enumerate what is
+ * dangerous. The two expansion families that can SYNTHESIZE the device path are
+ * `$` (all `$`-expansions) and `{` (brace) -- both refuse (ADR 0010, err broad).
+ * Glob (`*?[]`) and tilde cannot: `/dev/tcp` is a virtual path with no directory
+ * entry, so a glob never matches it, and `~` expands to a home dir, so those
+ * stay approvable. This over-refuses an ordinary variable/brace target like
+ * `< $LOG` / `< a{1,2}.txt` toward escalate -- accepted; the reverse was a live
+ * egress. A target with no `$`/`{` is dequoted of `'`/`"`/`\` (non-expanding,
+ * purely literal) and matched against the device prefix. Command substitution
+ * `$(...)`/backtick and process substitution `<(` are refused by `hasShellControl`
+ * before this runs.
  */
 function hasNetworkDeviceInputRedirect(segment: string, masked: string): boolean {
   for (let i = 0; i < masked.length; i++) {
@@ -803,8 +808,8 @@ function hasNetworkDeviceInputRedirect(segment: string, masked: string): boolean
     while (k < masked.length && masked[k] !== ' ' && masked[k] !== '\t' && masked[k] !== '<') k++;
     if (k === j) continue;
     const rawTarget = segment.slice(j, k);
-    // Any expansion in the target is unresolvable -> refuse (see doc).
-    if (rawTarget.includes('$')) return true;
+    // Any device-synthesizing expansion in the target is unresolvable -> refuse.
+    if (rawTarget.includes('$') || rawTarget.includes('{')) return true;
     const dequoted = rawTarget.replace(/['"\\]/g, '');
     if (NETWORK_DEV_PATH_RE.test(dequoted)) return true;
   }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -213,6 +213,18 @@ const INPUT_REDIRECT_PATH_RE = /^[A-Za-z0-9_./~-]+$/;
 const NETWORK_DEV_PATH_RE = /^\/dev\/(tcp|udp)\//;
 
 /**
+ * A single input-redirect operator and its target, for `hasShellControl`'s
+ * network-device egress check (#1063). Matches an optional leading fd number
+ * and one `<`, capturing the following target word. The lookbehind excludes
+ * the trailing `<` of `<<`/`<<<` (heredoc / here-string — neither opens a
+ * socket), and the lookahead excludes `<(` (process substitution, refused
+ * earlier). Deliberately scans anywhere (no whitespace anchor) so `cat</dev/...`
+ * without a space is still caught; the target is then filtered by
+ * `NETWORK_DEV_PATH_RE`, so an ordinary `< file` never triggers.
+ */
+const INPUT_REDIRECT_TARGET_RE = /(?<!<)\d*<(?![<(])\s*(\S+)/g;
+
+/**
  * One input-redirect clause inside a peeled residue: `< PATH` or `<<< WORD`
  * (a here-string). `<<<` is tried before the single-`<` alternative so a
  * here-string is never misread as a file redirect whose target happens to
@@ -730,6 +742,20 @@ export function hasShellControl(segment: string): boolean {
   // recognizes exactly the two safe shapes and refuses everything else.
   for (const clause of findRedirectClauses(masked)) {
     if (clause.target.kind !== 'discard' && clause.target.kind !== 'fd-dup') {
+      return true;
+    }
+  }
+  // Input redirection FROM a bash network device (`< /dev/tcp/host/port`,
+  // `N< /dev/udp/...`) opens an OUTBOUND socket -- an egress primitive a
+  // read-only prefix must never carry (#1063). `findRedirectClauses` models
+  // output redirects only, so ordinary `< file` input redirects are otherwise
+  // invisible here ON PURPOSE (they read, they neither run nor write, so
+  // `grep x < f` stays approvable). This narrows that only for the two device
+  // prefixes bash gives socket semantics; every other `< target` is untouched.
+  // `<<`/`<<<` (heredoc / here-string) do NOT open a socket and are excluded
+  // by the lookbehind/lookahead; `<(` (process substitution) already vetoed.
+  for (const match of masked.matchAll(INPUT_REDIRECT_TARGET_RE)) {
+    if (NETWORK_DEV_PATH_RE.test(match[1] ?? '')) {
       return true;
     }
   }

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -714,6 +714,19 @@ export function maskQuotedSpans(segment: string): string {
  * visible after masking as before, and still vetoes.
  */
 export function hasShellControl(segment: string): boolean {
+  // Backslash-newline line continuation is deleted by bash's INPUT READER,
+  // before tokenization and before every check below runs on `maskQuotedSpans`,
+  // which instead masks the pair to `__` and leaves a two-character desync.
+  // That desync let `cat < /dev/t\<nl>cp/...` synthesize `/dev/tcp` past the
+  // device veto AND `cat $\<nl>(whoami)` split the `$(` substitution veto into
+  // RCE (#1063 seventh re-review; the `$(` half is a latent #1023 gap). This
+  // veto operates one layer above the input reader, so rather than reproduce
+  // bash's continuation-removal (which must honor single-quote/here-doc
+  // literalness -- see the follow-up issue), fail closed on the raw pair: a
+  // line-continued command is refused (escalated), never silently miscovered.
+  if (/\\\r?\n/.test(segment)) {
+    return true;
+  }
   const masked = maskQuotedSpans(segment);
   // Command / process substitution.
   if (masked.includes('$(') || masked.includes('`') || masked.includes('<(')) {

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -750,6 +750,22 @@ export function hasShellControl(segment: string): boolean {
   if (hasNetworkDeviceInputRedirect(segment)) {
     return true;
   }
+  // An input redirect whose target uses ANSI-C `$'...'` quoting cannot be
+  // vetted by the device check above: `shellWords` UNDER-decodes `$'...'`
+  // (`\x2f` -> `x2f`, `\x74` -> `x74`), so `< $'\x2fdev\x2ftcp\x2fhost\x2fport'`
+  // reads as a benign token while bash decodes it to a real socket path (#1063
+  // fourth re-review). shellWords' under-decode is safe for the flag/positional
+  // vetoes it was built for (a hidden flag can only get longer, never shrink
+  // into a safe-looking one) but NOT for a `^`-anchored prefix membership test,
+  // where under-decoding corrupts the `/dev/tcp/` prefix. Rather than reimplement
+  // bash's ANSI-C decoder, fail closed: an input-redirect operator (detected on
+  // the MASKED text so a quoted `<` does not count) together with any `$'` span
+  // in the raw segment is refused. Over-refuses the rare `grep $'\t' < f` shape
+  // (ANSI-C arg + unrelated file redirect) toward escalate, never toward a
+  // silent socket -- the safe direction (ADR 0010).
+  if (/(?<!<)<(?![<(])/.test(masked) && segment.includes("$'")) {
+    return true;
+  }
   return false;
 }
 

--- a/packages/daemon/src/auto-approve/shell-safety.ts
+++ b/packages/daemon/src/auto-approve/shell-safety.ts
@@ -784,12 +784,19 @@ function hasNetworkDeviceInputRedirect(segment: string): boolean {
   const tokens = shellWords(segment);
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i] ?? '';
-    // Standalone redirect operator: the device is the following token.
-    if (t === '<' || /^\d+<$/.test(t)) {
-      if (NETWORK_DEV_PATH_RE.test(tokens[i + 1] ?? '')) return true;
-      continue;
+    // A token ENDING in a single `<` is a stdin-redirect operator whose target
+    // is the NEXT token -- bare `<`, an fd `N<`, and (bash treats `<` glued to
+    // the tail of any word as a fresh operator) `foo<`, `file<`, `{fd}<`. The
+    // lookbehind excludes `<<`/`<<<` (heredoc / here-string), whose next token
+    // is a delimiter/word bash never opens as a path. Recognizing only bare
+    // `<`/`N<` here let `cat foo< /dev/tcp/h/p` open a socket unseen (#1063
+    // third re-review).
+    if (/(?<!<)<$/.test(t) && NETWORK_DEV_PATH_RE.test(tokens[i + 1] ?? '')) {
+      return true;
     }
-    // One or more `<`-glued targets inside this (quote-removed) token.
+    // Also one or more `<`-glued targets WITHIN this (quote-removed) token. Not
+    // an `else`: a token can carry both (`foo<bar</dev/tcp/h/p` -- a glued
+    // target AND a trailing operator), so both are checked.
     for (const m of t.matchAll(GLUED_INPUT_REDIRECT_RE)) {
       if (NETWORK_DEV_PATH_RE.test(m[1] ?? '')) return true;
     }

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -239,14 +239,19 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl("cat < $'/dev/tcp/h/p'")).toBe(true);
     expect(hasShellControl("cat < /dev/tc$'\\x70'/h/p")).toBe(true);
     expect(hasShellControl("cat foo<$'/dev/tcp/h/p'")).toBe(true);
+    // Locale `$"..."` is the same class: the dequote leaves a stray `$`, so the
+    // fail-closed rule covers both dollar-quote forms (#1063 fifth re-review).
+    expect(hasShellControl('cat < $"/dev/tcp/h/p"')).toBe(true);
+    expect(hasShellControl('cat foo< $"/dev/tcp/h/p"')).toBe(true);
   });
 
-  test("MUST NOT VETO: ANSI-C $'...' with NO input redirect present", () => {
+  test('MUST NOT VETO: a dollar-quote with NO input redirect present', () => {
     // The fail-closed rule needs a real (unmasked) input-redirect operator, so
-    // an ordinary ANSI-C arg is untouched -- these are common idioms.
+    // an ordinary dollar-quoted arg is untouched -- these are common idioms.
     expect(hasShellControl("echo $'\\n'")).toBe(false);
     expect(hasShellControl("grep $'\\t' f")).toBe(false);
     expect(hasShellControl("printf $'%s\\n' a")).toBe(false);
+    expect(hasShellControl('echo $"hi"')).toBe(false);
   });
 
   test('MUST NOT VETO: a quoted device literal is NOT a redirect (masked-scan)', () => {

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -171,6 +171,15 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat<"/dev/tcp/h/1"')).toBe(true);
   });
 
+  test('MUST VETO: a SECOND glued redirect to the device behind a benign first', () => {
+    // `cat /dev/null</dev/null</dev/tcp/H/P` opens the socket in bash (both
+    // redirects apply left-to-right); a greedy first-`<` capture read only
+    // `/dev/null` and approved it (#1063 second re-review). Every `<`-glued
+    // field must be checked.
+    expect(hasShellControl('cat /dev/null</dev/null</dev/tcp/127.0.0.1/1')).toBe(true);
+    expect(hasShellControl('cat a<b</dev/udp/h/53')).toBe(true);
+  });
+
   test('MUST NOT VETO: an ordinary file input redirect (reads, never sockets)', () => {
     expect(hasShellControl('grep x < list.txt')).toBe(false);
     expect(hasShellControl('cat < ./config.ini')).toBe(false);
@@ -195,10 +204,20 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat < x/dev/tcp/h/1')).toBe(false);
   });
 
-  test('MUST NOT VETO: a quoted literal that merely CONTAINS the device text', () => {
-    // `'< /dev/tcp/x is bad'` is one data argument to grep, not a redirect --
-    // shellWords keeps it a single token, so the operator scan never sees a
-    // `<` operator. Pins that the quote-aware fix did not over-refuse.
+  test('a quoted literal with the device SPACED after < is not a redirect', () => {
+    // `'< /dev/tcp/x is bad'` is one grep argument: the `<` is spaced from the
+    // path, so the target capture is empty and nothing vetoes. This is the
+    // boundary a real spaced redirect (`cat < /dev/tcp/h/p`) does NOT share --
+    // there shellWords splits `<` into its own operator token.
     expect(hasShellControl("grep '< /dev/tcp/x is bad' f")).toBe(false);
+  });
+
+  test('ACCEPTED over-refusal: a space-less quoted device literal vetoes', () => {
+    // After shellWords removes the quotes, `x</dev/tcp/y` is byte-identical to
+    // an unquoted glued redirect, so it vetoes even though this grep opens no
+    // socket. Documented, not a bug: quote-safe socket detection cannot tell
+    // the two apart, and erring toward escalate (ADR 0010) beats the reverse,
+    // which was a live egress. Niche; nobody greps for that literal.
+    expect(hasShellControl("grep 'x</dev/tcp/y' f")).toBe(true);
   });
 });

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -217,6 +217,25 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat < x/dev/tcp/h/1')).toBe(false);
   });
 
+  test("MUST VETO: an ANSI-C $'...' input-redirect target (shellWords under-decodes it)", () => {
+    // `shellWords` copies the literal char after a `$'...'` escape's backslash
+    // (`\x2f` -> `x2f`), so the device prefix is corrupted and the anchored
+    // device check misses -- but bash fully decodes and opens the socket
+    // (#1063 fourth re-review). Fail closed on ANSI-C in a redirect context.
+    expect(hasShellControl("cat <$'\\x2fdev\\x2ftcp\\x2f127.0.0.1\\x2f1'")).toBe(true);
+    expect(hasShellControl("cat < $'/dev/tcp/h/p'")).toBe(true);
+    expect(hasShellControl("cat < /dev/tc$'\\x70'/h/p")).toBe(true);
+    expect(hasShellControl("cat foo<$'/dev/tcp/h/p'")).toBe(true);
+  });
+
+  test("MUST NOT VETO: ANSI-C $'...' with NO input redirect present", () => {
+    // The fail-closed rule needs a real (unmasked) input-redirect operator, so
+    // an ordinary ANSI-C arg is untouched -- these are common idioms.
+    expect(hasShellControl("echo $'\\n'")).toBe(false);
+    expect(hasShellControl("grep $'\\t' f")).toBe(false);
+    expect(hasShellControl("printf $'%s\\n' a")).toBe(false);
+  });
+
   test('a quoted literal with the device SPACED after < is not a redirect', () => {
     // `'< /dev/tcp/x is bad'` is one grep argument: the `<` is spaced from the
     // path, so the target capture is empty and nothing vetoes. This is the

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -134,6 +134,18 @@ describe('hasShellControl - #1023 quote-aware veto', () => {
     expect(hasShellControl("echo 'a > b")).toBe(true);
   });
 
+  test('MUST VETO: backslash-newline line continuation (bash deletes it pre-token)', () => {
+    // bash's input reader removes `\<newline>` before tokenization, so it can
+    // synthesize `/dev/tcp` (`/dev/t\<nl>cp`) or split the `$(` substitution
+    // veto (`$\<nl>(whoami)` = RCE). maskQuotedSpans masks the pair to `__`, a
+    // two-char desync. Fail closed on the raw pair until #1065 normalizes it.
+    expect(hasShellControl('cat < /dev/t\\\ncp/127.0.0.1/1')).toBe(true);
+    expect(hasShellControl('cat $\\\n(whoami)')).toBe(true);
+    expect(hasShellControl('cat <\\\n/dev/tcp/h/p')).toBe(true);
+    // A plain (non-continued) command is unaffected.
+    expect(hasShellControl('cat < /dev/null')).toBe(false);
+  });
+
   test('MUST STILL VETO: real shell control survives alongside masked prose', () => {
     // The `--body` prose is inert, but the trailing `$(...)` outside any
     // quote is a real command substitution and must still veto the whole

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -159,6 +159,18 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat</dev/tcp/h/1')).toBe(true);
   });
 
+  test('MUST VETO: quoting or escaping the target does not hide the socket', () => {
+    // The check runs on the quote-removed `shellWords` target, not the masked
+    // text -- a single quote or backslash defeated a masked-text scan while
+    // bash still opened the socket (#1063 re-review). All of these socket in
+    // bash.
+    expect(hasShellControl('cat < "/dev/tcp/evil/443"')).toBe(true);
+    expect(hasShellControl("cat < '/dev/tcp/evil/443'")).toBe(true);
+    expect(hasShellControl('cat < /dev/"tcp"/evil/443')).toBe(true);
+    expect(hasShellControl('cat < /d\\ev/tcp/evil/443')).toBe(true);
+    expect(hasShellControl('cat<"/dev/tcp/h/1"')).toBe(true);
+  });
+
   test('MUST NOT VETO: an ordinary file input redirect (reads, never sockets)', () => {
     expect(hasShellControl('grep x < list.txt')).toBe(false);
     expect(hasShellControl('cat < ./config.ini')).toBe(false);
@@ -181,5 +193,12 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat < /DEV/TCP/h/1')).toBe(false);
     expect(hasShellControl('cat < /dev/tcpx/h/1')).toBe(false);
     expect(hasShellControl('cat < x/dev/tcp/h/1')).toBe(false);
+  });
+
+  test('MUST NOT VETO: a quoted literal that merely CONTAINS the device text', () => {
+    // `'< /dev/tcp/x is bad'` is one data argument to grep, not a redirect --
+    // shellWords keeps it a single token, so the operator scan never sees a
+    // `<` operator. Pins that the quote-aware fix did not over-refuse.
+    expect(hasShellControl("grep '< /dev/tcp/x is bad' f")).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -193,6 +193,19 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat foo< data.txt')).toBe(false);
   });
 
+  test('MUST VETO: a quoted/escaped literal `<` glued before the real operator', () => {
+    // `cat 'x<'< /dev/tcp/h/p`: the quoted `x<` is a literal ARGUMENT, the
+    // trailing `<` is the live operator. shellWords concatenated them into the
+    // token `x<<`, read as a heredoc and skipped, opening the socket (#1063
+    // fifth re-review). Operator position now comes from the masked view,
+    // where the quoted `<` is `_` and cannot glue onto the operator.
+    expect(hasShellControl("cat 'x<'< /dev/tcp/127.0.0.1/1")).toBe(true);
+    expect(hasShellControl("cat '<'< /dev/tcp/h/p")).toBe(true);
+    expect(hasShellControl('cat \\<< /dev/tcp/h/p')).toBe(true);
+    // A quoted `<` INSIDE the target word must not fragment it (still a file).
+    expect(hasShellControl('cat < "a<b"')).toBe(false);
+  });
+
   test('MUST NOT VETO: an ordinary file input redirect (reads, never sockets)', () => {
     expect(hasShellControl('grep x < list.txt')).toBe(false);
     expect(hasShellControl('cat < ./config.ini')).toBe(false);
@@ -236,20 +249,15 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl("printf $'%s\\n' a")).toBe(false);
   });
 
-  test('a quoted literal with the device SPACED after < is not a redirect', () => {
-    // `'< /dev/tcp/x is bad'` is one grep argument: the `<` is spaced from the
-    // path, so the target capture is empty and nothing vetoes. This is the
-    // boundary a real spaced redirect (`cat < /dev/tcp/h/p`) does NOT share --
-    // there shellWords splits `<` into its own operator token.
+  test('MUST NOT VETO: a quoted device literal is NOT a redirect (masked-scan)', () => {
+    // Both the spaced (`'< /dev/tcp/x is bad'`) and the space-less
+    // (`'x</dev/tcp/y'`) forms are ONE grep argument: the `<` is quoted, so the
+    // masked view shows `_` where a literal `<` sits and never reads it as an
+    // operator. Deciding operator position from the masked view (not the
+    // quote-removed shellWords tokens) removed the over-refusal an earlier
+    // token-based cut had here, AND closed the `'x<'< /dev/tcp` operator-glue
+    // bypass -- the same architectural fix does both (#1063 fifth re-review).
     expect(hasShellControl("grep '< /dev/tcp/x is bad' f")).toBe(false);
-  });
-
-  test('ACCEPTED over-refusal: a space-less quoted device literal vetoes', () => {
-    // After shellWords removes the quotes, `x</dev/tcp/y` is byte-identical to
-    // an unquoted glued redirect, so it vetoes even though this grep opens no
-    // socket. Documented, not a bug: quote-safe socket detection cannot tell
-    // the two apart, and erring toward escalate (ADR 0010) beats the reverse,
-    // which was a live egress. Niche; nobody greps for that literal.
-    expect(hasShellControl("grep 'x</dev/tcp/y' f")).toBe(true);
+    expect(hasShellControl("grep 'x</dev/tcp/y' f")).toBe(false);
   });
 });

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -245,6 +245,27 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat foo< $"/dev/tcp/h/p"')).toBe(true);
   });
 
+  test('MUST VETO: parameter expansion that materializes the device path', () => {
+    // bash expands a redirect target: an empty `$x` prefix (`$x/dev/tcp/...`)
+    // or infix (`/dev/t${x}cp/...`) opens the socket while the literal does not
+    // begin `/dev/tcp/`. The general rule -- a `$` in the target is
+    // unresolvable, so fail closed -- subsumes ANSI-C, locale, and this (#1063
+    // sixth re-review).
+    expect(hasShellControl('cat < $x/dev/tcp/127.0.0.1/1')).toBe(true);
+    expect(hasShellControl('cat < ${x}/dev/tcp/h/p')).toBe(true);
+    expect(hasShellControl('cat < /dev/t${x}cp/127.0.0.1/1')).toBe(true);
+    expect(hasShellControl('head < ${x}/dev/udp/h/1')).toBe(true);
+  });
+
+  test('ACCEPTED over-refusal: a variable input-redirect target escalates', () => {
+    // The fail-closed `$`-in-target rule cannot tell `< $LOG` from
+    // `< $x/dev/tcp/...`, so it refuses both. A `<`-redirect from a variable
+    // path is uncommon and escalate is the safe direction; the reverse was a
+    // live socket. NOTE: a `$` OUTSIDE the redirect target does not trigger it.
+    expect(hasShellControl('sort < $TMPFILE')).toBe(true);
+    expect(hasShellControl('cat < $HOME/notes.txt')).toBe(true);
+  });
+
   test('MUST NOT VETO: a dollar-quote with NO input redirect present', () => {
     // The fail-closed rule needs a real (unmasked) input-redirect operator, so
     // an ordinary dollar-quoted arg is untouched -- these are common idioms.

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -180,6 +180,19 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('cat a<b</dev/udp/h/53')).toBe(true);
   });
 
+  test('MUST VETO: `<` glued to a word tail with the device in the next token', () => {
+    // bash treats `<` glued to the end of ANY word as a fresh stdin-redirect
+    // operator, target = next token: `cat foo< /dev/tcp/h/p` opens the socket.
+    // Recognizing only bare `<`/`N<` as operators missed it (#1063 third
+    // re-review). Every token ending in a single `<` is an operator.
+    expect(hasShellControl('cat foo< /dev/tcp/127.0.0.1/1')).toBe(true);
+    expect(hasShellControl('grep pat file< /dev/tcp/h/1')).toBe(true);
+    expect(hasShellControl('cat 2x< /dev/tcp/h/1')).toBe(true);
+    expect(hasShellControl('cat abc< /dev/udp/h/1')).toBe(true);
+    // ...but a word-glued `<` to an ordinary file is still fine.
+    expect(hasShellControl('cat foo< data.txt')).toBe(false);
+  });
+
   test('MUST NOT VETO: an ordinary file input redirect (reads, never sockets)', () => {
     expect(hasShellControl('grep x < list.txt')).toBe(false);
     expect(hasShellControl('cat < ./config.ini')).toBe(false);

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -143,3 +143,43 @@ describe('hasShellControl - #1023 quote-aware veto', () => {
     );
   });
 });
+
+// #1063: input redirection FROM a bash network device opens an OUTBOUND socket
+// and must veto on the matched-segment path, not only on the while-loop
+// grammar residue where the C6 fix (#1062) first added the guard.
+describe('hasShellControl - #1063 network-device input redirect', () => {
+  test('MUST VETO: input redirect from /dev/tcp and /dev/udp', () => {
+    expect(hasShellControl('cat < /dev/tcp/evil/443')).toBe(true);
+    expect(hasShellControl('cat < /dev/udp/host/53')).toBe(true);
+  });
+
+  test('MUST VETO: the fd-numbered and no-space spellings', () => {
+    expect(hasShellControl('cat 0< /dev/tcp/h/1')).toBe(true);
+    expect(hasShellControl('cat 3< /dev/tcp/h/1')).toBe(true);
+    expect(hasShellControl('cat</dev/tcp/h/1')).toBe(true);
+  });
+
+  test('MUST NOT VETO: an ordinary file input redirect (reads, never sockets)', () => {
+    expect(hasShellControl('grep x < list.txt')).toBe(false);
+    expect(hasShellControl('cat < ./config.ini')).toBe(false);
+  });
+
+  test('MUST NOT VETO: benign /dev targets that are not sockets', () => {
+    expect(hasShellControl('cat < /dev/null')).toBe(false);
+    expect(hasShellControl('cat < /dev/stdin')).toBe(false);
+  });
+
+  test('a here-string of a /dev/tcp literal is not a socket open', () => {
+    // `<<<` feeds the literal string to stdin; bash does not apply network-
+    // device magic to here-strings, only to `<`/`>` redirections.
+    expect(hasShellControl('cat <<< /dev/tcp/h/p')).toBe(false);
+  });
+
+  test('the case/prefix variants bash treats as ordinary files are not vetoed here', () => {
+    // Only the exact case-sensitive `/dev/tcp/`|`/dev/udp/` prefix sockets in
+    // bash; these all fall to a file open, so refusing them would be noise.
+    expect(hasShellControl('cat < /DEV/TCP/h/1')).toBe(false);
+    expect(hasShellControl('cat < /dev/tcpx/h/1')).toBe(false);
+    expect(hasShellControl('cat < x/dev/tcp/h/1')).toBe(false);
+  });
+});

--- a/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
+++ b/packages/daemon/tests/auto-approve/shell-safety-quote-masking.test.ts
@@ -257,13 +257,33 @@ describe('hasShellControl - #1063 network-device input redirect', () => {
     expect(hasShellControl('head < ${x}/dev/udp/h/1')).toBe(true);
   });
 
-  test('ACCEPTED over-refusal: a variable input-redirect target escalates', () => {
-    // The fail-closed `$`-in-target rule cannot tell `< $LOG` from
-    // `< $x/dev/tcp/...`, so it refuses both. A `<`-redirect from a variable
-    // path is uncommon and escalate is the safe direction; the reverse was a
-    // live socket. NOTE: a `$` OUTSIDE the redirect target does not trigger it.
+  test('MUST VETO: brace expansion that materializes the device path', () => {
+    // The brace RANGE `{p..p}` collapses to `p` with NO `$`, so `/dev/tc{p..p}`
+    // opens the socket -- the transformation that defeated the $-only rule
+    // (#1063 sixth re-review). Any `{` in the target now fails closed.
+    expect(hasShellControl('cat < /dev/tc{p..p}/127.0.0.1/9')).toBe(true);
+    expect(hasShellControl('cat < /d{e..e}v/tcp/h/p')).toBe(true);
+    expect(hasShellControl('grep x < /dev/tc{p,p}/h/p')).toBe(true);
+  });
+
+  test('MUST NOT VETO: glob and tilde targets (cannot synthesize the device)', () => {
+    // `/dev/tcp` is virtual (no directory entry) so a glob never matches it,
+    // and `~` expands to a home dir -- neither can form the device path, so
+    // they stay approvable (no over-refusal beyond `$`/`{`).
+    expect(hasShellControl('cat < /dev/tc?/h/p')).toBe(false);
+    expect(hasShellControl('cat < /dev/tc[p]/h/p')).toBe(false);
+    expect(hasShellControl('cat < ~/notes.txt')).toBe(false);
+  });
+
+  test('ACCEPTED over-refusal: a variable or brace input-redirect target escalates', () => {
+    // The fail-closed rule cannot tell `< $LOG` / `< a{1,2}.txt` from a
+    // device-synthesizing expansion, so it refuses both toward escalate. A
+    // `<`-redirect from a variable or brace path is uncommon and escalate is
+    // the safe direction; the reverse was a live socket. A `$`/`{` OUTSIDE the
+    // redirect target does not trigger it.
     expect(hasShellControl('sort < $TMPFILE')).toBe(true);
     expect(hasShellControl('cat < $HOME/notes.txt')).toBe(true);
+    expect(hasShellControl('cat < a{1,2}.txt')).toBe(true);
   });
 
   test('MUST NOT VETO: a dollar-quote with NO input redirect present', () => {


### PR DESCRIPTION
## Summary

Closes the input-redirect half of the bash network-device egress class. `cat < /dev/tcp/host/port` opens an OUTBOUND socket but was approved by `read-only` at the default `strict` level, because `hasShellControl`'s redirect model (`REDIRECT_CLAUSE_RE`) covers output redirects only — input redirects (`<`, `N<`) were invisible to the gate. #1062's C6 fix added the `NETWORK_DEV_PATH_RE` guard, but only on the while-loop grammar-residue path (`isPlainInputRedirectResidue`), leaving the plain matched-segment path open.

Found by the Phase 3 re-verification adversarial review; pre-existing (predates #1062 — `cat` was curated long before, and the gate never modelled input redirects), filed as #1063.

`hasShellControl` now scans input-redirect clauses (`\d*<`, excluding `<<`/`<<<` heredocs/here-strings via lookbehind and `<(` process substitution via lookahead) and vetoes any whose target matches `/dev/tcp/` or `/dev/udp/`. Stricter-only: it cannot widen anything, and every ordinary `< file` input redirect (including `< /dev/null`, `< /dev/stdin`) is untouched — only the two literal socket prefixes bash gives network semantics trigger it.

Verified against bash 5.3: only the exact case-sensitive `/dev/tcp/` / `/dev/udp/` prefix sockets; `/DEV/TCP/`, `//dev/tcp/`, `/dev/tcpx/`, and positional (non-redirect) `grep x /dev/tcp/...` all fall to a file open and are correctly left approvable. A `<<<` here-string of a `/dev/tcp` literal is not a socket and stays approved.

## Test plan

- New `#1063` block in `shell-safety-quote-masking.test.ts`: `/dev/tcp` + `/dev/udp`, fd-numbered and no-space spellings veto; ordinary file reads, `/dev/null`, `/dev/stdin`, `<<<` here-string, and the case/prefix variants do not.
- Full `packages/daemon/tests/auto-approve/` — 2368 pass, 0 fail; the pinned #1023/#1031/#1034/#1000 masking/split suites untouched.
- biome + typecheck clean.