### PR TITLE
Persist a genuine long DENY via signature provenance (#1067)

### DIFF
--- a/packages/daemon/src/auto-approve/auto-approve-service.ts
+++ b/packages/daemon/src/auto-approve/auto-approve-service.ts
@@ -893,7 +893,9 @@ export class AutoApproveService {
       // that path, with any content, at `high`, at 0ms).
       if (this.sessionPrecedent && precedent && precedentMayAuthorize(toolName, toolInput)) {
         const signature = signatureForOperation(toolName, toolInput);
-        const approvedMatch = precedent.matchApproved(toolName, signature);
+        // `whole: true` (#1067): this signature is untruncated by construction,
+        // so the precedent matcher must not apply the truncation refusal to it.
+        const approvedMatch = precedent.matchApproved(toolName, signature, true);
         if (approvedMatch !== null) {
           const band = classifyRisk(toolName, toolInput);
           const assessment = AuthorizationAssessment.fromPrecedent(approvedMatch);
@@ -1223,6 +1225,9 @@ export class AutoApproveService {
           const deniedMatch = precedent.matchDenied(
             toolName,
             signatureForOperation(toolName, toolInput),
+            // `whole: true` (#1067): untruncated by construction. Also what lets
+            // a genuine >=120-char DENY that ends in `...` re-match here.
+            true,
           );
           if (deniedMatch !== null) {
             decidedBy = 'precedent';

--- a/packages/daemon/src/auto-approve/precedent.ts
+++ b/packages/daemon/src/auto-approve/precedent.ts
@@ -215,6 +215,21 @@
  * — it still applies wherever that function is still consulted (defense in
  * depth, and `parsePermissionQuestionText`'s own now-uncalled-in-production
  * refusal, kept for its test coverage — see that function's doc).
+ *
+ * ### #1067: the heuristic's false positive weakened a DENY
+ *
+ * Post-#990 the production path never produces a truly truncated signature, so
+ * `isTruncatedSignature` firing there is always a FALSE positive — and for a
+ * `denied` record that dropped a human "no" as a stop rule (the deny half is
+ * the less-safe direction; the approve half just re-asks). A truncation and a
+ * genuine `>=120`-char command ending in `...` are the same shape, so they
+ * cannot be told apart by inspecting the string. #1067 adds a `whole`
+ * provenance bit (`PrecedentRecord.whole`, and a param on `record()` / the two
+ * match functions): a `signatureForOperation` signature is untruncated by
+ * construction and the refusal is skipped for it, while an unknown-provenance
+ * signature keeps the full defensive treatment above. The refusal — "in both
+ * directions", above — is therefore now conditional on `!whole` everywhere it
+ * appears.
  */
 
 import { summarizeToolInput } from '../hooks/tool-summary.ts';
@@ -246,6 +261,24 @@ export interface PrecedentRecord {
    * it captured at the point of truth rather than reconstructed later.
    */
   readonly recordedAt: number;
+  /**
+   * Provenance: `true` when this signature came from a producer that
+   * guarantees it is UNTRUNCATED — `signatureForOperation` (`forSignature:
+   * true`), the canonical derivation both production paths use (#1067). A
+   * `whole` record is trusted by the match loops, which therefore do NOT skip
+   * it even if its text happens to be `>=120` chars ending in `...` — that
+   * shape is a genuine command (`curl … # fetching…`), not a truncation
+   * artifact, and skipping it silently weakened a human DENY into a
+   * non-stop-rule (the deny half of the `isTruncatedSignature` false positive).
+   *
+   * `false`/absent means "provenance unknown" — a signature built some other
+   * way (a future caller, a test, a `PrecedentRecord[]` constructed directly).
+   * For those the defensive `isTruncatedSignature` refusal still applies, since
+   * an unknown source genuinely might hand over a truncated value. Optional so
+   * a directly-built record keeps the conservative (defensive) treatment
+   * without every existing test having to set it.
+   */
+  readonly whole?: boolean;
 }
 
 /**
@@ -357,8 +390,9 @@ const TRUNCATION_MARKER = '...';
  * to end in the marker is also refused) — both land on "missed precedent,"
  * never on a "false match" (the direction this function guards). "Missed
  * precedent" is the safe direction for an APPROVE but weakens the stop rule
- * for a DENY; see the approve/deny split under the heuristic note below
- * (#1067).
+ * for a DENY — which is why, as of #1067, this refusal is SKIPPED for a
+ * `whole` (untruncated-by-construction) signature and applies only to an
+ * unknown-provenance one; see the "Fixed by provenance" note below.
  *
  * This is a heuristic, not a certainty: a genuine, untruncated value that
  * happens to be at least 120 characters and end in `...` (e.g. a command
@@ -371,21 +405,30 @@ const TRUNCATION_MARKER = '...';
  * the older "missed precedent — the safe direction" framing understated one
  * half (adversarial review, 2026-08-16). Post-#990 the normal record/consult
  * path never produces a truly truncated signature, so on that path this
- * check only ever fires as a false positive; what it costs then depends on
- * the decision:
+ * check only ever fires as a false positive; what it costs depended on the
+ * decision:
  *   - APPROVE (record or match): the operation is not auto-approved by
  *     precedent and is simply re-asked. Fail-closed — the safe direction.
- *   - DENY: a human "no" is not persisted as a stop rule (`record()` drops
- *     it, and `findDeniedPrecedent` would skip it as a query), so a later
- *     model `approve` of the identical operation stands instead of being
- *     escalated back — the deny stop rule is silently weakened, the
- *     LESS-safe direction. It never manufactures a false approve on its own
- *     (the model still evaluates), and this is not a #990 regression
- *     (pre-#990 dropped EVERY >120-char denial; #990 shrinks it to only
- *     `...`-ending ones) — but it is a real gap, tracked as #1067. The
- *     record-side refusal is kept unchanged here: removing it for denials
- *     needs the deny-MATCH side handled too, without reopening the round-2
- *     substring hole, which is #1067's own delicate change, not this one.
+ *   - DENY: a human "no" was not persisted as a stop rule (`record()` dropped
+ *     it, and `findDeniedPrecedent` skipped it as a query), so a later model
+ *     `approve` of the identical operation stood instead of being escalated
+ *     back — the deny stop rule silently weakened, the LESS-safe direction.
+ *
+ * ## Fixed by provenance (#1067), not by softening the heuristic
+ *
+ * The false positive cannot be told from a real truncation by inspecting the
+ * string — they are the same shape. So the fix does not touch this function; it
+ * gives `record()` and the two match functions a `whole` bit (see
+ * `PrecedentRecord.whole`). A signature from `signatureForOperation`
+ * (untruncated by construction — the only producer either PRODUCTION path uses)
+ * is `whole`, and this check is SKIPPED for it: a genuine `>=120`-char command
+ * ending in `...` now records and re-matches, including a DENY, which persists
+ * as a stop rule. This function is unchanged and still applies — as
+ * defense-in-depth — to any UNKNOWN-provenance signature (a future caller, a
+ * test, or a value reconstructed from truncated display text via
+ * `parsePermissionQuestionText`), which genuinely might be truncated. The
+ * deny-match side is safe to open for a `whole` query specifically because a
+ * whole query is not opaque (see `findDeniedPrecedent`).
  *
  * ## No `': '` separator: the whole signature is the detail
  *
@@ -724,8 +767,15 @@ export function precedentMayAuthorize(
  * instead of relying on nobody calling `record`.
  */
 export interface PrecedentReader {
-  matchApproved(toolName: string, signature: string): PrecedentMatch | null;
-  matchDenied(toolName: string, signature: string): PrecedentMatch | null;
+  /**
+   * `whole` (#1067) declares the query signature came from
+   * `signatureForOperation` (untruncated by construction). Both production
+   * call sites pass `true`; it defaults to the conservative `false` for any
+   * caller that does not, so an unknown-provenance query keeps the defensive
+   * truncation refusal.
+   */
+  matchApproved(toolName: string, signature: string, whole?: boolean): PrecedentMatch | null;
+  matchDenied(toolName: string, signature: string, whole?: boolean): PrecedentMatch | null;
 }
 
 /**
@@ -777,8 +827,12 @@ export function findApprovedPrecedent(
   records: readonly PrecedentRecord[],
   toolName: string,
   signature: string,
+  whole = false,
 ): PrecedentMatch | null {
-  if (isTruncatedSignature(signature)) return null;
+  // Provenance (#1067): a `whole` query is untruncated by construction, so the
+  // truncation refusal — whose purpose is to reject an OPAQUE truncated query —
+  // does not apply to it. An unknown-provenance query still gets the refusal.
+  if (!whole && isTruncatedSignature(signature)) return null;
   // RAW, not `normalizeSignature`. See "Whitespace collapsing is a LOOSENING"
   // in the module doc: collapsing runs on the ALLOW side is exactly the
   // over-matching ADR 0010 forbids, and it was measured equating a dead-code
@@ -789,7 +843,10 @@ export function findApprovedPrecedent(
     if (!record) continue;
     if (record.toolName !== toolName) continue;
     const storedSignature = record.signature.trim();
-    if (isTruncatedSignature(storedSignature)) continue;
+    // A `whole` stored record is trusted; only an unknown-provenance one is
+    // skipped when it looks truncated (defense in depth for a directly-built
+    // `PrecedentRecord[]`). See `PrecedentRecord.whole`.
+    if (!record.whole && isTruncatedSignature(storedSignature)) continue;
     if (storedSignature !== target) continue;
     // First hit while scanning newest-first: the FRESHEST record for this
     // exact (tool, signature) pair. If the human's most recent word on it
@@ -844,8 +901,17 @@ export function findDeniedPrecedent(
   records: readonly PrecedentRecord[],
   toolName: string,
   signature: string,
+  whole = false,
 ): PrecedentMatch | null {
-  if (isTruncatedSignature(signature)) return null;
+  // Provenance (#1067). The query-side refusal here guards a DIFFERENT hazard
+  // than the approve side's: a truncated OPAQUE query could substring-match a
+  // short stored deny somewhere inside its unverifiable tail. A `whole` query
+  // is NOT opaque — it is the full command — so a substring hit is a REAL
+  // containment (the stop rule working), not a coincidence in hidden text. That
+  // is why skipping the refusal for a whole query does not reopen the round-2
+  // substring hole, which was specifically about opaque truncated queries. An
+  // unknown-provenance query still gets refused when truncated-shaped.
+  if (!whole && isTruncatedSignature(signature)) return null;
   const target = normalizeSignature(signature);
   for (let i = records.length - 1; i >= 0; i--) {
     const record = records[i];
@@ -853,7 +919,10 @@ export function findDeniedPrecedent(
     if (record.decision !== 'denied') continue;
     if (record.toolName !== toolName) continue;
     const storedSignature = normalizeSignature(record.signature);
-    if (isTruncatedSignature(storedSignature)) continue;
+    // Trust a `whole` stored deny (a genuine `>=120`-char command ending in
+    // `...` must persist as a stop rule, #1067); skip only an unknown-provenance
+    // record that looks truncated.
+    if (!record.whole && isTruncatedSignature(storedSignature)) continue;
     if (!target.includes(storedSignature) && !storedSignature.includes(target)) continue;
     return {
       decision: 'denied',
@@ -895,25 +964,29 @@ export class PrecedentStore {
    * expected pre-extracted (as of #990: `toolNameFromSignature` +
    * `Question.precedentSignature`, both untruncated — see that field's doc)
    * — this method only normalizes and stores, it does not parse. A blank
-   * tool name
-   * or signature (after normalization), OR a truncated signature
-   * (`isTruncatedSignature` — see "Truncation" in this module's doc,
-   * CRITICAL, found in review), is refused rather than stored: the first is
-   * a useless entry that could still occupy a cap slot, the second is a
-   * signature this store cannot safely match precisely. `record()` checking
-   * this too (not just `parsePermissionQuestionText`) is defense in depth
-   * for any future caller that builds a signature some other way — and this
-   * IS the authoritative truncation boundary for whatever is actually
-   * stored: once this check is correct, no truncated raw signature can ever
-   * reach `this.records`, so a stored record is never truncated in
-   * practice (see `isTruncatedSignature`'s doc on why the match functions'
-   * stored-side check is therefore redundant, not the reverse).
+   * tool name or signature (after normalization) is always refused (a useless
+   * entry that would occupy a cap slot). A truncated signature
+   * (`isTruncatedSignature` — see "Truncation" in this module's doc, CRITICAL,
+   * found in review) is refused ONLY when `whole` is false: a signature this
+   * store cannot safely match precisely.
    *
-   * This refusal runs for BOTH decisions, and dropping a `denied` record is
-   * not purely safe the way dropping an `approved` one is: it weakens the
-   * deny stop rule for a genuine, untruncated command that happens to end in
-   * `...` (>=120 chars). See the approve/deny split in `isTruncatedSignature`'s
-   * doc — kept unchanged here, tracked as #1067.
+   * `whole` (#1067) is the provenance bit. When true, the signature is
+   * untruncated by construction (`signatureForOperation`, the derivation both
+   * production paths use), so the truncation refusal is skipped and the record
+   * is stored marked `whole` — fixing the deny-side weakening below. When false
+   * (an unknown-provenance caller, or a test), the refusal still applies:
+   * `record()` checking this (not just `parsePermissionQuestionText`) is
+   * defense in depth, and for a non-`whole` signature this IS the authoritative
+   * truncation boundary — a non-`whole` truncated raw signature can never reach
+   * `this.records`, so a stored non-`whole` record is never truncated in
+   * practice (which is why the match functions' stored-side check skips only
+   * non-`whole` records: see `isTruncatedSignature`'s doc).
+   *
+   * Before #1067 this refusal ran for BOTH decisions unconditionally, and
+   * dropping a `denied` record was not purely safe the way dropping an
+   * `approved` one is: it weakened the deny stop rule for a genuine, untruncated
+   * command that happens to end in `...` (>=120 chars). Passing `whole: true`
+   * from the production record path is what closes that.
    *
    * The truncation check MUST run on the RAW `signature` parameter, BEFORE
    * `normalizeSignature` touches it (round 2, review 2026-08-02):
@@ -923,8 +996,19 @@ export class PrecedentStore {
    * command), not just an adversarial construction — and a check running
    * on the already-shrunk value would silently miss it.
    */
-  record(toolName: string, signature: string, decision: 'approved' | 'denied'): void {
-    if (isTruncatedSignature(signature)) return;
+  record(
+    toolName: string,
+    signature: string,
+    decision: 'approved' | 'denied',
+    whole = false,
+  ): void {
+    // Provenance decides whether the truncation heuristic applies (#1067). A
+    // `whole` signature is untruncated BY CONSTRUCTION (`signatureForOperation`),
+    // so `isTruncatedSignature` firing on it is a false positive — and dropping
+    // a genuine DENY here silently weakened the stop rule. Skip the refusal for
+    // a trusted signature; keep it for an unknown-provenance one, which really
+    // might be a truncated value this store cannot match precisely.
+    if (!whole && isTruncatedSignature(signature)) return;
     const normalizedToolName = toolName.trim();
     // Stored RAW (trimmed only), NOT whitespace-collapsed. Each matcher then
     // applies its OWN strictness: the approve side compares raw, the deny side
@@ -936,6 +1020,7 @@ export class PrecedentStore {
       signature: normalizedSignature,
       decision,
       recordedAt: Date.now(),
+      whole,
     });
     if (this.records.length > this.maxEntries) this.records.shift();
   }
@@ -945,14 +1030,16 @@ export class PrecedentStore {
     return this.records.length;
   }
 
-  /** Precise, allow-shaped lookup — see `findApprovedPrecedent`. */
-  matchApproved(toolName: string, signature: string): PrecedentMatch | null {
-    return findApprovedPrecedent(this.records, toolName, signature);
+  /** Precise, allow-shaped lookup — see `findApprovedPrecedent`. `whole`
+   *  (#1067) forwards the query's provenance. */
+  matchApproved(toolName: string, signature: string, whole = false): PrecedentMatch | null {
+    return findApprovedPrecedent(this.records, toolName, signature, whole);
   }
 
-  /** Broad, deny-shaped lookup — see `findDeniedPrecedent`. */
-  matchDenied(toolName: string, signature: string): PrecedentMatch | null {
-    return findDeniedPrecedent(this.records, toolName, signature);
+  /** Broad, deny-shaped lookup — see `findDeniedPrecedent`. `whole` (#1067)
+   *  forwards the query's provenance. */
+  matchDenied(toolName: string, signature: string, whole = false): PrecedentMatch | null {
+    return findDeniedPrecedent(this.records, toolName, signature, whole);
   }
 
   /** Drop every recorded precedent (session rotation — /clear, /resume,

--- a/packages/daemon/src/auto-approve/precedent.ts
+++ b/packages/daemon/src/auto-approve/precedent.ts
@@ -1049,3 +1049,52 @@ export class PrecedentStore {
     this.records.length = 0;
   }
 }
+
+/**
+ * Build the read-only `PrecedentReader` the gate consumes, over `store`.
+ *
+ * Extracted from `hook-bridge-setup.ts`'s inline `getPrecedent` (so it is
+ * unit-testable in its own right) but keeping that call site's TWO deliberate
+ * properties, both load-bearing:
+ *
+ * - It hands out a FRESH object exposing only the two matchers, never the store
+ *   — passing the store would satisfy `PrecedentReader` structurally (TypeScript
+ *   is structural, so `record` would come along) and the write surface would be
+ *   one cast away, breaking the "`handleAnswer` is the single writer" invariant
+ *   ADR 0015 rests on.
+ * - It FORWARDS the `whole` provenance bit (#1067) rather than dropping it.
+ *   Dropping it here silently re-imposes the truncation refusal on a query the
+ *   consult site already vouched for as untruncated, which would re-break the
+ *   genuine long DENY this exists to keep.
+ */
+export function readerFrom(store: PrecedentStore): PrecedentReader {
+  return {
+    matchApproved: (tool, signature, whole) => store.matchApproved(tool, signature, whole),
+    matchDenied: (tool, signature, whole) => store.matchDenied(tool, signature, whole),
+  };
+}
+
+/**
+ * Record a human's answer into `store` as a `whole` (untruncated-by-
+ * construction) precedent (#1067). The write-side companion to `readerFrom`,
+ * extracted from `cli.ts`'s `recordPrecedent` closure so the `whole=true`
+ * decision is a NAMED, tested unit rather than an inline literal on the
+ * entrypoint.
+ *
+ * `whole=true` is sound because the ONE production caller (`cli.ts`'s
+ * `recordPrecedent`, fed by `handleAnswer` -> `active.precedentSignature`) only
+ * ever passes a `signatureForOperation` value — untruncated by construction,
+ * and `undefined`/skipped otherwise (`handleAnswer` fails closed, never falling
+ * back to the truncated `active.text`). A future caller handing this a signature
+ * built some other way would wrongly mark it `whole`; keep this reserved for the
+ * record path whose signature provenance is guaranteed, exactly as the inline
+ * literal was.
+ */
+export function recordHumanAnswer(
+  store: PrecedentStore,
+  toolName: string,
+  signature: string,
+  decision: 'approved' | 'denied',
+): void {
+  store.record(toolName, signature, decision, true);
+}

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -2145,8 +2145,14 @@ const inputHandlers: InputHandlers = createInputHandlers({
   // store for this sessionId (no hookServer, or the session already closed)
   // is a silent no-op -- recording is additive and must never affect the
   // answer itself.
+  // `whole: true` (#1067): the only caller (`handleAnswer`, input-events.ts)
+  // sources `signature` from `active.precedentSignature`, which
+  // `buildPermissionQuestion` set via `signatureForOperation` — untruncated by
+  // construction. Recording it as `whole` is what lets a genuine >=120-char
+  // DENY that legitimately ends in `...` persist as a stop rule instead of
+  // being dropped by the truncation heuristic.
   recordPrecedent: (sessionId, toolName, signature, decision) =>
-    sessionPrecedentStores.get(sessionId)?.record(toolName, signature, decision),
+    sessionPrecedentStores.get(sessionId)?.record(toolName, signature, decision, true),
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -136,6 +136,7 @@ import {
   resolveProviderUrl,
 } from './auto-approve/index.ts';
 import type { PrecedentStore } from './auto-approve/precedent.ts';
+import { recordHumanAnswer } from './auto-approve/precedent.ts';
 import type { DenySource } from './auto-approve/types.ts';
 import { detectAutostartState } from './cli/autostart-state.ts';
 import { resolveClaudeBinding } from './cli/claude-binding.ts';
@@ -2145,14 +2146,16 @@ const inputHandlers: InputHandlers = createInputHandlers({
   // store for this sessionId (no hookServer, or the session already closed)
   // is a silent no-op -- recording is additive and must never affect the
   // answer itself.
-  // `whole: true` (#1067): the only caller (`handleAnswer`, input-events.ts)
-  // sources `signature` from `active.precedentSignature`, which
-  // `buildPermissionQuestion` set via `signatureForOperation` — untruncated by
-  // construction. Recording it as `whole` is what lets a genuine >=120-char
-  // DENY that legitimately ends in `...` persist as a stop rule instead of
-  // being dropped by the truncation heuristic.
-  recordPrecedent: (sessionId, toolName, signature, decision) =>
-    sessionPrecedentStores.get(sessionId)?.record(toolName, signature, decision, true),
+  // `recordHumanAnswer` records as `whole` (#1067): the only caller
+  // (`handleAnswer`, input-events.ts) sources `signature` from
+  // `active.precedentSignature` (set via `signatureForOperation`, untruncated by
+  // construction), so a genuine >=120-char DENY ending in `...` persists as a
+  // stop rule instead of being dropped by the truncation heuristic. See that
+  // function's doc for why `whole=true` is sound here.
+  recordPrecedent: (sessionId, toolName, signature, decision) => {
+    const store = sessionPrecedentStores.get(sessionId);
+    if (store) recordHumanAnswer(store, toolName, signature, decision);
+  },
 });
 
 const sessionHandlers: SessionHandlers = createSessionHandlers({

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -105,7 +105,7 @@ import type { AutoApproveService } from '../../auto-approve/index.ts';
 // Not re-exported from `auto-approve/index.ts` on purpose (#976 prerequisite
 // scope: that barrel is being edited concurrently by other work on the same
 // epic). Imported directly from its own module instead.
-import { PrecedentStore } from '../../auto-approve/precedent.ts';
+import { PrecedentStore, readerFrom } from '../../auto-approve/precedent.ts';
 import type { DenySource } from '../../auto-approve/types.ts';
 import { HookEventBridge } from '../../hooks/index.ts';
 import type {
@@ -720,21 +720,10 @@ export function setupHookBridge(
       // handed out — `handleAnswer` stays the single writer by construction,
       // which is what keeps the gate from recording its own ADR-0004
       // arbitration verdicts as human precedent (see `precedent.ts`).
-      //
-      // The `PrecedentStore` methods are read via a fresh object rather than
-      // by passing the store: passing it would satisfy `PrecedentReader`
-      // structurally (TypeScript is structural, so the extra `record` comes
-      // along) and the write surface would be one cast away at any future call
-      // site. This closes it over the two methods and hands out nothing else.
-      getPrecedent: () => ({
-        // Forward the `whole` provenance bit (#1067) rather than dropping it —
-        // the consult sites pass `true` (their signature is untruncated by
-        // construction), and swallowing it here would silently re-impose the
-        // truncation refusal on a genuine long command.
-        matchApproved: (tool, signature, whole) =>
-          precedentStore.matchApproved(tool, signature, whole),
-        matchDenied: (tool, signature, whole) => precedentStore.matchDenied(tool, signature, whole),
-      }),
+      // `readerFrom` (precedent.ts) hands out only the two matchers — never the
+      // store's `record` — and forwards the `whole` provenance bit (#1067). See
+      // its doc for why both properties are load-bearing.
+      getPrecedent: () => readerFrom(precedentStore),
       // #710: lets the gate recover from a tracker leak (a MAIN-tagged
       // PermissionRequest observing isInSubagentContext() stuck true) instead
       // of denying the main agent forever.

--- a/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
+++ b/packages/daemon/src/cli/session-phases/hook-bridge-setup.ts
@@ -727,8 +727,13 @@ export function setupHookBridge(
       // along) and the write surface would be one cast away at any future call
       // site. This closes it over the two methods and hands out nothing else.
       getPrecedent: () => ({
-        matchApproved: (tool, signature) => precedentStore.matchApproved(tool, signature),
-        matchDenied: (tool, signature) => precedentStore.matchDenied(tool, signature),
+        // Forward the `whole` provenance bit (#1067) rather than dropping it —
+        // the consult sites pass `true` (their signature is untruncated by
+        // construction), and swallowing it here would silently re-impose the
+        // truncation refusal on a genuine long command.
+        matchApproved: (tool, signature, whole) =>
+          precedentStore.matchApproved(tool, signature, whole),
+        matchDenied: (tool, signature, whole) => precedentStore.matchDenied(tool, signature, whole),
       }),
       // #710: lets the gate recover from a tracker leak (a MAIN-tagged
       // PermissionRequest observing isInSubagentContext() stuck true) instead

--- a/packages/daemon/tests/auto-approve/precedent-widening.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent-widening.test.ts
@@ -19,6 +19,7 @@ import {
   type PrecedentReader,
   PrecedentStore,
   precedentMayAuthorize,
+  readerFrom,
   signatureForOperation,
 } from '../../src/auto-approve/precedent.ts';
 import { classifyRisk } from '../../src/auto-approve/risk-bands.ts';
@@ -64,23 +65,27 @@ function config(overrides?: Partial<AutoApproveConfig>): AutoApproveConfig {
   } as AutoApproveConfig;
 }
 
-/** Read-only view of a real store, exactly as `hook-bridge-setup.ts` builds it. */
+/** Read-only view of a real store — the EXACT production adapter
+ *  (`readerFrom`, precedent.ts) `hook-bridge-setup.ts` hands the gate, so these
+ *  integration tests exercise the real reader (which forwards the `whole`
+ *  provenance bit, #1067) rather than a hand-rolled double that could drift
+ *  from it. */
 function readerFor(store: PrecedentStore): PrecedentReader {
-  return {
-    matchApproved: (tool, signature) => store.matchApproved(tool, signature),
-    matchDenied: (tool, signature) => store.matchDenied(tool, signature),
-  };
+  return readerFrom(store);
 }
 
-/** Record a human answer the way `handleAnswer` does: the signature the
- *  question carried, not a hand-written string. */
+/** Record a human answer the way `handleAnswer` -> `cli.ts` does: the signature
+ *  the question carried (from `signatureForOperation`, untruncated by
+ *  construction), recorded with `whole=true` (#1067). Passing `whole=true` here
+ *  mirrors the production record path and is what lets a genuine >=120-char
+ *  `...`-ending command be stored at all. */
 function humanAnswered(
   store: PrecedentStore,
   toolName: string,
   toolInput: Record<string, unknown>,
   decision: 'approved' | 'denied',
 ): void {
-  store.record(toolName, signatureForOperation(toolName, toolInput), decision);
+  store.record(toolName, signatureForOperation(toolName, toolInput), decision, true);
 }
 
 const service = (overrides?: Partial<AutoApproveConfig>) =>
@@ -658,6 +663,46 @@ describe('#976 an earlier denial downgrades a model approve to escalate', () => 
     expect(result.decision).toBe('escalate');
     expect(result.reasoning).toContain('Session precedent');
     expect(result.reasoning).toContain('gh pr list');
+  });
+
+  test('#1067 end-to-end: a genuine >=120-char DENY ending in "..." re-escalates its repeat', async () => {
+    // The headline, through the REAL service consult (not just the store): a
+    // human denies a long command that legitimately ends in "...", the model
+    // approves its identical repeat, and the risk of standing is caught only
+    // because the consult forwards `whole=true` end to end. Revert the
+    // `whole` forwarding at `readerFor` OR the service consult site OR
+    // `humanAnswered` and this flips to `approve` -- which is exactly the
+    // silent DENY-drop #1067 fixes.
+    // Moderate-band on purpose: a high-band command (e.g. one with `-exec`)
+    // would be escalated by the risk ceiling BEFORE the precedent deny consult,
+    // masking what this test checks. `git log …` is read-only, so the model
+    // approves it and only the denied precedent moves it to escalate.
+    const longDeniedCommand =
+      'git log --oneline --graph --all --decorate --abbrev-commit --author=yahya --since="2 weeks ago" -- packages/daemon/src...';
+    const detail = signatureForOperation('Bash', { command: longDeniedCommand }).slice(
+      'Bash: '.length,
+    );
+    expect(detail.length).toBeGreaterThanOrEqual(120);
+    expect(detail.endsWith('...')).toBe(true);
+
+    const store = new PrecedentStore();
+    humanAnswered(store, 'Bash', { command: longDeniedCommand }, 'denied');
+    expect(store.size).toBe(1); // stored, not dropped by the truncation heuristic
+
+    const result = await approvingService().evaluate(
+      'Bash',
+      { command: longDeniedCommand },
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      readerFor(store),
+    );
+    expect(result.decision).toBe('escalate');
+    expect(result.reasoning).toContain('Session precedent');
   });
 
   test('an UNRELATED denial leaves the approve alone', async () => {

--- a/packages/daemon/tests/auto-approve/precedent.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent.test.ts
@@ -16,6 +16,8 @@ import {
   findDeniedPrecedent,
   parsePermissionQuestionText,
   precedentMayAuthorize,
+  readerFrom,
+  recordHumanAnswer,
   signatureForOperation,
   toolNameFromSignature,
 } from '../../src/auto-approve/precedent.ts';
@@ -636,6 +638,70 @@ describe('#1067 whole-provenance keeps a genuine >=120-char command ending in ".
     const store = new PrecedentStore();
     store.record('Bash', truncated, 'denied'); // whole=false
     expect(store.size).toBe(0);
+  });
+
+  test('an approve record of the genuine long command is refused too without whole (both directions)', () => {
+    // Symmetry with the deny case above: record()'s truncation check is
+    // decision-independent, so the approve direction is equally refused for an
+    // unknown-provenance signature.
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'approved'); // whole=false
+    expect(store.size).toBe(0);
+  });
+
+  // #1067 NEWLY stores these commands (pre-#1067 both were refused, so a
+  // collision was impossible; now both are stored whole=true). Precision then
+  // rests entirely on the approve matcher comparing FULL strings -- this is the
+  // #990 collision test re-run for the "..."-ending shape, on the whole-skip
+  // branch the earlier #990 test never exercises.
+  test('two different >=120-char commands ending in "..." do NOT collide on the approve side', () => {
+    const shared = 'x'.repeat(117);
+    const cmdA = `${shared} apple ...`;
+    const cmdB = `${shared} orange ...`;
+    const sigA = signatureForOperation('Bash', { command: cmdA });
+    const sigB = signatureForOperation('Bash', { command: cmdB });
+    // Sanity: both are the false-positive shape and share their first 117 chars.
+    expect(sigA.slice('Bash: '.length).endsWith('...')).toBe(true);
+    expect(cmdA.slice(0, 117)).toBe(cmdB.slice(0, 117));
+
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(sigA), sigA, 'approved', true);
+    store.record(toolNameFromSignature(sigB), sigB, 'approved', true);
+    expect(store.size).toBe(2); // both stored, unlike pre-#1067
+    // Each matches only its own full text, never the other.
+    expect(store.matchApproved('Bash', sigB, true)?.matchedSignature).toBe(sigB);
+
+    // With ONLY A recorded, a query for B does not match -- approving A never
+    // authorizes B despite the shared 117-char prefix.
+    const onlyA = new PrecedentStore();
+    onlyA.record(toolNameFromSignature(sigA), sigA, 'approved', true);
+    expect(onlyA.matchApproved('Bash', sigB, true)).toBeNull();
+  });
+
+  // The PRODUCTION reader adapter (hook-bridge-setup.ts hands exactly this to
+  // the gate). A revert that drops the `whole` arg re-imposes the truncation
+  // refusal on a genuine long command; a revert that leaks `record` breaks the
+  // single-writer invariant. Both are pinned here.
+  test('readerFrom forwards whole and exposes no write surface', () => {
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'denied', true);
+    const reader = readerFrom(store);
+    // Forwards whole=true -> the genuine long deny matches through the reader.
+    expect(reader.matchDenied('Bash', signature, true)?.decision).toBe('denied');
+    // Drops whole -> the truncation refusal re-applies (proves it forwards, not
+    // hard-codes true).
+    expect(reader.matchDenied('Bash', signature)).toBeNull();
+    // No `record` method leaked (single-writer invariant, ADR 0015).
+    expect((reader as unknown as Record<string, unknown>)['record']).toBeUndefined();
+  });
+
+  // The PRODUCTION record adapter (cli.ts's recordPrecedent calls exactly this).
+  // A revert to a plain `record()` (whole omitted) drops the genuine long DENY.
+  test('recordHumanAnswer stores the genuine long command as whole (persists the DENY)', () => {
+    const store = new PrecedentStore();
+    recordHumanAnswer(store, toolNameFromSignature(signature), signature, 'denied');
+    expect(store.size).toBe(1); // a plain record() would have dropped it here
+    expect(store.matchDenied('Bash', signature, true)?.decision).toBe('denied');
   });
 });
 

--- a/packages/daemon/tests/auto-approve/precedent.test.ts
+++ b/packages/daemon/tests/auto-approve/precedent.test.ts
@@ -540,6 +540,105 @@ describe('truncation refusal (CRITICAL, review 2026-08-02)', () => {
   });
 });
 
+// #1067: the truncation heuristic is a FALSE positive on a genuine, untruncated
+// command that legitimately ends in `...` (>=120 chars). Before #1067 it dropped
+// such a record/query in BOTH directions; the deny direction silently weakened a
+// human "no" into a non-stop-rule. The `whole` provenance bit (true for a
+// `signatureForOperation` value) is what distinguishes the real command from a
+// truncation artifact, which are otherwise the same shape.
+describe('#1067 whole-provenance keeps a genuine >=120-char command ending in "..."', () => {
+  // A real command whose text is >=120 chars and legitimately ends in "..." --
+  // the exact false-positive shape. Built via signatureForOperation so it is
+  // byte-identical to what production records and consults.
+  const DOTS_COMMAND =
+    'find . -type f -name "*.ts" -not -path "./node_modules/*" -exec grep -l TODO {} + # release audit pass two, before tagging the build...';
+  const signature = signatureForOperation('Bash', { command: DOTS_COMMAND });
+
+  test('sanity: this is the false-positive shape (detail >=120 chars, ends in "...")', () => {
+    const detail = signature.slice('Bash: '.length);
+    expect(detail.length).toBeGreaterThanOrEqual(120);
+    expect(detail.endsWith('...')).toBe(true);
+    expect(precedentMayAuthorize('Bash', { command: DOTS_COMMAND })).toBe(true);
+  });
+
+  test('headline: a DENY of it persists and re-escalates its identical repeat', () => {
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'denied', true);
+    expect(store.size).toBe(1); // NOT dropped by the truncation heuristic
+    const match = store.matchDenied('Bash', signature, true);
+    expect(match?.decision).toBe('denied');
+    expect(match?.matchedSignature).toBe(signature);
+  });
+
+  test('an APPROVE of it records and re-matches (whole), and stays exact', () => {
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'approved', true);
+    expect(store.size).toBe(1);
+    const match = store.matchApproved('Bash', signature, true);
+    expect(match?.decision).toBe('approved');
+    expect(match?.matchKind).toBe('exact');
+  });
+
+  test('without whole (unknown provenance) the same record is still refused -- defense in depth', () => {
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'denied'); // whole defaults false
+    expect(store.size).toBe(0);
+  });
+
+  test('a whole query is not refused, but an unknown-provenance query of the same text still is', () => {
+    // Store a whole DENY, then query it two ways. The production query (whole)
+    // matches; a hypothetical unknown-provenance query of the identical text is
+    // refused by the surviving truncation heuristic.
+    const store = new PrecedentStore();
+    store.record(toolNameFromSignature(signature), signature, 'denied', true);
+    expect(store.matchDenied('Bash', signature, true)?.decision).toBe('denied');
+    expect(store.matchDenied('Bash', signature /* whole=false */)).toBeNull();
+  });
+
+  test('a directly-built stored record is trusted iff it is marked whole', () => {
+    const denied = (whole: boolean): PrecedentRecord => ({
+      toolName: 'Bash',
+      signature,
+      decision: 'denied',
+      recordedAt: Date.now(),
+      whole,
+    });
+    // whole:true stored record is matched; whole:false is skipped as
+    // possibly-truncated (the same defensive treatment an omitted flag gets).
+    expect(findDeniedPrecedent([denied(true)], 'Bash', signature, true)?.decision).toBe('denied');
+    expect(findDeniedPrecedent([denied(false)], 'Bash', signature, true)).toBeNull();
+  });
+
+  test('the substring hole is not reopened: a whole query genuinely containing a stored short deny still matches', () => {
+    // The round-2 refusal guards an OPAQUE truncated query that could
+    // coincidentally embed a short denial. A WHOLE query is the real full
+    // command, so a substring hit is a REAL containment -- the stop rule working
+    // -- not a coincidence, and must still fire.
+    // The query must START with the denied command for `Bash: rm -rf ./build`
+    // to be a substring of `Bash: rm -rf ./build && ...` (the `Bash: ` prefix
+    // only appears at the head), which is how the deny matcher genuinely works.
+    const store = new PrecedentStore();
+    store.record('Bash', 'Bash: rm -rf ./build', 'denied', true);
+    const longWhole = signatureForOperation('Bash', {
+      command:
+        'rm -rf ./build && rm -rf ./dist && echo "cleaned every derived tree before the release run"',
+    });
+    const match = store.matchDenied('Bash', longWhole, true);
+    expect(match?.decision).toBe('denied');
+    expect(match?.matchKind).toBe('substring');
+  });
+
+  test('the genuine truncation artifact is STILL refused even when marked whole=false', () => {
+    // The heuristic must keep catching a real 117+"..." truncation from an
+    // unknown-provenance source -- #1067 only trusts signatureForOperation
+    // output, never a truncated display string.
+    const truncated = `Bash: ${'x'.repeat(117)}...`;
+    const store = new PrecedentStore();
+    store.record('Bash', truncated, 'denied'); // whole=false
+    expect(store.size).toBe(0);
+  });
+});
+
 describe('toolNameFromSignature splits on the FIRST ": " (the prefix boundary)', () => {
   // The record side (`handleAnswer`) recovers the tool name from the signature
   // string alone -- `Question` carries no separate tool-name field. That is


### PR DESCRIPTION
## Summary

Follow-up from the #1057 epic. `isTruncatedSignature` (precedent.ts) is a heuristic — any signature whose detail is `>=120` chars and ends in `...` is treated as a display truncation and refused, on both the record and match paths. Post-#990 the production path never produces a genuinely truncated signature (they come from `signatureForOperation`, untruncated by construction), so that refusal now only ever fires as a **false positive**: on a real command that legitimately ends in `...` at `>=120` chars.

For an APPROVE that is harmless (the op is just re-asked). For a **DENY** it silently dropped a human "no" — `record()` didn't store it and `findDeniedPrecedent` skipped it as a query — so a later model `approve` of the identical operation stood instead of being escalated back. The deny stop rule quietly weakened.

## The fix: provenance, not softening the heuristic

A truncation artifact and a genuine `...`-ending command are the *same shape*, so they can't be told apart from the string. The fix distinguishes them by **provenance**: a `whole` bit, true for a `signatureForOperation` value (untruncated by construction — the only producer either production path uses).

- `PrecedentRecord` carries `whole`; `record()` and both match functions take a `whole` param (default `false`).
- For a `whole` signature the truncation refusal is **skipped** (record stores it; query and stored-side checks trust it). For an unknown-provenance signature (a future caller, a test, or a value reconstructed from truncated display text) the full defensive refusal still applies.
- The two production consult sites (`auto-approve-service.ts`) and the one record path (`cli.ts` → `handleAnswer`) pass `whole: true`; the `PrecedentReader` seam forwards it.

Opening the deny-**match** side for a `whole` query does **not** reopen the round-2 substring hole: that hole was specifically about an *opaque* truncated query coincidentally embedding a short stored denial. A `whole` query is the full command, so a substring hit is a real containment (the stop rule working), not a coincidence in hidden text — acceptance criterion 3, with the reasoning pinned by test.

## Acceptance criteria (all covered by new tests)

- A human DENY of a genuine `>=120`-char command ending in `...` **persists and re-escalates** its identical repeat.
- No truncated (collision-prone) signature can be stored or matched — the #989/#990 invariant holds for any unknown-provenance signature (defensive refusal unchanged; a directly-built stored record is trusted only if marked `whole`).
- The round-2 substring-refusal reasoning is **preserved for opaque queries** and explicitly superseded for whole ones, with a test proving a whole query genuinely containing a stored short deny still matches.

Doc comments updated in the same change (ADR 0011): the module header, `isTruncatedSignature`, `record()`, and both match functions now describe the provenance rule instead of calling the deny weakening an open gap.

## Test plan

- New `#1067` describe block in `precedent.test.ts`: headline deny-persist + re-match, approve re-match, unknown-provenance still refused, whole-vs-unknown query contrast, directly-built record trusted iff `whole`, the substring-hole-not-reopened case, and the genuine truncation artifact still refused.
- Full suite: **6525 pass / 0 fail**, typecheck clean, biome clean, typos clean.

Closes #1067.
