### PR TITLE
Correct two risk-ceiling band misclassifications (#1071, #1013)

### DIFF
--- a/packages/daemon/src/auto-approve/permission-groups.ts
+++ b/packages/daemon/src/auto-approve/permission-groups.ts
@@ -43,7 +43,9 @@
 import { looksLikeToolName } from './pattern-matcher.ts';
 import { COMMAND_WRAPPERS, SHELL_C_BINARIES } from './risk-bands.ts';
 import {
+  classifyScratchAbsolute,
   isSensitiveWritePath,
+  joinScratchSegments,
   resolveDotDot,
   segmentTouchesSensitivePath,
 } from './sensitive-paths.ts';
@@ -445,65 +447,11 @@ const SCRATCH_COMMANDS: readonly string[] = ['touch', 'cp', 'mv', 'tee', 'mkdir'
  */
 type ScratchCwd = { readonly segments: readonly string[]; readonly rootLen: number } | null;
 
-/**
- * Join `relParts` onto `base`, collapsing `.`/`..` lexically, and refusing to
- * pop below `floorLen` segments — the root boundary a scratch directory may
- * never be navigated above. Returns null on an attempted escape.
- */
-function joinScratchSegments(
-  base: readonly string[],
-  floorLen: number,
-  relParts: readonly string[],
-): string[] | null {
-  const segs = [...base];
-  for (const part of relParts) {
-    if (part === '' || part === '.') continue;
-    if (part === '..') {
-      if (segs.length <= floorLen) return null;
-      segs.pop();
-    } else {
-      segs.push(part);
-    }
-  }
-  return segs;
-}
-
-/**
- * Classify an ABSOLUTE-shaped token (`/tmp/...`, `/private/tmp/...`,
- * `$TMPDIR/...`, `${TMPDIR}/...`) into its scratch-root segments, or null if
- * it is not one of those four shapes. `..`/`.` are resolved via
- * `resolveDotDot` (sensitive-paths.ts) BEFORE the root check runs, the same
- * ordering that module documents and for the same reason: `/tmp/../etc`
- * fails every `startsWith('/tmp')` test only AFTER resolution, not before.
- */
-function classifyScratchAbsolute(token: string): { segments: string[]; rootLen: number } | null {
-  for (const marker of ['$TMPDIR', '${TMPDIR}']) {
-    if (token === marker || token.startsWith(`${marker}/`)) {
-      const rest = token.slice(marker.length).replace(/^\//, '');
-      // The $TMPDIR/-PREFIX carve-out is consumed above; the REMAINDER must
-      // contain no FURTHER `$`/`~` anywhere (#1061 -- see the anywhere-check
-      // note on `resolveRelativeTarget` below for the mid-path bypass this
-      // closes). `$TMPDIR/x` and `$TMPDIR/sub/file` stay granted; `$TMPDIR/$FOO`
-      // does not, even though it starts with the trusted marker.
-      if (rest.includes('$') || rest.includes('~')) return null;
-      const extra = rest === '' ? [] : rest.split('/');
-      const segs = joinScratchSegments(['$TMPDIR'], 1, extra);
-      return segs === null ? null : { segments: segs, rootLen: 1 };
-    }
-  }
-  if (token.startsWith('/')) {
-    // Same anywhere-check as the `$TMPDIR` arm above, applied before dot-dot
-    // resolution: a plain `/tmp/...`/`/private/tmp/...` token gets no
-    // trusted-prefix carve-out at all, so ANY `$`/`~` anywhere refuses it.
-    if (token.includes('$') || token.includes('~')) return null;
-    const resolved = resolveDotDot(token);
-    const segs = resolved.split('/').filter((s) => s !== '');
-    if (segs[0] === 'tmp') return { segments: segs, rootLen: 1 };
-    if (segs[0] === 'private' && segs[1] === 'tmp') return { segments: segs, rootLen: 2 };
-    return null;
-  }
-  return null;
-}
+// `joinScratchSegments` and `classifyScratchAbsolute` moved to
+// `sensitive-paths.ts` (#1071) so `risk-bands.ts`'s ceiling carve-out can share
+// the ONE absolute-scratch classifier — see `isAbsoluteScratchTarget` there.
+// permission-groups.ts still owns the cwd-aware composition below; the two
+// combine so `scratch`'s runtime behavior is byte-identical to before the move.
 
 /**
  * Resolve any token (absolute-scratch, `$TMPDIR`-form, or a genuinely
@@ -2388,26 +2336,16 @@ export function matchComposedCommand(
  * the operation being elevated. Those are different questions about the same
  * token, which is the one situation where two sets are right.
  *
- * The other eight names have no such argument, and review showed sharing them
- * would IMPROVE risk-bands rather than harm it: `setsid git push origin main
- * --force` grades `moderate` there today while the bare command grades `high`,
- * because the wrapper hides the command from the classifier. That is a live gap
- * in a shipped module, filed separately — they stay here until it is fixed, so
- * the deny path is not waiting on it.
+ * The other eight names (`runuser`, `ionice`, `setsid`, `script`, `chrt`,
+ * `taskset`, `proxychains`/`proxychains4`, `systemd-run`) USED to live here too,
+ * for exactly the gap #1013 named: `setsid git push origin main --force` graded
+ * `moderate` in risk-bands while the bare command graded `high`, because the
+ * wrapper hid the head from the classifier. #1013 fixed that by moving them into
+ * the shared `COMMAND_WRAPPERS`, so `isDenyUnwrappableWrapper` now reaches them
+ * through that set and this list shrinks to the three elevation wrappers — the
+ * only ones with a real reason to differ between the two consumers.
  */
-const DENY_EXTRA_WRAPPERS: ReadonlySet<string> = new Set([
-  'sudo',
-  'su',
-  'doas',
-  'runuser',
-  'ionice',
-  'setsid',
-  'script',
-  'chrt',
-  'taskset',
-  'proxychains',
-  'systemd-run',
-]);
+const DENY_EXTRA_WRAPPERS: ReadonlySet<string> = new Set(['sudo', 'su', 'doas']);
 
 function isDenyUnwrappableWrapper(word: string): boolean {
   return COMMAND_WRAPPERS.has(word) || DENY_EXTRA_WRAPPERS.has(word);

--- a/packages/daemon/src/auto-approve/risk-bands.ts
+++ b/packages/daemon/src/auto-approve/risk-bands.ts
@@ -111,7 +111,11 @@
 
 import { extractToolCommand } from './command-tools.ts';
 import { matchesCatastrophicPattern } from './deny-floor.ts';
-import { isSensitiveWritePath, segmentTouchesSensitivePath } from './sensitive-paths.ts';
+import {
+  isAbsoluteScratchTarget,
+  isSensitiveWritePath,
+  segmentTouchesSensitivePath,
+} from './sensitive-paths.ts';
 import {
   ghTopIndex,
   gitSubcommandIndex,
@@ -182,6 +186,22 @@ export const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
   'unshare',
   'watch',
   'chroot',
+  // #1013: eight wrappers that previously hid the head token from the ceiling,
+  // so `setsid git push --force` / `runuser -u root -- git push --force` /
+  // `ionice -c2 git push --force` all graded `moderate` and the ceiling — which
+  // only acts on `high` — could never override a wrong LLM approve of them.
+  // NOT `sudo`/`su`/`doas`: `classifyRisk` treats an elevation wrapper's mere
+  // PRESENCE as the risk (`isPrivilegeElevation`), a different question from
+  // "what is wrapped" — see `DENY_EXTRA_WRAPPERS` (permission-groups.ts).
+  'runuser',
+  'ionice',
+  'setsid',
+  'script',
+  'chrt',
+  'taskset',
+  'proxychains',
+  'proxychains4',
+  'systemd-run',
 ]);
 
 /**
@@ -222,6 +242,32 @@ const WRAPPER_VALUE_FLAGS: Readonly<Record<string, ReadonlySet<string>>> = {
   ]),
   sshpass: new Set(['-p', '-f', '-d', '-P', '-U']),
   time: new Set(['-f', '-o', '--format', '--output']),
+  // #1013. Only flags that consume a SEPARATE following token are listed —
+  // attached forms (`ionice -c2`) are single tokens the bare-flag path already
+  // skips, and command-string flags (`runuser -c '<cmd>'`, `script -c '<cmd>'`)
+  // are deliberately ABSENT: their value IS a command, so discarding it would
+  // erase the head (the `env -S` mistake, #1004). Those `-c` forms stay a
+  // declared residual — the wrapped command still grades from the `-c` string
+  // token, and `hasDangerousWholeWord` still backstops ssh/rm/sudo inside it.
+  runuser: new Set(['-u', '--user', '-g', '--group', '-G', '--supp-group', '-s', '--shell']),
+  ionice: new Set(['-c', '--class', '-n', '--classdata', '-p', '--pid']),
+  taskset: new Set(['-c', '--cpu-list', '-p', '--pid']),
+  proxychains: new Set(['-f']),
+  proxychains4: new Set(['-f']),
+  'systemd-run': new Set([
+    '-u',
+    '--unit',
+    '-p',
+    '--property',
+    '-M',
+    '--machine',
+    '-E',
+    '--setenv',
+    '--slice',
+    '--on-active',
+    '--on-calendar',
+    '--description',
+  ]),
 };
 
 /**
@@ -235,6 +281,14 @@ const WRAPPER_VALUE_FLAGS: Readonly<Record<string, ReadonlySet<string>>> = {
 const WRAPPER_POSITIONAL_ARG: Readonly<Record<string, RegExp>> = {
   timeout: /^[0-9]+(\.[0-9]+)?[smhd]?$/i,
   chroot: /^\S+$/,
+  // #1013. `chrt [policy] <priority> <cmd>` and `taskset <mask> <cmd>` bury the
+  // command behind a bare positional. The patterns match ONLY the priority
+  // number / CPU mask shape (pure decimal or `0x…` hex) — never a command name,
+  // which is never all-digits or `0x`-prefixed — so an over-skip that hides a
+  // real head cannot happen. `taskset -c <list>` takes the value-flag path
+  // instead, so this positional is only consulted for the bare-mask spelling.
+  chrt: /^\d+$/,
+  taskset: /^(0x[0-9a-fA-F]+|\d+)$/,
 };
 
 /** A bare `NAME=value` shell assignment token (`FOO=1 cmd`, valid with or without `env`). */
@@ -657,6 +711,76 @@ function isDestructiveLocalOp(words: readonly string[]): boolean {
 }
 
 /**
+ * True when a deletion is confined to scratch — an `rm`/`rmdir` whose EVERY
+ * operand resolves STRICTLY under an absolute scratch root (`/tmp/...`,
+ * `/private/tmp/...`, `$TMPDIR/...`), and which touches no sensitive
+ * destination. This is exactly what the `scratch` permission group already
+ * approves DETERMINISTICALLY at `balanced`+ (`permission-groups.ts`:
+ * `SCRATCH_COMMANDS` + `scratchTargetVeto` + the mutating-owner sensitive
+ * conjunct), so the risk ceiling must not band it `high` and re-escalate a
+ * model approve the scratch grant would never have sent to the model at all
+ * (#1071). `isAbsoluteScratchTarget` (sensitive-paths.ts) is the SAME
+ * classifier `scratch` uses for absolute targets, shared so the two cannot
+ * drift.
+ *
+ * Scoped tightly to the safe direction:
+ *
+ * - `rm`/`rmdir` ONLY. `shred`/`truncate`/`find -delete`/git deletions are NOT
+ *   in `scratch`'s command set, so they stay `high` — this carve-out never
+ *   widens past what `scratch` itself grants.
+ * - EVERY operand must be a proven absolute scratch target. A relative operand
+ *   (`rm pp.bak`), a non-scratch absolute (`rm /home/x`), a `..` escape
+ *   (`rm /tmp/../etc/passwd`), the scratch ROOT itself (`rm -rf /tmp`), or any
+ *   `$`/`~` token all fail `isAbsoluteScratchTarget` and keep the segment
+ *   `high`. This module is pure (no cwd), so it deliberately does NOT try to
+ *   prove a `cd /tmp && rm x` relative delete — that stays `high`, the
+ *   fail-safe direction.
+ * - At least one operand is required; a bare `rm -rf` with only flags proves
+ *   nothing and stays `high`.
+ * - `segmentTouchesSensitivePath` still vetoes (`rm /tmp/.env`,
+ *   `rm /tmp/.git/hooks/pre-commit`), mirroring the global sensitive-destination
+ *   conjunct `matchGroups` applies to every mutating owner.
+ *
+ * Redirect clauses are not stripped here (unlike `scratchTargetVeto`), so a
+ * scratch delete carrying a redirect (`rm /tmp/x 2>/dev/null`) leaves an
+ * unrecognised token that fails `isAbsoluteScratchTarget` and stays `high` —
+ * an extra escalation, never a wrongful downgrade.
+ *
+ * `words` is the SANITIZED, unwrapped token list its caller already built, so a
+ * command/process substitution appears as `SUBSTITUTION_PLACEHOLDER`. A target
+ * carrying one (`rm /tmp/$(whoami)`, `rm /tmp/`+backtick) is refused here —
+ * matching `scratchTargetVeto`, which sees the raw `$`/backtick and refuses it
+ * too — so this carve-out is never MORE permissive than the `scratch` grant it
+ * mirrors. A bare `$FOO`/`~` needs no special case: `isAbsoluteScratchTarget`
+ * rejects any `$`/`~` token directly.
+ */
+function isScratchConfinedDeletion(words: readonly string[], segment: string): boolean {
+  const bin = words[0];
+  if (bin !== 'rm' && bin !== 'rmdir') return false;
+  if (segmentTouchesSensitivePath(segment)) return false;
+  let sawTarget = false;
+  for (const word of words.slice(1)) {
+    if (word === '') continue;
+    if (word.includes(SUBSTITUTION_PLACEHOLDER)) return false;
+    if (word.startsWith('-')) {
+      // A `--flag=value` token's VALUE is a real destination (mirrors
+      // `scratchTargetVeto`'s `--target-directory=/etc` handling); a bare flag
+      // carries none.
+      const eq = word.indexOf('=');
+      if (eq === -1) continue;
+      const value = word.slice(eq + 1);
+      if (value === '') continue;
+      if (!isAbsoluteScratchTarget(value)) return false;
+      sawTarget = true;
+      continue;
+    }
+    if (!isAbsoluteScratchTarget(word)) return false;
+    sawTarget = true;
+  }
+  return sawTarget;
+}
+
+/**
  * True if a single word looks like it names a destination outside the
  * project tree — absolute (`/...`), home-rooted (`~...` or `$HOME`/`$home`,
  * case-insensitively — matching how `sensitive-paths.ts`'s own
@@ -709,6 +833,13 @@ function isPrivilegeElevation(words: readonly string[], segment: string): boolea
  * Order of checks, all documented in the module doc's "Command-hiding
  * bypasses" section:
  *
+ * 0. `isScratchConfinedDeletion` (#1071) — a `rm`/`rmdir` whose every operand
+ *    is a proven absolute-scratch path returns `moderate` up front, BEFORE the
+ *    whole-word backstop that would otherwise force `high` on the bare `rm`
+ *    name. Placed first, and safe there, because it is a WHITELIST: it accepts
+ *    only segments in which every token is a scratch path or a bare flag, so it
+ *    cannot let a hidden command or substitution past the checks below (see the
+ *    function's own doc).
  * 1. `hasDangerousWholeWord` on the RAW segment text (includes whatever is
  *    inside a substitution, as an extra layer — it does not depend on the
  *    extraction below finding it).
@@ -716,7 +847,9 @@ function isPrivilegeElevation(words: readonly string[], segment: string): boolea
  *    RECURSES into each (bounded by `depth`), then continues with the
  *    SANITIZED segment (placeholders instead of substitution text) for
  *    every check below, so a substitution's internal whitespace cannot
- *    corrupt this segment's own word boundaries.
+ *    corrupt this segment's own word boundaries. (The extraction itself runs
+ *    ahead of check 1 now, so `words` is available for check 0; the recursion
+ *    into the extracted spans still runs in this position.)
  * 3. `hasExecPrimitive` (shell-safety.ts, reused as-is) on the sanitized text.
  * 4. `extractShellDashC` recognises `sh -c "..."` and recurses into the `-c`
  *    argument (bounded by `depth`).
@@ -730,18 +863,7 @@ function classifySegmentBand(rawSegment: string, depth: number): 'moderate' | 'h
   const segment = rawSegment.trim();
   if (segment === '') return 'moderate';
 
-  if (hasDangerousWholeWord(segment)) return 'high';
-
   const { sanitized, inner } = extractSubstitutions(segment);
-  if (inner.length > 0) {
-    if (depth >= MAX_RECURSION_DEPTH) return 'high';
-    for (const innerCommand of inner) {
-      if (classifyCommandMax(innerCommand, depth + 1) === 'high') return 'high';
-    }
-  }
-
-  if (hasExecPrimitive(sanitized)) return 'high';
-
   const rawWords = shellWords(sanitized);
   // Read BEFORE unwrapping: `unwrapCommand` strips `env` and its flags, so by
   // the time `words` exists the `-S` marker is gone. The first draft of this
@@ -751,6 +873,29 @@ function classifySegmentBand(rawSegment: string, depth: number): 'moderate' | 'h
   // exposed it.
   const envSplit = extractEnvSplitString(rawWords);
   const words = unwrapCommand(rawWords);
+
+  // #1071: a deletion confined to scratch is what the `scratch` group already
+  // approves DETERMINISTICALLY, so the ceiling must not band it `high` and
+  // re-escalate a model approve. This is checked FIRST — ahead of the
+  // `hasDangerousWholeWord` backstop below, which fires on the bare `rm`/`rmdir`
+  // name and would otherwise force `high` before any operand is inspected. Safe
+  // to place first because `isScratchConfinedDeletion` is a WHITELIST: it
+  // returns true ONLY when every operand is a proven absolute-scratch path or a
+  // bare flag (no substitution, no `$`/`~`, no second command — any such token
+  // fails `isAbsoluteScratchTarget`), so a segment it accepts cannot hide the
+  // danger the checks below exist to catch.
+  if (isScratchConfinedDeletion(words, segment)) return 'moderate';
+
+  if (hasDangerousWholeWord(segment)) return 'high';
+
+  if (inner.length > 0) {
+    if (depth >= MAX_RECURSION_DEPTH) return 'high';
+    for (const innerCommand of inner) {
+      if (classifyCommandMax(innerCommand, depth + 1) === 'high') return 'high';
+    }
+  }
+
+  if (hasExecPrimitive(sanitized)) return 'high';
 
   // A leading assignment sets the environment the following command runs in,
   // and what that does is defined by the TOOL, not by anything visible here:

--- a/packages/daemon/src/auto-approve/sensitive-paths.ts
+++ b/packages/daemon/src/auto-approve/sensitive-paths.ts
@@ -301,6 +301,90 @@ export function resolveDotDot(path: string): string {
 }
 
 /**
+ * Join `relParts` onto `base`, collapsing `.`/`..` lexically, and refusing to
+ * pop below `floorLen` segments — the scratch-root boundary a target may never
+ * be navigated above. Returns null on an attempted escape.
+ *
+ * Lives here (not in `permission-groups.ts`) so the ONE absolute-scratch
+ * classifier below is shared by BOTH the `scratch` group (which composes it
+ * with `cd`-tracked relative offsets) and `risk-bands.ts`'s ceiling carve-out
+ * (which needs only the pure, cwd-free absolute case). `permission-groups.ts`
+ * imports `risk-bands.ts` already, so risk-bands cannot import back from it —
+ * this module, which both import and which imports neither, is the one place a
+ * shared predicate can live without a cycle.
+ */
+export function joinScratchSegments(
+  base: readonly string[],
+  floorLen: number,
+  relParts: readonly string[],
+): string[] | null {
+  const segs = [...base];
+  for (const part of relParts) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      if (segs.length <= floorLen) return null;
+      segs.pop();
+    } else {
+      segs.push(part);
+    }
+  }
+  return segs;
+}
+
+/**
+ * Classify an ABSOLUTE-shaped token (`/tmp/...`, `/private/tmp/...`,
+ * `$TMPDIR/...`, `${TMPDIR}/...`) into its scratch-root segments and the length
+ * of the root itself, or null if it is not one of those four shapes. `..`/`.`
+ * are resolved via `resolveDotDot` BEFORE the root check runs, the same
+ * ordering that function documents and for the same reason: `/tmp/../etc`
+ * fails every `startsWith('/tmp')` test only AFTER resolution, not before.
+ *
+ * Any `$`/`~` beyond the recognised `$TMPDIR` marker refuses the token (#1061):
+ * an unresolved shell expansion mid-path (`$TMPDIR/$FOO`, `/tmp/$FOO`) is not a
+ * path this pure check can prove stays under a scratch root.
+ */
+export function classifyScratchAbsolute(
+  token: string,
+): { segments: string[]; rootLen: number } | null {
+  for (const marker of ['$TMPDIR', '${TMPDIR}']) {
+    if (token === marker || token.startsWith(`${marker}/`)) {
+      const rest = token.slice(marker.length).replace(/^\//, '');
+      if (rest.includes('$') || rest.includes('~')) return null;
+      const extra = rest === '' ? [] : rest.split('/');
+      const segs = joinScratchSegments(['$TMPDIR'], 1, extra);
+      return segs === null ? null : { segments: segs, rootLen: 1 };
+    }
+  }
+  if (token.startsWith('/')) {
+    if (token.includes('$') || token.includes('~')) return null;
+    const resolved = resolveDotDot(token);
+    const segs = resolved.split('/').filter((s) => s !== '');
+    if (segs[0] === 'tmp') return { segments: segs, rootLen: 1 };
+    if (segs[0] === 'private' && segs[1] === 'tmp') return { segments: segs, rootLen: 2 };
+    return null;
+  }
+  return null;
+}
+
+/**
+ * True if `token` is an ABSOLUTE path that resolves STRICTLY under a scratch
+ * root (deeper than the root itself) — the pure, cwd-free half of
+ * `permission-groups.ts`'s `isStrictlyUnderScratchRoot`. Strict, not
+ * root-or-equal: `/tmp` and `/private/tmp` themselves are the roots, so
+ * deleting them (`rm -rf /tmp`) does NOT qualify. A relative token, a
+ * non-scratch absolute path (`/etc/...`, `~/...`, `$HOME/...`), or a `..`
+ * escape (`/tmp/../etc`) all return false.
+ *
+ * This is the SAME classifier the `scratch` permission group uses for absolute
+ * targets; `risk-bands.ts` consumes it so the ceiling cannot treat a deletion
+ * as high-risk that `scratch` would already approve deterministically (#1071).
+ */
+export function isAbsoluteScratchTarget(token: string): boolean {
+  const resolved = classifyScratchAbsolute(token);
+  return resolved !== null && resolved.segments.length > resolved.rootLen;
+}
+
+/**
  * True if any token in a Bash segment names a sensitive destination.
  *
  * Every token is checked, not just the ones that look like a destination:

--- a/packages/daemon/src/auto-approve/sensitive-paths.ts
+++ b/packages/daemon/src/auto-approve/sensitive-paths.ts
@@ -339,9 +339,17 @@ export function joinScratchSegments(
  * ordering that function documents and for the same reason: `/tmp/../etc`
  * fails every `startsWith('/tmp')` test only AFTER resolution, not before.
  *
- * Any `$`/`~` beyond the recognised `$TMPDIR` marker refuses the token (#1061):
- * an unresolved shell expansion mid-path (`$TMPDIR/$FOO`, `/tmp/$FOO`) is not a
- * path this pure check can prove stays under a scratch root.
+ * Any `$`/`~` beyond the recognised `$TMPDIR` marker refuses the token (#1061),
+ * and any brace `{`/`}` refuses it too (adversarial review of #1071): an
+ * unresolved shell expansion mid-path (`$TMPDIR/$FOO`, `/tmp/$FOO`) or a brace
+ * expansion (`/tmp/{x,../etc/passwd}`) is not a path this pure check can prove
+ * stays under a scratch root. Braces are the subtle one — `shellWords` does not
+ * expand them, so a glued `../etc/passwd` inside `{x,..}` never becomes a
+ * standalone `..` segment for `resolveDotDot` to collapse, and the token still
+ * reads as `/tmp/...`. Refusing braces outright closes that for BOTH the risk
+ * ceiling (#1071) and the `scratch` group (which shares this classifier for
+ * absolute targets); a genuine scratch path with a literal brace just stays
+ * high/escalated, the ADR 0010 safe direction.
  */
 export function classifyScratchAbsolute(
   token: string,
@@ -349,14 +357,14 @@ export function classifyScratchAbsolute(
   for (const marker of ['$TMPDIR', '${TMPDIR}']) {
     if (token === marker || token.startsWith(`${marker}/`)) {
       const rest = token.slice(marker.length).replace(/^\//, '');
-      if (rest.includes('$') || rest.includes('~')) return null;
+      if (hasUnprovableExpansion(rest)) return null;
       const extra = rest === '' ? [] : rest.split('/');
       const segs = joinScratchSegments(['$TMPDIR'], 1, extra);
       return segs === null ? null : { segments: segs, rootLen: 1 };
     }
   }
   if (token.startsWith('/')) {
-    if (token.includes('$') || token.includes('~')) return null;
+    if (hasUnprovableExpansion(token)) return null;
     const resolved = resolveDotDot(token);
     const segs = resolved.split('/').filter((s) => s !== '');
     if (segs[0] === 'tmp') return { segments: segs, rootLen: 1 };
@@ -364,6 +372,17 @@ export function classifyScratchAbsolute(
     return null;
   }
   return null;
+}
+
+/**
+ * True if `value` carries a shell expansion this pure, cwd-free classifier
+ * cannot resolve to a definite path: a variable/tilde expansion (`$`/`~`,
+ * #1061) or a brace expansion (`{`/`}`, adversarial review of #1071). Any of
+ * them means the string as written is not the path the shell would act on, so a
+ * scratch-root proof over the literal token would be unsound.
+ */
+function hasUnprovableExpansion(value: string): boolean {
+  return value.includes('$') || value.includes('~') || value.includes('{') || value.includes('}');
 }
 
 /**

--- a/packages/daemon/tests/auto-approve/permission-groups.test.ts
+++ b/packages/daemon/tests/auto-approve/permission-groups.test.ts
@@ -1224,6 +1224,13 @@ describe('scratch: adversarial (MUST fall through, never group-approve)', () => 
     // Traversal out via `..` inside a single absolute token.
     'rm -rf /tmp/../etc',
     'rm -rf /tmp/../../Users/yahya',
+    // Traversal out via a `..` GLUED inside a brace expansion, so it never
+    // becomes a standalone `..` segment for resolveDotDot to collapse. The
+    // shared classifier now refuses any brace token (adversarial review of
+    // #1071), closing this for the scratch group and the risk ceiling at once.
+    'rm -rf /tmp/{x,../etc/passwd}',
+    'rm -rf /tmp/{x,..}',
+    'rm -rf $TMPDIR/{a,../etc}',
     // Traversal out via a relative path after a leading cd.
     'cd /tmp && rm -rf ../..',
     // The same traversal, but landing on a target that is STILL deeper than

--- a/packages/daemon/tests/auto-approve/risk-bands.test.ts
+++ b/packages/daemon/tests/auto-approve/risk-bands.test.ts
@@ -450,6 +450,10 @@ describe('classifyRisk — #1071 a scratch-confined deletion is not high (ceilin
     'rm -rf', // flags only, no provable target
     'rm /tmp/$(whoami)', // command substitution in the target
     'rm /tmp/$FOO', // unresolved parameter expansion
+    'rm -rf /tmp/{x,../etc/passwd}', // brace-glued `..` escape (adversarial review of #1071)
+    'rm -rf /tmp/{x,..}', // brace expansion reaching `/`
+    'rm -rf /tmp/{x,../home/victim}', // another brace escape target
+    'rm -rf $TMPDIR/{a,../etc}', // brace escape from the $TMPDIR root
     'shred /tmp/secret', // not an rm/rmdir -> not in scratch's command set
     'truncate -s0 /tmp/x', // same
     'find /tmp -delete', // same

--- a/packages/daemon/tests/auto-approve/risk-bands.test.ts
+++ b/packages/daemon/tests/auto-approve/risk-bands.test.ts
@@ -17,6 +17,7 @@ import {
   riskBandAtLeast,
   riskBandRank,
 } from '../../src/auto-approve/risk-bands.ts';
+import { enforceRiskCeiling } from '../../src/auto-approve/risk-ceiling.ts';
 
 const bash = (command: string) => ({ command });
 
@@ -158,12 +159,19 @@ describe('classifyRisk — command-wrapper bypass (coordinator field report on #
     expect(classifyRisk('Bash', bash('timeout 30 chmod 700 /usr/local/bin/tool'))).toBe('high');
   });
 
-  test('two wrappers NOT in the enumerated list are still caught by the whole-word backstop', () => {
-    // `ionice` and `setsid` are deliberately absent from COMMAND_WRAPPERS --
-    // unwrapCommand does nothing for either, so only hasDangerousWholeWord can
-    // classify these correctly. Proves the backstop, not just the list.
+  test('ionice/setsid are now unwrapped (#1013) AND still covered by the whole-word backstop', () => {
+    // As of #1013 both are enumerated in COMMAND_WRAPPERS, so unwrapCommand
+    // reaches the wrapped head. The whole-word backstop is a SECOND,
+    // independent layer, so these stay `high` via either route.
     expect(classifyRisk('Bash', bash('ionice -c3 rm -rf ./dist'))).toBe('high');
     expect(classifyRisk('Bash', bash('setsid ssh dev@host uptime'))).toBe('high');
+  });
+
+  test('the whole-word backstop still fires for a wrapper NOT in the enumerated list', () => {
+    // `catchsegv` is genuinely absent from COMMAND_WRAPPERS, so unwrapCommand
+    // does nothing and only hasDangerousWholeWord classifies this -- proving the
+    // backstop independently of the list now that ionice/setsid are enumerated.
+    expect(classifyRisk('Bash', bash('catchsegv rm -rf ./dist'))).toBe('high');
   });
 
   test('accepted trade-off: the whole-word backstop over-fires on prose containing the word (ADR 0010, err broad)', () => {
@@ -319,10 +327,11 @@ describe('classifyRisk — command-hiding bypasses, round 2 (independent review 
     });
   }
 
-  test('(a) setsid is still NOT enumerated, but sudo is now in the whole-word backstop', () => {
-    // `setsid` stays deliberately absent from COMMAND_WRAPPERS (it already
-    // proves the backstop for ssh/rm elsewhere); this line is resolved
-    // entirely by adding 'sudo' to DANGEROUS_WHOLE_WORDS.
+  test('(a) setsid is now enumerated (#1013), and sudo is also in the whole-word backstop', () => {
+    // `setsid` is enumerated in COMMAND_WRAPPERS as of #1013, so unwrapCommand
+    // reaches the wrapped `sudo` head (`isPrivilegeElevation` -> high); adding
+    // 'sudo' to DANGEROUS_WHOLE_WORDS is a second, independent route to the same
+    // verdict. Either alone suffices here.
     expect(classifyRisk('Bash', bash('setsid sudo apt-get install curl'))).toBe('high');
   });
 
@@ -401,6 +410,137 @@ describe('classifyRisk — command-hiding bypasses, round 2 (independent review 
 
   test('(item 5) already-correct case stays high: ascent landing on a named system tree', () => {
     expect(classifyRisk('Bash', bash('chmod 700 ../../../../../var/random'))).toBe('high');
+  });
+});
+
+describe('classifyRisk — #1071 a scratch-confined deletion is not high (ceiling must not re-escalate it)', () => {
+  // The reported case: at `trusted` the model correctly approves `rm /tmp/pp.bak`,
+  // and the risk ceiling force-escalated it. A deletion the `scratch` group
+  // already grants deterministically must not band `high`.
+  const scratchDeletes = [
+    'rm /tmp/pp.bak',
+    'rm -rf /tmp/build',
+    'rm -f /tmp/a /tmp/b',
+    'rmdir /tmp/sub',
+    'rm /private/tmp/x',
+    'rm -rf /private/tmp/work/out',
+    'rm $TMPDIR/scratch.log',
+    'rm ${TMPDIR}/scratch.log',
+  ];
+  for (const command of scratchDeletes) {
+    test(`moderate: ${command}`, () => {
+      expect(classifyRisk('Bash', bash(command))).toBe('moderate');
+    });
+  }
+
+  test('the ceiling no longer overrides a model approve of a scratch delete', () => {
+    const r = enforceRiskCeiling('Bash', bash('rm /tmp/pp.bak'), 'approve');
+    expect(r).toEqual({ decision: 'approve', overridden: false });
+  });
+
+  // Everything the carve-out must NOT swallow — each stays `high`.
+  const stillHigh = [
+    'rm -rf /tmp', // the scratch ROOT itself, not something under it
+    'rm -rf /private/tmp', // same, private form
+    'rm /tmp/../etc/passwd', // `..` escape out of scratch
+    'rm pp.bak', // relative, no cwd -> cannot prove scratch
+    'rm ./build/x', // relative in-tree
+    'rm /home/user/notes.txt', // non-scratch absolute
+    'rm /tmp/a /home/user/x', // one non-scratch target vetoes the whole line
+    'rm -rf', // flags only, no provable target
+    'rm /tmp/$(whoami)', // command substitution in the target
+    'rm /tmp/$FOO', // unresolved parameter expansion
+    'shred /tmp/secret', // not an rm/rmdir -> not in scratch's command set
+    'truncate -s0 /tmp/x', // same
+    'find /tmp -delete', // same
+    'git rm /tmp/x', // git deletion, never a scratch grant
+  ];
+  for (const command of stillHigh) {
+    test(`still high: ${command}`, () => {
+      expect(classifyRisk('Bash', bash(command))).toBe('high');
+    });
+  }
+
+  test('a sensitive destination under /tmp is still high (mirrors scratch’s sensitive conjunct)', () => {
+    expect(classifyRisk('Bash', bash('rm /tmp/.env'))).toBe('high');
+    expect(classifyRisk('Bash', bash('rm /tmp/.git/hooks/pre-commit'))).toBe('high');
+  });
+
+  test('critical scratch-shaped deletes are still critical (deny floor runs first)', () => {
+    // `rm -rf /tmp/*`-style catastrophic patterns are caught by
+    // matchesCatastrophicPattern BEFORE this carve-out ever runs.
+    expect(classifyRisk('Bash', bash('rm -rf /'))).toBe('critical');
+  });
+
+  test('a scratch delete chained with a dangerous segment stays high (max across segments)', () => {
+    expect(classifyRisk('Bash', bash('rm /tmp/x && git push origin main --force'))).toBe('high');
+  });
+
+  test('a wrapper in front of a scratch delete is still moderate (unwrap then carve-out)', () => {
+    expect(classifyRisk('Bash', bash('nice rm /tmp/pp.bak'))).toBe('moderate');
+  });
+});
+
+describe('classifyRisk — #1013 wrappers hide a high-band command from the ceiling', () => {
+  // The KEY cases: `git push --force` carries no dangerous WHOLE WORD (neither
+  // "push" nor "force" is in DANGEROUS_WHOLE_WORDS), so ONLY unwrapCommand
+  // reaching the `git` head can classify these. Before #1013 every one graded
+  // `moderate` and `enforceRiskCeiling` (which acts only on `high`) was blind
+  // to them.
+  const hiddenByWrapper = [
+    'setsid git push origin main --force',
+    'runuser -u root -- git push origin main --force',
+    'ionice -c2 git push origin main --force',
+    'ionice -c 2 git push origin main --force',
+    'chrt 20 git push origin main --force',
+    'chrt -f 20 git push origin main --force',
+    'taskset 0x3 git push origin main --force',
+    'taskset -c 0,1 git push origin main --force',
+    'proxychains git push origin main --force',
+    'proxychains -f /etc/proxychains.conf git push origin main --force',
+    'proxychains4 git push origin main --force',
+    'systemd-run git push origin main --force',
+    'systemd-run --unit oneoff --scope git push origin main --force',
+  ];
+  for (const command of hiddenByWrapper) {
+    test(`high (was moderate): ${command}`, () => {
+      expect(classifyRisk('Bash', bash(command))).toBe('high');
+    });
+  }
+
+  test('the ceiling now actually fires on a wrapped high-band approve', () => {
+    // The whole point: an LLM `approve` of a wrapper-hidden force-push is now
+    // overridden, where before the wrapper kept it at `moderate` and the ceiling
+    // never ran.
+    const r = enforceRiskCeiling('Bash', bash('setsid git push origin main --force'), 'approve');
+    expect(r).toEqual({ decision: 'escalate', overridden: true, band: 'high' });
+  });
+
+  // Discrimination, not blanket escalation: a SAFE command behind the same
+  // wrappers must stay moderate, or the fix would just re-escalate everything.
+  const safeBehindWrapper = [
+    'setsid git status',
+    'ionice -c2 git log --oneline',
+    'chrt 20 bun test',
+    'taskset 0x3 cat README.md',
+    'systemd-run --scope bun run build',
+  ];
+  for (const command of safeBehindWrapper) {
+    test(`moderate (discrimination): ${command}`, () => {
+      expect(classifyRisk('Bash', bash(command))).toBe('moderate');
+    });
+  }
+
+  test('declared residual: a wrapper -c command-string is not recursed into (stays moderate)', () => {
+    // `runuser -c '<cmd>'` / `script -c '<cmd>'` carry the wrapped command as a
+    // single quoted value. Discarding it would erase the head (the `env -S`
+    // mistake, #1004), so `-c` is deliberately NOT a value flag and the string
+    // is not recursed; the force-push inside is not reached. This is unchanged
+    // from before #1013 (the wrapper hid it then too) and is pinned so the gap
+    // is visible, not silent.
+    expect(classifyRisk('Bash', bash("runuser -c 'git push origin main --force'"))).toBe(
+      'moderate',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Two follow-ups from the #1057 approval-rate epic, both in the risk ceiling's band classifier (`classifyRisk`, risk-bands.ts). The ceiling (#976) overrides a model **approve** only when the operation bands `high`/`critical`; two band errors made it fire wrongly in opposite directions, so they ship together.

### #1071 — a scratch-confined delete is no longer `high`

The phase-7 sweep's most actionable finding: at `trusted`, the model correctly approves a delete of a file under `/tmp`, and the risk ceiling force-escalated it. The delete graded `high` via the `rm`/`rmdir` whole-word backstop, even though the `scratch` permission group already grants exactly these deletes at 0ms.

`classifySegmentBand` now returns `moderate` up front — **before** the whole-word backstop — for an `rm`/`rmdir` whose every operand is a proven absolute-scratch path and which touches no sensitive destination. The predicate (`isScratchConfinedDeletion`) is a **whitelist**: it accepts a segment only when every token is a scratch path or a bare flag (no substitution, no `$`/`~`, no second command — any such token fails the check), so it cannot let a hidden command slip past the backstop it precedes. Sensitive destinations under `/tmp` (`.env`, `.git/hooks`), the scratch root itself, `..` escapes, relative deletes, and non-`rm` deletion tools all stay `high`.

The absolute-scratch classifier moves from `permission-groups.ts` to `sensitive-paths.ts` so risk-bands and permission-groups share **one** definition — `permission-groups.ts` already imports risk-bands, so risk-bands cannot import back from it; `sensitive-paths.ts` (which both import and which imports neither) is the only cycle-free home.

### #1013 — eight wrappers no longer hide a high-band command

`setsid`, `runuser`, `ionice`, `script`, `chrt`, `taskset`, `proxychains`/`proxychains4`, and `systemd-run` were missing from `COMMAND_WRAPPERS`, so a wrapped force-push graded `moderate` and the ceiling (which acts only on `high`) never saw it. Those words carry no dangerous whole word, so **only** unwrapping to the real head can classify them.

They are enumerated now, each with accurate value-flags (only flags that consume a separate token — command-string `-c` forms stay a declared residual, since discarding them would erase the head, the `env -S` mistake from #1004) and positional-arg patterns (`chrt <prio>`, `taskset <mask>`, matched only in shapes a command name can never take). `DENY_EXTRA_WRAPPERS` shrinks to the three elevation wrappers (`sudo`/`su`/`doas`) that genuinely differ between the two consumers.

## Test plan

- New risk-bands tests pin #1071 (moderate for scratch deletes; still-high for root/escape/relative/sensitive/non-rm/mixed/substitution; the ceiling no longer overrides a scratch-delete approve) and #1013 (high for each wrapped force-push, discrimination that safe wrapped commands stay moderate, the ceiling now fires on a wrapped approve, and the `-c` residual pinned honestly).
- Two stale-rationale wrapper tests updated per ADR 0011 (they claimed ionice/setsid were deliberately absent from COMMAND_WRAPPERS, which #1013 makes false).
- Full suite: **6565 pass / 0 fail**, typecheck clean, biome clean, typos clean.

Closes #1071. Closes #1013.
